### PR TITLE
feat: #3 단과대 목록 조회 기능 추가

### DIFF
--- a/src/main/kotlin/com/yourssu/scouter/common/application/domain/college/CollegeController.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/application/domain/college/CollegeController.kt
@@ -1,0 +1,21 @@
+package com.yourssu.scouter.common.application.domain.college
+
+import com.yourssu.scouter.common.business.domain.college.CollegeService
+import com.yourssu.scouter.common.business.domain.college.ReadCollegesResult
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+class CollegeController(
+    private val collegeService: CollegeService,
+) {
+
+    @GetMapping("/colleges")
+    fun readAll(): ResponseEntity<List<ReadCollegeResponse>> {
+        val result: ReadCollegesResult = collegeService.readAll()
+        val response: List<ReadCollegeResponse> = result.collegeDtos.map { ReadCollegeResponse.from(it) }
+
+        return ResponseEntity.ok(response)
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/common/application/domain/college/ReadCollegeResponse.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/application/domain/college/ReadCollegeResponse.kt
@@ -1,0 +1,16 @@
+package com.yourssu.scouter.common.application.domain.college
+
+import com.yourssu.scouter.common.business.domain.college.CollegeDto
+
+data class ReadCollegeResponse(
+    val id: Long,
+    val name: String,
+) {
+
+    companion object {
+        fun from(collegeDto: CollegeDto) = ReadCollegeResponse(
+            id = collegeDto.id,
+            name = collegeDto.name,
+        )
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/common/business/domain/college/CollegeDto.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/business/domain/college/CollegeDto.kt
@@ -1,0 +1,16 @@
+package com.yourssu.scouter.common.business.domain.college
+
+import com.yourssu.scouter.common.implement.domain.college.College
+
+data class CollegeDto(
+    val id: Long,
+    val name: String,
+) {
+
+    companion object {
+        fun from(college: College): CollegeDto = CollegeDto(
+            id = college.id!!,
+            name = college.name,
+        )
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/common/business/domain/college/CollegeService.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/business/domain/college/CollegeService.kt
@@ -1,0 +1,17 @@
+package com.yourssu.scouter.common.business.domain.college
+
+import com.yourssu.scouter.common.implement.domain.college.College
+import com.yourssu.scouter.common.implement.domain.college.CollegeReader
+import org.springframework.stereotype.Service
+
+@Service
+class CollegeService(
+    private val collegeReader: CollegeReader,
+) {
+
+    fun readAll(): ReadCollegesResult {
+        val colleges: List<College> = collegeReader.readAll()
+
+        return ReadCollegesResult.from(colleges)
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/common/business/domain/college/ReadCollegesResult.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/business/domain/college/ReadCollegesResult.kt
@@ -1,0 +1,16 @@
+package com.yourssu.scouter.common.business.domain.college
+
+import com.yourssu.scouter.common.implement.domain.college.College
+
+data class ReadCollegesResult(
+    val collegeDtos : List<CollegeDto>,
+) {
+
+    companion object {
+        fun from(colleges: List<College>): ReadCollegesResult {
+            return ReadCollegesResult(
+                collegeDtos = colleges.map { CollegeDto.from(it) },
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/domain/college/College.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/domain/college/College.kt
@@ -1,0 +1,20 @@
+package com.yourssu.scouter.common.implement.domain.college
+
+class College(
+    val id: Long? = null,
+    val name: String,
+) {
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as College
+
+        return id == other.id
+    }
+
+    override fun hashCode(): Int {
+        return id?.hashCode() ?: 0
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/domain/college/CollegeReader.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/domain/college/CollegeReader.kt
@@ -1,0 +1,15 @@
+package com.yourssu.scouter.common.implement.domain.college
+
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+
+@Component
+@Transactional(readOnly = true)
+class CollegeReader(
+    private val collegeRepository: CollegeRepository,
+) {
+
+    fun readAll(): List<College> {
+        return collegeRepository.findAll()
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/domain/college/CollegeRepository.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/domain/college/CollegeRepository.kt
@@ -5,5 +5,7 @@ import org.springframework.stereotype.Repository
 @Repository
 interface CollegeRepository {
 
+    fun saveAll(colleges: List<College>)
+    fun count(): Long
     fun findAll(): List<College>
 }

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/domain/college/CollegeRepository.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/domain/college/CollegeRepository.kt
@@ -1,0 +1,9 @@
+package com.yourssu.scouter.common.implement.domain.college
+
+import org.springframework.stereotype.Repository
+
+@Repository
+interface CollegeRepository {
+
+    fun findAll(): List<College>
+}

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/support/initialization/DataInitializer.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/support/initialization/DataInitializer.kt
@@ -1,0 +1,23 @@
+package com.yourssu.scouter.common.implement.support.initialization
+
+import com.yourssu.scouter.common.implement.domain.college.CollegeRepository
+import org.springframework.boot.CommandLineRunner
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+
+@Component
+@Transactional
+class DataInitializer(
+    private val collegeRepository: CollegeRepository,
+) : CommandLineRunner {
+
+    override fun run(vararg args: String?) {
+        initializeColleges()
+    }
+
+    private fun initializeColleges() {
+        if (collegeRepository.count() == 0L) {
+            collegeRepository.saveAll(InitialColleges.getData())
+        }
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/support/initialization/InitialColleges.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/support/initialization/InitialColleges.kt
@@ -1,0 +1,22 @@
+package com.yourssu.scouter.common.implement.support.initialization
+
+import com.yourssu.scouter.common.implement.domain.college.College
+
+class InitialColleges {
+
+    companion object {
+
+        fun getData() : List<College> = listOf(
+            College(name = "IT대학"),
+            College(name = "경영대학"),
+            College(name = "경제통상대학"),
+            College(name = "공과대학"),
+            College(name = "법과대학"),
+            College(name = "베어드학부대학"),
+            College(name = "사회과학대학"),
+            College(name = "인문대학"),
+            College(name = "자연과학대학"),
+            College(name = "차세대반도체학과"),
+        )
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/common/storage/domain/college/CollegeEntity.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/storage/domain/college/CollegeEntity.kt
@@ -20,6 +20,13 @@ class CollegeEntity(
     val name: String,
 ) {
 
+    companion object {
+        fun from(college: College) = CollegeEntity(
+            id = college.id,
+            name = college.name,
+        )
+    }
+
     fun toDomain() = College(
         id = id,
         name = name,

--- a/src/main/kotlin/com/yourssu/scouter/common/storage/domain/college/CollegeEntity.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/storage/domain/college/CollegeEntity.kt
@@ -20,6 +20,11 @@ class CollegeEntity(
     val name: String,
 ) {
 
+    fun toDomain() = College(
+        id = id,
+        name = name,
+    )
+
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (javaClass != other?.javaClass) return false

--- a/src/main/kotlin/com/yourssu/scouter/common/storage/domain/college/CollegeEntity.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/storage/domain/college/CollegeEntity.kt
@@ -1,0 +1,39 @@
+package com.yourssu.scouter.common.storage.domain.college
+
+import com.yourssu.scouter.common.implement.domain.college.College
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+
+@Entity
+@Table(name = "college")
+class CollegeEntity(
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long? = null,
+
+    @Column(unique = true, nullable = false)
+    val name: String,
+) {
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as CollegeEntity
+
+        return id == other.id
+    }
+
+    override fun hashCode(): Int {
+        return id?.hashCode() ?: 0
+    }
+
+    override fun toString(): String {
+        return "CollegeEntity(id=$id, name='$name')"
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/common/storage/domain/college/CollegeRepositoryImpl.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/storage/domain/college/CollegeRepositoryImpl.kt
@@ -1,0 +1,15 @@
+package com.yourssu.scouter.common.storage.domain.college
+
+import com.yourssu.scouter.common.implement.domain.college.College
+import com.yourssu.scouter.common.implement.domain.college.CollegeRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+class CollegeRepositoryImpl(
+    private val jpaCollegeRepository: JpaCollegeRepository,
+) : CollegeRepository {
+
+    override fun findAll(): List<College> {
+        return jpaCollegeRepository.findAll().map { it.toDomain() }
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/common/storage/domain/college/CollegeRepositoryImpl.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/storage/domain/college/CollegeRepositoryImpl.kt
@@ -9,6 +9,14 @@ class CollegeRepositoryImpl(
     private val jpaCollegeRepository: JpaCollegeRepository,
 ) : CollegeRepository {
 
+    override fun saveAll(colleges: List<College>) {
+        jpaCollegeRepository.saveAll(colleges.map { CollegeEntity.from(it) })
+    }
+
+    override fun count(): Long {
+        return jpaCollegeRepository.count()
+    }
+
     override fun findAll(): List<College> {
         return jpaCollegeRepository.findAll().map { it.toDomain() }
     }

--- a/src/main/kotlin/com/yourssu/scouter/common/storage/domain/college/JpaCollegeRepository.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/storage/domain/college/JpaCollegeRepository.kt
@@ -1,0 +1,6 @@
+package com.yourssu.scouter.common.storage.domain.college
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface JpaCollegeRepository : JpaRepository<CollegeEntity, Long> {
+}


### PR DESCRIPTION
## 📄 작업 내용 요약
- 단과대 도메인 엔티티 추가
- 단과대 목록 조회 api 추가
- 스프링부트 실행 시 단과대 데이터 db에 삽입하는 기능 추가
    - `CommandLineRunner` 구현체 사용
    - 단과대 테이블이 비어있으면 초기 데이터 삽입

## 📎 Issue 번호
- closed #3 
