### PR TITLE
feat: #5 구분/파트 목록 조회 기능 추가

### DIFF
--- a/src/main/kotlin/com/yourssu/scouter/common/application/domain/college/ReadCollegeResponse.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/application/domain/college/ReadCollegeResponse.kt
@@ -4,13 +4,13 @@ import com.yourssu.scouter.common.business.domain.college.CollegeDto
 
 data class ReadCollegeResponse(
     val collegeId: Long,
-    val collegetName: String,
+    val collegeName: String,
 ) {
 
     companion object {
         fun from(collegeDto: CollegeDto) = ReadCollegeResponse(
             collegeId = collegeDto.id,
-            collegetName = collegeDto.name,
+            collegeName = collegeDto.name,
         )
     }
 }

--- a/src/main/kotlin/com/yourssu/scouter/common/application/domain/department/ReadDepartmentsResponse.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/application/domain/department/ReadDepartmentsResponse.kt
@@ -6,6 +6,7 @@ data class ReadDepartmentsResponse(
     val departmentId: Long,
     val departmentName: String,
 ) {
+
     companion object {
         fun from(departmentDto: DepartmentDto) = ReadDepartmentsResponse(
             departmentId = departmentDto.id,

--- a/src/main/kotlin/com/yourssu/scouter/common/application/domain/division/DivisionController.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/application/domain/division/DivisionController.kt
@@ -1,0 +1,21 @@
+package com.yourssu.scouter.common.application.domain.division
+
+import com.yourssu.scouter.common.business.domain.division.DivisionService
+import com.yourssu.scouter.common.business.domain.division.ReadDivisionsResult
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+class DivisionController(
+    private val divisionService: DivisionService,
+) {
+
+    @GetMapping("/divisions")
+    fun readAll(): ResponseEntity<List<ReadDivisionResponse>> {
+        val result: ReadDivisionsResult = divisionService.readAll()
+        val response: List<ReadDivisionResponse> = result.divisionDtos.map { ReadDivisionResponse.from(it) }
+
+        return ResponseEntity.ok(response)
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/common/application/domain/division/ReadDivisionResponse.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/application/domain/division/ReadDivisionResponse.kt
@@ -1,0 +1,16 @@
+package com.yourssu.scouter.common.application.domain.division
+
+import com.yourssu.scouter.common.business.domain.division.DivisionDto
+
+data class ReadDivisionResponse(
+    val divisionId: Long,
+    val divisionName: String,
+) {
+
+    companion object {
+        fun from(divisionDto: DivisionDto) = ReadDivisionResponse(
+            divisionId = divisionDto.id,
+            divisionName = divisionDto.name,
+        )
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/common/application/domain/part/PartController.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/application/domain/part/PartController.kt
@@ -1,0 +1,21 @@
+package com.yourssu.scouter.common.application.domain.part
+
+import com.yourssu.scouter.common.business.domain.part.PartService
+import com.yourssu.scouter.common.business.domain.part.ReadPartsResult
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+class PartController(
+    private val partService: PartService,
+) {
+
+    @GetMapping("/parts")
+    fun readAll(): ResponseEntity<List<ReadPartsResponse>> {
+        val result: ReadPartsResult = partService.readAll()
+        val response: List<ReadPartsResponse> = result.partDtos.map { ReadPartsResponse.from(it) }
+
+        return ResponseEntity.ok(response)
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/common/application/domain/part/ReadPartsResponse.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/application/domain/part/ReadPartsResponse.kt
@@ -1,0 +1,16 @@
+package com.yourssu.scouter.common.application.domain.part
+
+import com.yourssu.scouter.common.business.domain.part.PartDto
+
+data class ReadPartsResponse(
+    val partId: Long,
+    val partName: String,
+) {
+
+    companion object {
+        fun from(partDto: PartDto) = ReadPartsResponse(
+            partId = partDto.id,
+            partName = partDto.name,
+        )
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/common/business/domain/college/ReadCollegesResult.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/business/domain/college/ReadCollegesResult.kt
@@ -7,10 +7,8 @@ data class ReadCollegesResult(
 ) {
 
     companion object {
-        fun from(colleges: List<College>): ReadCollegesResult {
-            return ReadCollegesResult(
-                collegeDtos = colleges.map { CollegeDto.from(it) },
-            )
-        }
+        fun from(colleges: List<College>): ReadCollegesResult = ReadCollegesResult(
+            collegeDtos = colleges.map { CollegeDto.from(it) },
+        )
     }
 }

--- a/src/main/kotlin/com/yourssu/scouter/common/business/domain/department/DepartmentDto.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/business/domain/department/DepartmentDto.kt
@@ -9,12 +9,10 @@ data class DepartmentDto(
 ) {
 
     companion object {
-        fun from(department: Department): DepartmentDto {
-            return DepartmentDto(
-                id = department.id!!,
-                collegeId = department.collegeId,
-                name = department.name,
-            )
-        }
+        fun from(department: Department): DepartmentDto = DepartmentDto(
+            id = department.id!!,
+            collegeId = department.collegeId,
+            name = department.name,
+        )
     }
 }

--- a/src/main/kotlin/com/yourssu/scouter/common/business/domain/department/ReadDepartmentsResult.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/business/domain/department/ReadDepartmentsResult.kt
@@ -7,10 +7,8 @@ data class ReadDepartmentsResult(
 ) {
 
     companion object {
-        fun from(departments: List<Department>): ReadDepartmentsResult {
-            return ReadDepartmentsResult(
-                departmentDtos = departments.map { DepartmentDto.from(it) },
-            )
-        }
+        fun from(departments: List<Department>): ReadDepartmentsResult = ReadDepartmentsResult(
+            departmentDtos = departments.map { DepartmentDto.from(it) },
+        )
     }
 }

--- a/src/main/kotlin/com/yourssu/scouter/common/business/domain/division/DivisionDto.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/business/domain/division/DivisionDto.kt
@@ -1,0 +1,16 @@
+package com.yourssu.scouter.common.business.domain.division
+
+import com.yourssu.scouter.common.implement.domain.division.Division
+
+data class DivisionDto(
+    val id: Long,
+    val name: String,
+) {
+
+    companion object {
+        fun from(division: Division): DivisionDto = DivisionDto(
+            id = division.id!!,
+            name = division.name,
+        )
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/common/business/domain/division/DivisionService.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/business/domain/division/DivisionService.kt
@@ -1,0 +1,17 @@
+package com.yourssu.scouter.common.business.domain.division
+
+import com.yourssu.scouter.common.implement.domain.division.Division
+import com.yourssu.scouter.common.implement.domain.division.DivisionReader
+import org.springframework.stereotype.Service
+
+@Service
+class DivisionService(
+    private val divisionReader: DivisionReader,
+) {
+
+    fun readAll(): ReadDivisionsResult {
+        val divisions: List<Division> = divisionReader.readAll()
+
+        return ReadDivisionsResult.from(divisions)
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/common/business/domain/division/ReadDivisionsResult.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/business/domain/division/ReadDivisionsResult.kt
@@ -7,10 +7,8 @@ data class ReadDivisionsResult(
 ) {
 
     companion object {
-        fun from(divisions: List<Division>): ReadDivisionsResult {
-            return ReadDivisionsResult(
-                divisionDtos = divisions.map { DivisionDto.from(it) },
-            )
-        }
+        fun from(divisions: List<Division>): ReadDivisionsResult = ReadDivisionsResult(
+            divisionDtos = divisions.map { DivisionDto.from(it) },
+        )
     }
 }

--- a/src/main/kotlin/com/yourssu/scouter/common/business/domain/division/ReadDivisionsResult.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/business/domain/division/ReadDivisionsResult.kt
@@ -1,0 +1,16 @@
+package com.yourssu.scouter.common.business.domain.division
+
+import com.yourssu.scouter.common.implement.domain.division.Division
+
+data class ReadDivisionsResult(
+    val divisionDtos: List<DivisionDto>,
+) {
+
+    companion object {
+        fun from(divisions: List<Division>): ReadDivisionsResult {
+            return ReadDivisionsResult(
+                divisionDtos = divisions.map { DivisionDto.from(it) },
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/common/business/domain/part/PartDto.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/business/domain/part/PartDto.kt
@@ -1,0 +1,18 @@
+package com.yourssu.scouter.common.business.domain.part
+
+import com.yourssu.scouter.common.implement.domain.part.Part
+
+data class PartDto(
+    val id: Long,
+    val divisionId: Long,
+    val name: String,
+) {
+
+    companion object {
+        fun from(part: Part): PartDto = PartDto(
+            id = part.id!!,
+            divisionId = part.divisionId,
+            name = part.name,
+        )
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/common/business/domain/part/PartService.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/business/domain/part/PartService.kt
@@ -1,0 +1,16 @@
+package com.yourssu.scouter.common.business.domain.part
+
+import com.yourssu.scouter.common.implement.domain.part.PartReader
+import org.springframework.stereotype.Service
+
+@Service
+class PartService(
+    private val partReader: PartReader,
+) {
+
+    fun readAll(): ReadPartsResult {
+        val parts = partReader.readAll()
+
+        return ReadPartsResult.from(parts)
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/common/business/domain/part/ReadPartsResult.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/business/domain/part/ReadPartsResult.kt
@@ -1,0 +1,14 @@
+package com.yourssu.scouter.common.business.domain.part
+
+import com.yourssu.scouter.common.implement.domain.part.Part
+
+data class ReadPartsResult(
+    val partDtos: List<PartDto>,
+) {
+
+    companion object {
+        fun from(parts: List<Part>): ReadPartsResult = ReadPartsResult(
+            partDtos = parts.map { PartDto.from(it) },
+        )
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/domain/college/CollegeRepository.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/domain/college/CollegeRepository.kt
@@ -1,8 +1,5 @@
 package com.yourssu.scouter.common.implement.domain.college
 
-import org.springframework.stereotype.Repository
-
-@Repository
 interface CollegeRepository {
 
     fun save(college: College): College

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/domain/department/DepartmentReader.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/domain/department/DepartmentReader.kt
@@ -9,7 +9,5 @@ class DepartmentReader(
     private val departmentRepository: DepartmentRepository,
 ) {
 
-    fun readAllByCollegeId(collegeId: Long): List<Department> {
-        return departmentRepository.findAllByCollegeId(collegeId)
-    }
+    fun readAllByCollegeId(collegeId: Long): List<Department> = departmentRepository.findAllByCollegeId(collegeId)
 }

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/domain/division/Division.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/domain/division/Division.kt
@@ -1,0 +1,24 @@
+package com.yourssu.scouter.common.implement.domain.division
+
+class Division(
+    val id: Long? = null,
+    val name: String,
+) {
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as Division
+
+        return id == other.id
+    }
+
+    override fun hashCode(): Int {
+        return id?.hashCode() ?: 0
+    }
+
+    override fun toString(): String {
+        return "Division(id=$id, name='$name')"
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/domain/division/DivisionReader.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/domain/division/DivisionReader.kt
@@ -9,7 +9,5 @@ class DivisionReader(
     private val divisionRepository: DivisionRepository,
 ) {
 
-    fun readAll(): List<Division> {
-        return divisionRepository.findAll()
-    }
+    fun readAll(): List<Division> = divisionRepository.findAll()
 }

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/domain/division/DivisionReader.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/domain/division/DivisionReader.kt
@@ -1,0 +1,15 @@
+package com.yourssu.scouter.common.implement.domain.division
+
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+
+@Component
+@Transactional
+class DivisionReader(
+    private val divisionRepository: DivisionRepository,
+) {
+
+    fun readAll(): List<Division> {
+        return divisionRepository.findAll()
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/domain/division/DivisionRepository.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/domain/division/DivisionRepository.kt
@@ -2,5 +2,7 @@ package com.yourssu.scouter.common.implement.domain.division
 
 interface DivisionRepository {
 
+    fun save(division: Division): Division
+    fun count(): Long
     fun findAll(): List<Division>
 }

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/domain/division/DivisionRepository.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/domain/division/DivisionRepository.kt
@@ -1,0 +1,6 @@
+package com.yourssu.scouter.common.implement.domain.division
+
+interface DivisionRepository {
+
+    fun findAll(): List<Division>
+}

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/domain/part/Part.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/domain/part/Part.kt
@@ -1,0 +1,25 @@
+package com.yourssu.scouter.common.implement.domain.part
+
+class Part(
+    val id: Long? = null,
+    val divisionId: Long,
+    val name: String,
+) {
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as Part
+
+        return id == other.id
+    }
+
+    override fun hashCode(): Int {
+        return id?.hashCode() ?: 0
+    }
+
+    override fun toString(): String {
+        return "Part(id=$id, divisionId=$divisionId, name='$name')"
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/domain/part/PartReader.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/domain/part/PartReader.kt
@@ -1,0 +1,15 @@
+package com.yourssu.scouter.common.implement.domain.part
+
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+
+@Component
+@Transactional(readOnly = true)
+class PartReader(
+    private val partRepository: PartRepository,
+) {
+
+    fun readAll(): List<Part> {
+        return partRepository.findAll()
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/domain/part/PartReader.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/domain/part/PartReader.kt
@@ -9,7 +9,5 @@ class PartReader(
     private val partRepository: PartRepository,
 ) {
 
-    fun readAll(): List<Part> {
-        return partRepository.findAll()
-    }
+    fun readAll(): List<Part> = partRepository.findAll()
 }

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/domain/part/PartRepository.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/domain/part/PartRepository.kt
@@ -1,0 +1,6 @@
+package com.yourssu.scouter.common.implement.domain.part
+
+interface PartRepository {
+
+    fun findAll(): List<Part>
+}

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/domain/part/PartRepository.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/domain/part/PartRepository.kt
@@ -2,5 +2,6 @@ package com.yourssu.scouter.common.implement.domain.part
 
 interface PartRepository {
 
+    fun saveAll(parts: List<Part>)
     fun findAll(): List<Part>
 }

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/support/initialization/DivisionsAndPartsInitializer.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/support/initialization/DivisionsAndPartsInitializer.kt
@@ -1,0 +1,64 @@
+package com.yourssu.scouter.common.implement.support.initialization
+
+import com.yourssu.scouter.common.implement.domain.division.Division
+import com.yourssu.scouter.common.implement.domain.division.DivisionRepository
+import com.yourssu.scouter.common.implement.domain.part.Part
+import com.yourssu.scouter.common.implement.domain.part.PartRepository
+import org.springframework.boot.CommandLineRunner
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+
+@Suppress("NonAsciiCharacters", "FunctionName")
+@Component
+@Transactional
+class DivisionsAndPartsInitializer(
+    private val divisionRepository: DivisionRepository,
+    private val partRepository: PartRepository,
+) : CommandLineRunner {
+
+    override fun run(vararg args: String?) {
+        if (alreadyInitialized()) {
+            return
+        }
+
+        initialize_운영()
+        initialize_개발()
+        initialize_디자인()
+    }
+
+    private fun alreadyInitialized() = divisionRepository.count() != 0L
+
+    private fun initialize_운영() {
+        val division = divisionRepository.save(Division(name = "운영"))
+
+        val parts = mutableListOf<Part>()
+        parts.add(Part(divisionId = division.id!!, name = "Head lead"))
+        parts.add(Part(divisionId = division.id, name = "finance"))
+        parts.add(Part(divisionId = division.id, name = "HR"))
+        parts.add(Part(divisionId = division.id, name = "marketing"))
+        parts.add(Part(divisionId = division.id, name = "legal"))
+        parts.add(Part(divisionId = division.id, name = "PM"))
+
+        partRepository.saveAll(parts)
+    }
+
+    private fun initialize_개발() {
+        val division = divisionRepository.save(Division(name = "개발"))
+        val parts = mutableListOf<Part>()
+        parts.add(Part(divisionId = division.id!!, name = "Backend"))
+        parts.add(Part(divisionId = division.id, name = "Android"))
+        parts.add(Part(divisionId = division.id, name = "iOS"))
+        parts.add(Part(divisionId = division.id, name = "Web-frontend"))
+
+        partRepository.saveAll(parts)
+    }
+
+    private fun initialize_디자인() {
+        val division = divisionRepository.save(Division(name = "디자인"))
+
+        val parts = mutableListOf<Part>()
+        parts.add(Part(divisionId = division.id!!, name = "Product Design"))
+
+        partRepository.saveAll(parts)
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/common/storage/domain/college/CollegeRepositoryImpl.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/storage/domain/college/CollegeRepositoryImpl.kt
@@ -9,15 +9,9 @@ class CollegeRepositoryImpl(
     private val jpaCollegeRepository: JpaCollegeRepository,
 ) : CollegeRepository {
 
-    override fun save(college: College): College {
-        return jpaCollegeRepository.save(CollegeEntity.from(college)).toDomain()
-    }
+    override fun save(college: College): College = jpaCollegeRepository.save(CollegeEntity.from(college)).toDomain()
 
-    override fun count(): Long {
-        return jpaCollegeRepository.count()
-    }
+    override fun count(): Long = jpaCollegeRepository.count()
 
-    override fun findAll(): List<College> {
-        return jpaCollegeRepository.findAll().map { it.toDomain() }
-    }
+    override fun findAll(): List<College> = jpaCollegeRepository.findAll().map { it.toDomain() }
 }

--- a/src/main/kotlin/com/yourssu/scouter/common/storage/domain/department/DepartmentRepositoryImpl.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/storage/domain/department/DepartmentRepositoryImpl.kt
@@ -13,7 +13,6 @@ class DepartmentRepositoryImpl(
         jpaDepartmentRepository.saveAll(departments.map { DepartmentEntity.from(it) })
     }
 
-    override fun findAllByCollegeId(collegeId: Long): List<Department> {
-        return jpaDepartmentRepository.findAllByCollegeId(collegeId).map { it.toDomain() }
-    }
+    override fun findAllByCollegeId(collegeId: Long): List<Department> =
+        jpaDepartmentRepository.findAllByCollegeId(collegeId).map { it.toDomain() }
 }

--- a/src/main/kotlin/com/yourssu/scouter/common/storage/domain/division/DivisionEntity.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/storage/domain/division/DivisionEntity.kt
@@ -1,5 +1,6 @@
 package com.yourssu.scouter.common.storage.domain.division
 
+import com.yourssu.scouter.common.implement.domain.division.Division
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.GeneratedValue
@@ -18,6 +19,11 @@ class DivisionEntity(
     @Column(nullable = false, unique = true)
     val name: String,
 ) {
+
+    fun toDomain() = Division(
+        id = id,
+        name = name,
+    )
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true

--- a/src/main/kotlin/com/yourssu/scouter/common/storage/domain/division/DivisionEntity.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/storage/domain/division/DivisionEntity.kt
@@ -1,0 +1,38 @@
+package com.yourssu.scouter.common.storage.domain.division
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+
+@Entity
+@Table(name = "division")
+class DivisionEntity(
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long? = null,
+
+    @Column(nullable = false, unique = true)
+    val name: String,
+) {
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as DivisionEntity
+
+        return id == other.id
+    }
+
+    override fun hashCode(): Int {
+        return id?.hashCode() ?: 0
+    }
+
+    override fun toString(): String {
+        return "DivisionEntity(id=$id, name='$name')"
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/common/storage/domain/division/DivisionEntity.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/storage/domain/division/DivisionEntity.kt
@@ -20,6 +20,13 @@ class DivisionEntity(
     val name: String,
 ) {
 
+    companion object {
+        fun from(division: Division): DivisionEntity = DivisionEntity(
+            id = division.id,
+            name = division.name,
+        )
+    }
+
     fun toDomain() = Division(
         id = id,
         name = name,

--- a/src/main/kotlin/com/yourssu/scouter/common/storage/domain/division/DivisionRepositoryImpl.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/storage/domain/division/DivisionRepositoryImpl.kt
@@ -9,5 +9,9 @@ class DivisionRepositoryImpl(
     private val jpaDivisionRepository: JpaDivisionRepository,
 ) : DivisionRepository {
 
+    override fun save(division: Division): Division = jpaDivisionRepository.save(DivisionEntity.from(division)).toDomain()
+
+    override fun count() = jpaDivisionRepository.count()
+
     override fun findAll(): List<Division> = jpaDivisionRepository.findAll().map { it.toDomain() }
 }

--- a/src/main/kotlin/com/yourssu/scouter/common/storage/domain/division/DivisionRepositoryImpl.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/storage/domain/division/DivisionRepositoryImpl.kt
@@ -9,7 +9,5 @@ class DivisionRepositoryImpl(
     private val jpaDivisionRepository: JpaDivisionRepository,
 ) : DivisionRepository {
 
-    override fun findAll(): List<Division> {
-        return jpaDivisionRepository.findAll().map { it.toDomain() }
-    }
+    override fun findAll(): List<Division> = jpaDivisionRepository.findAll().map { it.toDomain() }
 }

--- a/src/main/kotlin/com/yourssu/scouter/common/storage/domain/division/DivisionRepositoryImpl.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/storage/domain/division/DivisionRepositoryImpl.kt
@@ -1,0 +1,15 @@
+package com.yourssu.scouter.common.storage.domain.division
+
+import com.yourssu.scouter.common.implement.domain.division.Division
+import com.yourssu.scouter.common.implement.domain.division.DivisionRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+class DivisionRepositoryImpl(
+    private val jpaDivisionRepository: JpaDivisionRepository,
+) : DivisionRepository {
+
+    override fun findAll(): List<Division> {
+        return jpaDivisionRepository.findAll().map { it.toDomain() }
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/common/storage/domain/division/JpaDivisionRepository.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/storage/domain/division/JpaDivisionRepository.kt
@@ -1,0 +1,6 @@
+package com.yourssu.scouter.common.storage.domain.division
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface JpaDivisionRepository : JpaRepository<DivisionEntity, Long> {
+}

--- a/src/main/kotlin/com/yourssu/scouter/common/storage/domain/part/JpaPartRepository.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/storage/domain/part/JpaPartRepository.kt
@@ -1,0 +1,6 @@
+package com.yourssu.scouter.common.storage.domain.part
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface JpaPartRepository : JpaRepository<PartEntity, Long> {
+}

--- a/src/main/kotlin/com/yourssu/scouter/common/storage/domain/part/PartEntity.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/storage/domain/part/PartEntity.kt
@@ -23,6 +23,14 @@ class PartEntity(
     val name: String,
 ) {
 
+    companion object {
+        fun from(part: Part) = PartEntity(
+            id = part.id,
+            divisionId = part.divisionId,
+            name = part.name,
+        )
+    }
+
     fun toDomain() = Part(
         id = id,
         divisionId = divisionId,

--- a/src/main/kotlin/com/yourssu/scouter/common/storage/domain/part/PartEntity.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/storage/domain/part/PartEntity.kt
@@ -1,0 +1,41 @@
+package com.yourssu.scouter.common.storage.domain.part
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+
+@Entity
+@Table(name = "part")
+class PartEntity(
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long? = null,
+
+    @Column(nullable = false)
+    val divisionId: Long,
+
+    @Column(nullable = false, unique = true)
+    val name: String,
+) {
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as PartEntity
+
+        return id == other.id
+    }
+
+    override fun hashCode(): Int {
+        return id?.hashCode() ?: 0
+    }
+
+    override fun toString(): String {
+        return "PartEntity(id=$id, divisionId=$divisionId, name='$name')"
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/common/storage/domain/part/PartEntity.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/storage/domain/part/PartEntity.kt
@@ -1,5 +1,6 @@
 package com.yourssu.scouter.common.storage.domain.part
 
+import com.yourssu.scouter.common.implement.domain.part.Part
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.GeneratedValue
@@ -21,6 +22,12 @@ class PartEntity(
     @Column(nullable = false, unique = true)
     val name: String,
 ) {
+
+    fun toDomain() = Part(
+        id = id,
+        divisionId = divisionId,
+        name = name,
+    )
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true

--- a/src/main/kotlin/com/yourssu/scouter/common/storage/domain/part/PartRepositoryImpl.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/storage/domain/part/PartRepositoryImpl.kt
@@ -9,7 +9,5 @@ class PartRepositoryImpl(
     private val jpaPartRepository: JpaPartRepository,
 ) : PartRepository {
 
-    override fun findAll(): List<Part> {
-        return jpaPartRepository.findAll().map { it.toDomain() }
-    }
+    override fun findAll(): List<Part> = jpaPartRepository.findAll().map { it.toDomain() }
 }

--- a/src/main/kotlin/com/yourssu/scouter/common/storage/domain/part/PartRepositoryImpl.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/storage/domain/part/PartRepositoryImpl.kt
@@ -9,5 +9,8 @@ class PartRepositoryImpl(
     private val jpaPartRepository: JpaPartRepository,
 ) : PartRepository {
 
+    override fun saveAll(parts: List<Part>) {
+        jpaPartRepository.saveAll(parts.map { PartEntity.from(it) })
+    }
     override fun findAll(): List<Part> = jpaPartRepository.findAll().map { it.toDomain() }
 }

--- a/src/main/kotlin/com/yourssu/scouter/common/storage/domain/part/PartRepositoryImpl.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/storage/domain/part/PartRepositoryImpl.kt
@@ -1,0 +1,15 @@
+package com.yourssu.scouter.common.storage.domain.part
+
+import com.yourssu.scouter.common.implement.domain.part.Part
+import com.yourssu.scouter.common.implement.domain.part.PartRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+class PartRepositoryImpl(
+    private val jpaPartRepository: JpaPartRepository,
+) : PartRepository {
+
+    override fun findAll(): List<Part> {
+        return jpaPartRepository.findAll().map { it.toDomain() }
+    }
+}


### PR DESCRIPTION
## 📄 작업 내용 요약
- 구분 도메인 엔티티 추가
- 구분 목록 조회 api 추가
- 파트 도메인 엔티티 추가
- 파트 목록 조회 api 추가
- 스프링부트 실행 시 구분과 파트 초기  데이터 저장 로직 추가
    - `CommandLineRunner` 구현체 사용
    - 구분 테이블이 비어있으면 초기 데이터 삽입

## 📎 Issue 번호
- closed #5 
