### PR TITLE
feat: #18 지원자 추가/단일조회/목록조회/수정/삭제 기능 추가

### DIFF
--- a/src/main/kotlin/com/yourssu/scouter/ats/application/domain/applicant/ApplicantController.kt
+++ b/src/main/kotlin/com/yourssu/scouter/ats/application/domain/applicant/ApplicantController.kt
@@ -1,0 +1,32 @@
+package com.yourssu.scouter.ats.application.domain.applicant
+
+import com.yourssu.scouter.ats.business.domain.applicant.ApplicantDto
+import com.yourssu.scouter.ats.business.domain.applicant.ApplicantService
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+class ApplicantController(
+    private val applicantService: ApplicantService,
+) {
+
+    @GetMapping("/applicants")
+    fun readAll(): ResponseEntity<List<ReadApplicantResponse>> {
+        val applicantDtos: List<ApplicantDto> = applicantService.readAll()
+        val responses: List<ReadApplicantResponse> = applicantDtos.map { ReadApplicantResponse.from(it) }
+
+        return ResponseEntity.ok(responses)
+    }
+
+    @GetMapping("/applicants/{applicantId}")
+    fun readById(
+        @PathVariable applicantId: Long,
+    ): ResponseEntity<ReadApplicantResponse> {
+        val applicantDto: ApplicantDto = applicantService.readById(applicantId)
+        val response = ReadApplicantResponse.from(applicantDto)
+
+        return ResponseEntity.ok(response)
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/ats/application/domain/applicant/ApplicantController.kt
+++ b/src/main/kotlin/com/yourssu/scouter/ats/application/domain/applicant/ApplicantController.kt
@@ -7,6 +7,7 @@ import java.net.URI
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
@@ -33,6 +34,17 @@ class ApplicantController(
         val responses: List<ReadApplicantResponse> = applicantDtos.map { ReadApplicantResponse.from(it) }
 
         return ResponseEntity.ok(responses)
+    }
+
+    @PatchMapping("/applicants/{applicantId}")
+    fun updateById(
+        @PathVariable applicantId: Long,
+        @RequestBody @Valid request: UpdateApplicantRequest,
+    ): ResponseEntity<Unit> {
+        val command = request.toCommand(applicantId)
+        applicantService.updateById(command)
+
+        return ResponseEntity.ok().build()
     }
 
     @GetMapping("/applicants/{applicantId}")

--- a/src/main/kotlin/com/yourssu/scouter/ats/application/domain/applicant/ApplicantController.kt
+++ b/src/main/kotlin/com/yourssu/scouter/ats/application/domain/applicant/ApplicantController.kt
@@ -2,15 +2,30 @@ package com.yourssu.scouter.ats.application.domain.applicant
 
 import com.yourssu.scouter.ats.business.domain.applicant.ApplicantDto
 import com.yourssu.scouter.ats.business.domain.applicant.ApplicantService
+import jakarta.validation.Valid
+import java.net.URI
 import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
 class ApplicantController(
     private val applicantService: ApplicantService,
 ) {
+
+    @PostMapping("/applicants")
+    fun create(
+        @RequestBody @Valid request: CreateApplicantRequest,
+    ): ResponseEntity<Unit> {
+        val command = request.toCommand()
+        val applicantId: Long = applicantService.create(command)
+
+        return ResponseEntity.created(URI.create("/applicants/$applicantId")).build()
+    }
 
     @GetMapping("/applicants")
     fun readAll(): ResponseEntity<List<ReadApplicantResponse>> {
@@ -28,5 +43,14 @@ class ApplicantController(
         val response = ReadApplicantResponse.from(applicantDto)
 
         return ResponseEntity.ok(response)
+    }
+
+    @DeleteMapping("/applicants/{applicantId}")
+    fun deleteById(
+        @PathVariable applicantId: Long,
+    ): ResponseEntity<Unit> {
+        applicantService.deleteById(applicantId)
+
+        return ResponseEntity.noContent().build()
     }
 }

--- a/src/main/kotlin/com/yourssu/scouter/ats/application/domain/applicant/CreateApplicantRequest.kt
+++ b/src/main/kotlin/com/yourssu/scouter/ats/application/domain/applicant/CreateApplicantRequest.kt
@@ -1,0 +1,62 @@
+package com.yourssu.scouter.ats.application.domain.applicant
+
+import com.fasterxml.jackson.annotation.JsonFormat
+import com.yourssu.scouter.ats.business.domain.applicant.ApplicantStateConverter
+import com.yourssu.scouter.ats.business.domain.applicant.CreateApplicantCommand
+import jakarta.validation.constraints.Email
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotNull
+import jakarta.validation.constraints.Pattern
+import java.time.LocalDate
+
+data class CreateApplicantRequest(
+
+    @NotNull(message = "파트를 입력하지 않았습니다.")
+    val partId: Long,
+
+    @NotBlank(message = "이름을 입력하지 않았습니다.")
+    val name: String,
+
+    @NotBlank(message = "상태를 입력하지 않았습니다.")
+    val state: String,
+
+    @NotNull(message = "지원일을 입력하지 않았습니다.")
+    @JsonFormat(pattern = "yyyy.MM.dd")
+    val applicationDate: LocalDate,
+
+    @Email(message = "이메일 형식이 아닙니다.")
+    val email: String,
+
+    @NotBlank(message = "전화번호를 입력하지 않았습니다.")
+    @Pattern(
+        regexp = "^010-\\d{4}-\\d{4}\$",
+        message = "전화번호는 \\{ 010-xxxx-xxxx \\} 형식이어야 합니다"
+    )
+    val phoneNumber: String,
+
+    @NotNull(message = "학과를 입력하지 않았습니다.")
+    val departmentId: Long,
+
+    @NotBlank(message = "학번을 입력하지 않았습니다.")
+    val studentId: String,
+
+    @NotNull(message = "학기를 입력하지 않았습니다.")
+    val semesterId: Long,
+
+    @NotBlank(message = "나이를 입력하지 않았습니다.")
+    val age: String,
+) {
+
+    fun toCommand(): CreateApplicantCommand = CreateApplicantCommand(
+        partId = partId,
+        name = name,
+        state = ApplicantStateConverter.convertToEnum(state),
+        applicationDate = applicationDate,
+        email = email,
+        phoneNumber = phoneNumber,
+        departmentId = departmentId,
+        studentId = studentId,
+        applicantSemesterId = semesterId,
+        age = age,
+    )
+}

--- a/src/main/kotlin/com/yourssu/scouter/ats/application/domain/applicant/ReadApplicantResponse.kt
+++ b/src/main/kotlin/com/yourssu/scouter/ats/application/domain/applicant/ReadApplicantResponse.kt
@@ -1,0 +1,53 @@
+package com.yourssu.scouter.ats.application.domain.applicant
+
+import com.fasterxml.jackson.annotation.JsonFormat
+import com.yourssu.scouter.ats.business.domain.applicant.ApplicantDto
+import com.yourssu.scouter.ats.business.domain.applicant.ApplicantStateConverter
+import com.yourssu.scouter.common.business.domain.semester.SemesterConverter
+import java.time.LocalDate
+
+data class ReadApplicantResponse(
+
+    val applicantId: Long,
+
+    val division: String,
+
+    val part: String,
+
+    val name: String,
+
+    val state: String,
+
+    @JsonFormat(pattern = "yyyy.MM.dd")
+    val applicationDate: LocalDate,
+
+    val email: String,
+
+    val phoneNumber: String,
+
+    val department: String,
+
+    val studentId: String,
+
+    val semester: String,
+
+    val age: String,
+) {
+
+    companion object {
+        fun from(applicantDto: ApplicantDto): ReadApplicantResponse = ReadApplicantResponse(
+            applicantId = applicantDto.id,
+            division = applicantDto.part.division.name,
+            part = applicantDto.part.name,
+            name = applicantDto.name,
+            state = ApplicantStateConverter.convertToString(applicantDto.state),
+            applicationDate = applicantDto.applicationDate,
+            email = applicantDto.email,
+            phoneNumber = applicantDto.phoneNumber,
+            department = applicantDto.department.name,
+            studentId = applicantDto.studentId,
+            semester = SemesterConverter.convertToString(applicantDto.applicationSemester),
+            age = applicantDto.age,
+        )
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/ats/application/domain/applicant/UpdateApplicantRequest.kt
+++ b/src/main/kotlin/com/yourssu/scouter/ats/application/domain/applicant/UpdateApplicantRequest.kt
@@ -1,0 +1,52 @@
+package com.yourssu.scouter.ats.application.domain.applicant
+
+import com.fasterxml.jackson.annotation.JsonFormat
+import com.yourssu.scouter.ats.business.domain.applicant.ApplicantStateConverter
+import com.yourssu.scouter.ats.business.domain.applicant.UpdateApplicantCommand
+import jakarta.validation.constraints.Email
+import jakarta.validation.constraints.Pattern
+import java.time.LocalDate
+
+data class UpdateApplicantRequest(
+
+    val partId: Long? = null,
+
+    val name: String? = null,
+
+    val state: String? = null,
+
+    @JsonFormat(pattern = "yyyy.MM.dd")
+    val applicationDate: LocalDate? = null,
+
+    @Email(message = "이메일 형식이 아닙니다.")
+    val email: String? = null,
+
+    @Pattern(
+        regexp = "^010-\\d{4}-\\d{4}\$",
+        message = "전화번호는 \\{ 010-xxxx-xxxx \\} 형식이어야 합니다"
+    )
+    val phoneNumber: String? = null,
+
+    val departmentId: Long? = null,
+
+    val studentId: String? = null,
+
+    val semesterId: Long? = null,
+
+    val age: String? = null,
+) {
+
+    fun toCommand(applicantId: Long): UpdateApplicantCommand = UpdateApplicantCommand(
+        targetApplicantId = applicantId,
+        partId = partId,
+        name = name,
+        state = state?.let { ApplicantStateConverter.convertToEnum(it) },
+        applicationDate = applicationDate,
+        email = email,
+        phoneNumber = phoneNumber,
+        departmentId = departmentId,
+        studentId = studentId,
+        applicantSemesterId = semesterId,
+        age = age,
+    )
+}

--- a/src/main/kotlin/com/yourssu/scouter/ats/business/domain/applicant/ApplicantDto.kt
+++ b/src/main/kotlin/com/yourssu/scouter/ats/business/domain/applicant/ApplicantDto.kt
@@ -1,0 +1,39 @@
+package com.yourssu.scouter.ats.business.domain.applicant
+
+import com.yourssu.scouter.ats.implement.domain.applicant.Applicant
+import com.yourssu.scouter.ats.implement.domain.applicant.ApplicantState
+import com.yourssu.scouter.common.business.domain.department.DepartmentDto
+import com.yourssu.scouter.common.business.domain.part.PartDto
+import com.yourssu.scouter.common.business.domain.semester.SemesterDto
+import java.time.LocalDate
+
+data class ApplicantDto(
+    val id: Long,
+    val name: String,
+    val email: String,
+    val phoneNumber: String,
+    val age: String,
+    val department: DepartmentDto,
+    val studentId: String,
+    val part: PartDto,
+    val state: ApplicantState,
+    val applicationDate: LocalDate,
+    val applicationSemester: SemesterDto,
+) {
+
+    companion object {
+        fun from(applicant: Applicant): ApplicantDto = ApplicantDto(
+            id = applicant.id!!,
+            name = applicant.name,
+            email = applicant.email,
+            phoneNumber = applicant.phoneNumber,
+            age = applicant.age,
+            department = DepartmentDto.from(applicant.department),
+            studentId = applicant.studentId,
+            part = PartDto.from(applicant.part),
+            state = applicant.state,
+            applicationDate = applicant.applicationDate,
+            applicationSemester = SemesterDto.from(applicant.applicationSemester),
+        )
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/ats/business/domain/applicant/ApplicantService.kt
+++ b/src/main/kotlin/com/yourssu/scouter/ats/business/domain/applicant/ApplicantService.kt
@@ -1,0 +1,23 @@
+package com.yourssu.scouter.ats.business.domain.applicant
+
+import com.yourssu.scouter.ats.implement.domain.applicant.Applicant
+import com.yourssu.scouter.ats.implement.domain.applicant.ApplicantReader
+import org.springframework.stereotype.Service
+
+@Service
+class ApplicantService(
+    private val applicationReader: ApplicantReader,
+) {
+
+    fun readById(applicantId: Long): ApplicantDto {
+        val applicant: Applicant = applicationReader.readById(applicantId)
+
+        return ApplicantDto.from(applicant)
+    }
+
+    fun readAll(): List<ApplicantDto> {
+        val applicants: List<Applicant> = applicationReader.readAll()
+
+        return applicants.map { ApplicantDto.from(it) }
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/ats/business/domain/applicant/ApplicantService.kt
+++ b/src/main/kotlin/com/yourssu/scouter/ats/business/domain/applicant/ApplicantService.kt
@@ -43,6 +43,25 @@ class ApplicantService(
         return applicants.map { ApplicantDto.from(it) }
     }
 
+    fun updateById(command: UpdateApplicantCommand) {
+        val target: Applicant = applicationReader.readById(command.targetApplicantId)
+        val updated = Applicant(
+            id = target.id,
+            name = command.name ?: target.name,
+            email = command.email ?: target.email,
+            phoneNumber = command.phoneNumber ?: target.phoneNumber,
+            age = command.age ?: target.age,
+            department = command.departmentId?.let { departmentReader.readById(it) } ?: target.department,
+            studentId = command.studentId ?: target.studentId,
+            part = command.partId?.let { partReader.readById(it) } ?: target.part,
+            state = command.state ?: target.state,
+            applicationDate = command.applicationDate ?: target.applicationDate,
+            applicationSemester = command.applicantSemesterId?.let { semesterReader.readById(it) } ?: target.applicationSemester,
+        )
+
+        applicantWriter.write(updated)
+    }
+
     fun deleteById(applicantId: Long) {
         val target: Applicant = applicationReader.readById(applicantId)
 

--- a/src/main/kotlin/com/yourssu/scouter/ats/business/domain/applicant/ApplicantService.kt
+++ b/src/main/kotlin/com/yourssu/scouter/ats/business/domain/applicant/ApplicantService.kt
@@ -2,12 +2,34 @@ package com.yourssu.scouter.ats.business.domain.applicant
 
 import com.yourssu.scouter.ats.implement.domain.applicant.Applicant
 import com.yourssu.scouter.ats.implement.domain.applicant.ApplicantReader
+import com.yourssu.scouter.ats.implement.domain.applicant.ApplicantWriter
+import com.yourssu.scouter.common.implement.domain.department.Department
+import com.yourssu.scouter.common.implement.domain.department.DepartmentReader
+import com.yourssu.scouter.common.implement.domain.part.Part
+import com.yourssu.scouter.common.implement.domain.part.PartReader
+import com.yourssu.scouter.common.implement.domain.semester.Semester
+import com.yourssu.scouter.common.implement.domain.semester.SemesterReader
 import org.springframework.stereotype.Service
 
 @Service
 class ApplicantService(
+    private val applicantWriter: ApplicantWriter,
     private val applicationReader: ApplicantReader,
+    private val departmentReader: DepartmentReader,
+    private val partReader: PartReader,
+    private val semesterReader: SemesterReader,
 ) {
+
+    fun create(command: CreateApplicantCommand): Long {
+        val department: Department = departmentReader.readById(command.departmentId)
+        val part: Part = partReader.readById(command.partId)
+        val applicantSemester: Semester = semesterReader.readById(command.applicantSemesterId)
+
+        val toWriteApplicant: Applicant = command.toDomain(department, part, applicantSemester)
+        val writtenApplicant: Applicant = applicantWriter.write(toWriteApplicant)
+
+        return writtenApplicant.id!!
+    }
 
     fun readById(applicantId: Long): ApplicantDto {
         val applicant: Applicant = applicationReader.readById(applicantId)
@@ -19,5 +41,11 @@ class ApplicantService(
         val applicants: List<Applicant> = applicationReader.readAll()
 
         return applicants.map { ApplicantDto.from(it) }
+    }
+
+    fun deleteById(applicantId: Long) {
+        val target: Applicant = applicationReader.readById(applicantId)
+
+        applicantWriter.delete(target)
     }
 }

--- a/src/main/kotlin/com/yourssu/scouter/ats/business/domain/applicant/ApplicantStateConverter.kt
+++ b/src/main/kotlin/com/yourssu/scouter/ats/business/domain/applicant/ApplicantStateConverter.kt
@@ -1,0 +1,24 @@
+package com.yourssu.scouter.ats.business.domain.applicant
+
+import com.yourssu.scouter.ats.implement.domain.applicant.ApplicantState
+
+/**
+ * - “under-review”                 // 심사 진행 중
+ * - “document-rejected”      // 서류 불합
+ * - “interview-rejected”       // 면접 불합
+ * - “incubating-rejected      // 인큐베이팅 불합
+ * - “final-accepted”             // 최종 합격
+ */
+object ApplicantStateConverter {
+
+    private val stateToString = mapOf(
+        ApplicantState.UNDER_REVIEW to "심사 진행 중",
+        ApplicantState.DOCUMENT_REJECTED to "서류 불합",
+        ApplicantState.INTERVIEW_REJECTED to "면접 불합",
+        ApplicantState.INCUBATING_REJECTED to "인큐베이팅 불합",
+        ApplicantState.FINAL_ACCEPTED to "최종 합격",
+    )
+
+    fun convertToString(state: ApplicantState): String = stateToString[state]
+        ?: throw IllegalArgumentException("Unknown role: $state")
+}

--- a/src/main/kotlin/com/yourssu/scouter/ats/business/domain/applicant/ApplicantStateConverter.kt
+++ b/src/main/kotlin/com/yourssu/scouter/ats/business/domain/applicant/ApplicantStateConverter.kt
@@ -19,6 +19,17 @@ object ApplicantStateConverter {
         ApplicantState.FINAL_ACCEPTED to "최종 합격",
     )
 
+    private val stringToState = stateToString.entries.associate {
+        it.value.replace(" ", "") to it.key
+    }
+
     fun convertToString(state: ApplicantState): String = stateToString[state]
         ?: throw IllegalArgumentException("Unknown role: $state")
+
+    fun convertToEnum(state: String): ApplicantState {
+        val blankRemovedState = state.replace(" ", "")
+
+        return stringToState[blankRemovedState]
+            ?: throw IllegalArgumentException("Unknown Applicant State: $state")
+    }
 }

--- a/src/main/kotlin/com/yourssu/scouter/ats/business/domain/applicant/CreateApplicantCommand.kt
+++ b/src/main/kotlin/com/yourssu/scouter/ats/business/domain/applicant/CreateApplicantCommand.kt
@@ -1,0 +1,39 @@
+package com.yourssu.scouter.ats.business.domain.applicant
+
+import com.yourssu.scouter.ats.implement.domain.applicant.Applicant
+import com.yourssu.scouter.ats.implement.domain.applicant.ApplicantState
+import com.yourssu.scouter.common.implement.domain.department.Department
+import com.yourssu.scouter.common.implement.domain.part.Part
+import com.yourssu.scouter.common.implement.domain.semester.Semester
+import java.time.LocalDate
+
+data class CreateApplicantCommand(
+    val name: String,
+    val email: String,
+    val phoneNumber: String,
+    val age: String,
+    val departmentId: Long,
+    val studentId: String,
+    val partId: Long,
+    val state: ApplicantState,
+    val applicationDate: LocalDate,
+    val applicantSemesterId: Long,
+) {
+
+    fun toDomain(
+        department: Department,
+        part: Part,
+        applicantSemester: Semester
+    ): Applicant = Applicant(
+        name = name,
+        email = email,
+        phoneNumber = phoneNumber,
+        age = age,
+        department = department,
+        studentId = studentId,
+        part = part,
+        state = state,
+        applicationDate = applicationDate,
+        applicationSemester = applicantSemester,
+    )
+}

--- a/src/main/kotlin/com/yourssu/scouter/ats/business/domain/applicant/UpdateApplicantCommand.kt
+++ b/src/main/kotlin/com/yourssu/scouter/ats/business/domain/applicant/UpdateApplicantCommand.kt
@@ -1,0 +1,18 @@
+package com.yourssu.scouter.ats.business.domain.applicant
+
+import com.yourssu.scouter.ats.implement.domain.applicant.ApplicantState
+import java.time.LocalDate
+
+data class UpdateApplicantCommand(
+    val targetApplicantId: Long,
+    val name: String? = null,
+    val email: String? = null,
+    val phoneNumber: String? = null,
+    val age: String? = null,
+    val departmentId: Long? = null,
+    val studentId: String? = null,
+    val partId: Long? = null,
+    val state: ApplicantState? = null,
+    val applicationDate: LocalDate? = null,
+    val applicantSemesterId: Long? = null,
+)

--- a/src/main/kotlin/com/yourssu/scouter/ats/implement/domain/applicant/Applicant.kt
+++ b/src/main/kotlin/com/yourssu/scouter/ats/implement/domain/applicant/Applicant.kt
@@ -1,0 +1,39 @@
+package com.yourssu.scouter.ats.implement.domain.applicant
+
+import com.yourssu.scouter.common.implement.domain.department.Department
+import com.yourssu.scouter.common.implement.domain.part.Part
+import com.yourssu.scouter.common.implement.domain.semester.Semester
+import com.yourssu.scouter.hrms.implement.domain.member.Member
+import java.time.LocalDate
+
+class Applicant(
+    val id: Long? = null,
+    val name: String,
+    val email: String,
+    val phoneNumber: String,
+    val age: String,
+    val department: Department,
+    val studentId: String,
+    val part: Part,
+    val state: ApplicantState,
+    val applicationDate: LocalDate,
+    val applicationSemester: Semester,
+) {
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as Member
+
+        return id == other.id
+    }
+
+    override fun hashCode(): Int {
+        return id?.hashCode() ?: 0
+    }
+
+    override fun toString(): String {
+        return "Applicant(id=$id, name='$name', email='$email', phoneNumber='$phoneNumber', age='$age', department=$department, studentId='$studentId', part=$part, state=$state, applicationDate=$applicationDate, applicationSemester=$applicationSemester)"
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/ats/implement/domain/applicant/ApplicantNotFoundException.kt
+++ b/src/main/kotlin/com/yourssu/scouter/ats/implement/domain/applicant/ApplicantNotFoundException.kt
@@ -1,0 +1,5 @@
+package com.yourssu.scouter.ats.implement.domain.applicant
+
+class ApplicantNotFoundException(
+    override val message: String
+) : RuntimeException(message)

--- a/src/main/kotlin/com/yourssu/scouter/ats/implement/domain/applicant/ApplicantReader.kt
+++ b/src/main/kotlin/com/yourssu/scouter/ats/implement/domain/applicant/ApplicantReader.kt
@@ -1,0 +1,16 @@
+package com.yourssu.scouter.ats.implement.domain.applicant
+
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+
+@Component
+@Transactional(readOnly = true)
+class ApplicantReader(
+    private val applicantRepository: ApplicantRepository,
+) {
+
+    fun readById(applicantId: Long): Applicant =
+        applicantRepository.findById(applicantId) ?: throw ApplicantNotFoundException("지정한 지원자를 찾을 수 없습니다.")
+
+    fun readAll(): List<Applicant> = applicantRepository.findAll()
+}

--- a/src/main/kotlin/com/yourssu/scouter/ats/implement/domain/applicant/ApplicantRepository.kt
+++ b/src/main/kotlin/com/yourssu/scouter/ats/implement/domain/applicant/ApplicantRepository.kt
@@ -1,0 +1,9 @@
+package com.yourssu.scouter.ats.implement.domain.applicant
+
+interface ApplicantRepository {
+
+    fun save(applicant: Applicant): Applicant
+    fun findById(applicantId: Long): Applicant?
+    fun findAll(): List<Applicant>
+    fun deleteById(applicantId: Long)
+}

--- a/src/main/kotlin/com/yourssu/scouter/ats/implement/domain/applicant/ApplicantState.kt
+++ b/src/main/kotlin/com/yourssu/scouter/ats/implement/domain/applicant/ApplicantState.kt
@@ -1,0 +1,10 @@
+package com.yourssu.scouter.ats.implement.domain.applicant
+
+enum class ApplicantState {
+
+    UNDER_REVIEW,
+    DOCUMENT_REJECTED,
+    INTERVIEW_REJECTED,
+    INCUBATING_REJECTED,
+    FINAL_ACCEPTED,
+}

--- a/src/main/kotlin/com/yourssu/scouter/ats/implement/domain/applicant/ApplicantWriter.kt
+++ b/src/main/kotlin/com/yourssu/scouter/ats/implement/domain/applicant/ApplicantWriter.kt
@@ -1,0 +1,19 @@
+package com.yourssu.scouter.ats.implement.domain.applicant
+
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+
+@Component
+@Transactional
+class ApplicantWriter(
+    private val applicantRepository: ApplicantRepository,
+) {
+
+    fun write(applicant: Applicant): Applicant {
+        return applicantRepository.save(applicant)
+    }
+
+    fun delete(applicant: Applicant) {
+        applicantRepository.deleteById(applicant.id!!)
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/ats/storage/domain/applicant/ApplicantEntity.kt
+++ b/src/main/kotlin/com/yourssu/scouter/ats/storage/domain/applicant/ApplicantEntity.kt
@@ -1,0 +1,80 @@
+package com.yourssu.scouter.ats.storage.domain.applicant
+
+import com.yourssu.scouter.ats.implement.domain.applicant.ApplicantState
+import com.yourssu.scouter.common.storage.domain.department.DepartmentEntity
+import com.yourssu.scouter.common.storage.domain.part.PartEntity
+import com.yourssu.scouter.common.storage.domain.semester.SemesterEntity
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.FetchType
+import jakarta.persistence.ForeignKey
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.Table
+import java.time.LocalDate
+
+@Entity
+@Table(name = "applicant")
+class ApplicantEntity(
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long? = null,
+
+    @Column(nullable = false)
+    val name: String,
+
+    @Column(nullable = false)
+    val email: String,
+
+    @Column(nullable = false)
+    val phoneNumber: String,
+
+    @Column(nullable = false)
+    val age: String,
+
+    @ManyToOne(fetch = FetchType.EAGER)
+    @JoinColumn(name = "department_id", nullable = false, foreignKey = ForeignKey(name = "fk_applicant_department"))
+    val department: DepartmentEntity,
+
+    @Column(nullable = false)
+    val studentId: String,
+
+    @ManyToOne(fetch = FetchType.EAGER)
+    @JoinColumn(name = "part_id", nullable = false, foreignKey = ForeignKey(name = "fk_applicant_part"))
+    val part: PartEntity,
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    val state: ApplicantState,
+
+    @Column(nullable = false)
+    val applicationDate: LocalDate,
+
+    @ManyToOne(fetch = FetchType.EAGER)
+    @JoinColumn(name = "semester_id", nullable = false, foreignKey = ForeignKey(name = "fk_applicant_semester"))
+    val applicationSemester: SemesterEntity,
+) {
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as ApplicantEntity
+
+        return id == other.id
+    }
+
+    override fun hashCode(): Int {
+        return id?.hashCode() ?: 0
+    }
+
+    override fun toString(): String {
+        return "ApplicantEntity(id=$id, name='$name', email='$email', phoneNumber='$phoneNumber', age='$age', department=$department, studentId='$studentId', part=$part, state=$state, applicationDate=$applicationDate, applicationSemester=$applicationSemester)"
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/ats/storage/domain/applicant/ApplicantEntity.kt
+++ b/src/main/kotlin/com/yourssu/scouter/ats/storage/domain/applicant/ApplicantEntity.kt
@@ -1,5 +1,6 @@
 package com.yourssu.scouter.ats.storage.domain.applicant
 
+import com.yourssu.scouter.ats.implement.domain.applicant.Applicant
 import com.yourssu.scouter.ats.implement.domain.applicant.ApplicantState
 import com.yourssu.scouter.common.storage.domain.department.DepartmentEntity
 import com.yourssu.scouter.common.storage.domain.part.PartEntity
@@ -60,6 +61,36 @@ class ApplicantEntity(
     @JoinColumn(name = "semester_id", nullable = false, foreignKey = ForeignKey(name = "fk_applicant_semester"))
     val applicationSemester: SemesterEntity,
 ) {
+
+    companion object {
+        fun from(applicant: Applicant): ApplicantEntity = ApplicantEntity(
+            id = applicant.id,
+            name = applicant.name,
+            email = applicant.email,
+            phoneNumber = applicant.phoneNumber,
+            age = applicant.age,
+            department = DepartmentEntity.from(applicant.department),
+            studentId = applicant.studentId,
+            part = PartEntity.from(applicant.part),
+            state = applicant.state,
+            applicationDate = applicant.applicationDate,
+            applicationSemester = SemesterEntity.from(applicant.applicationSemester),
+        )
+    }
+
+    fun toDomain(): Applicant = Applicant(
+        id = id,
+        name = name,
+        email = email,
+        phoneNumber = phoneNumber,
+        age = age,
+        department = department.toDomain(),
+        studentId = studentId,
+        part = part.toDomain(),
+        state = state,
+        applicationDate = applicationDate,
+        applicationSemester = applicationSemester.toDomain(),
+    )
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true

--- a/src/main/kotlin/com/yourssu/scouter/ats/storage/domain/applicant/ApplicantRepositoryImpl.kt
+++ b/src/main/kotlin/com/yourssu/scouter/ats/storage/domain/applicant/ApplicantRepositoryImpl.kt
@@ -1,0 +1,25 @@
+package com.yourssu.scouter.ats.storage.domain.applicant
+
+import com.yourssu.scouter.ats.implement.domain.applicant.Applicant
+import com.yourssu.scouter.ats.implement.domain.applicant.ApplicantRepository
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Repository
+
+@Repository
+class ApplicantRepositoryImpl(
+    private val jpaApplicantRepository: JpaApplicantRepository,
+) : ApplicantRepository {
+
+    override fun save(applicant: Applicant): Applicant =
+        jpaApplicantRepository.save(ApplicantEntity.from(applicant)).toDomain()
+
+    override fun findById(applicantId: Long): Applicant? {
+        return jpaApplicantRepository.findByIdOrNull(applicantId)?.toDomain()
+    }
+
+    override fun findAll(): List<Applicant> = jpaApplicantRepository.findAll().map { it.toDomain() }
+
+    override fun deleteById(applicantId: Long) {
+        jpaApplicantRepository.deleteById(applicantId)
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/ats/storage/domain/applicant/JpaApplicantRepository.kt
+++ b/src/main/kotlin/com/yourssu/scouter/ats/storage/domain/applicant/JpaApplicantRepository.kt
@@ -1,0 +1,6 @@
+package com.yourssu.scouter.ats.storage.domain.applicant
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface JpaApplicantRepository : JpaRepository<ApplicantEntity, Long> {
+}

--- a/src/main/kotlin/com/yourssu/scouter/common/business/domain/semester/SemesterConverter.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/business/domain/semester/SemesterConverter.kt
@@ -1,0 +1,8 @@
+package com.yourssu.scouter.common.business.domain.semester
+
+object SemesterConverter {
+
+    fun convertToString(semester: SemesterDto): String {
+        return "${semester.year}-${semester.semester}학기"
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/common/business/domain/semester/SemesterDto.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/business/domain/semester/SemesterDto.kt
@@ -15,4 +15,10 @@ data class SemesterDto(
             semester = semester.semester,
         )
     }
+
+    fun toDomain(): Semester = Semester(
+        id = id,
+        year = year,
+        semester = semester,
+    )
 }

--- a/src/main/kotlin/com/yourssu/scouter/common/business/domain/semester/SemesterDto.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/business/domain/semester/SemesterDto.kt
@@ -1,0 +1,18 @@
+package com.yourssu.scouter.common.business.domain.semester
+
+import com.yourssu.scouter.common.implement.domain.semester.Semester
+
+data class SemesterDto(
+    val id: Long,
+    val year: Int,
+    val semester: Int,
+) {
+
+    companion object {
+        fun from(semester: Semester): SemesterDto = SemesterDto(
+            id = semester.id!!,
+            year = semester.year,
+            semester = semester.semester,
+        )
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/domain/semester/Semester.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/domain/semester/Semester.kt
@@ -1,0 +1,25 @@
+package com.yourssu.scouter.common.implement.domain.semester
+
+class Semester(
+    val id: Long? = null,
+    val year: Int,
+    val semester: Int,
+) {
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as Semester
+
+        return id == other.id
+    }
+
+    override fun hashCode(): Int {
+        return id?.hashCode() ?: 0
+    }
+
+    override fun toString(): String {
+        return "Semester(id=$id, year=$year, semester=$semester)"
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/domain/semester/SemesterNotFoundException.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/domain/semester/SemesterNotFoundException.kt
@@ -1,0 +1,5 @@
+package com.yourssu.scouter.common.implement.domain.semester
+
+class SemesterNotFoundException(
+    override val message: String
+) : RuntimeException(message)

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/domain/semester/SemesterReader.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/domain/semester/SemesterReader.kt
@@ -1,0 +1,14 @@
+package com.yourssu.scouter.common.implement.domain.semester
+
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+
+@Component
+@Transactional(readOnly = true)
+class SemesterReader(
+    private val semesterRepository: SemesterRepository,
+) {
+
+    fun readById(semesterId: Long): Semester =
+        semesterRepository.findById(semesterId) ?: throw SemesterNotFoundException("지정한 학기를 찾을 수 없습니다.")
+}

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/domain/semester/SemesterRepository.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/domain/semester/SemesterRepository.kt
@@ -1,0 +1,6 @@
+package com.yourssu.scouter.common.implement.domain.semester
+
+interface SemesterRepository {
+
+    fun findById(semesterId: Long): Semester?
+}

--- a/src/main/kotlin/com/yourssu/scouter/common/storage/domain/semester/JpaSemesterRepository.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/storage/domain/semester/JpaSemesterRepository.kt
@@ -1,0 +1,6 @@
+package com.yourssu.scouter.common.storage.domain.semester
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface JpaSemesterRepository : JpaRepository<SemesterEntity, Long> {
+}

--- a/src/main/kotlin/com/yourssu/scouter/common/storage/domain/semester/SemesterEntity.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/storage/domain/semester/SemesterEntity.kt
@@ -16,7 +16,7 @@ class SemesterEntity(
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     val id: Long? = null,
 
-    @Column(nullable = false)
+    @Column(name = "academic_year", nullable = false)
     val year: Int,
 
     @Column(nullable = false)

--- a/src/main/kotlin/com/yourssu/scouter/common/storage/domain/semester/SemesterEntity.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/storage/domain/semester/SemesterEntity.kt
@@ -1,0 +1,24 @@
+package com.yourssu.scouter.common.storage.domain.semester
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+
+@Entity
+@Table(name = "semester")
+class SemesterEntity(
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long? = null,
+
+    @Column(nullable = false)
+    val year: Int,
+
+    @Column(nullable = false)
+    val semester: Int,
+) {
+}

--- a/src/main/kotlin/com/yourssu/scouter/common/storage/domain/semester/SemesterEntity.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/storage/domain/semester/SemesterEntity.kt
@@ -1,5 +1,6 @@
 package com.yourssu.scouter.common.storage.domain.semester
 
+import com.yourssu.scouter.common.implement.domain.semester.Semester
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.GeneratedValue
@@ -21,4 +22,18 @@ class SemesterEntity(
     @Column(nullable = false)
     val semester: Int,
 ) {
+
+    companion object {
+        fun from(semester: Semester): SemesterEntity = SemesterEntity(
+            id = semester.id,
+            year = semester.year,
+            semester = semester.semester
+        )
+    }
+
+    fun toDomain(): Semester = Semester(
+        id = id,
+        year = year,
+        semester = semester
+    )
 }

--- a/src/main/kotlin/com/yourssu/scouter/common/storage/domain/semester/SemesterRepositoryImpl.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/storage/domain/semester/SemesterRepositoryImpl.kt
@@ -1,0 +1,16 @@
+package com.yourssu.scouter.common.storage.domain.semester
+
+import com.yourssu.scouter.common.implement.domain.semester.Semester
+import com.yourssu.scouter.common.implement.domain.semester.SemesterRepository
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Repository
+
+@Repository
+class SemesterRepositoryImpl(
+    private val jpaSemesterRepository: JpaSemesterRepository,
+) : SemesterRepository {
+
+    override fun findById(semesterId: Long): Semester? {
+        return jpaSemesterRepository.findByIdOrNull(semesterId)?.toDomain()
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/hrms/application/domain/member/ReadMemberResponse.kt
+++ b/src/main/kotlin/com/yourssu/scouter/hrms/application/domain/member/ReadMemberResponse.kt
@@ -10,21 +10,35 @@ import java.time.LocalDate
 data class ReadMemberResponse(
 
     val memberId: Long,
+
     val division: String,
+
     val part: String,
+
     val role: String,
+
     val name: String,
+
     val nickname: String,
+
     val state: String,
+
     @JsonFormat(pattern = "yyyy.MM.dd")
     val joinDate: LocalDate,
+
     val email: String,
+
     val phoneNumber: String,
+
     val department: String,
+
     val studentId: String,
+
     @JsonFormat(pattern = "yyyy.MM.dd")
     val birthDate: LocalDate,
+
     val membershipFee: Boolean,
+
     val note: String,
 ) {
 

--- a/src/main/kotlin/com/yourssu/scouter/hrms/business/domain/member/MemberRoleConverter.kt
+++ b/src/main/kotlin/com/yourssu/scouter/hrms/business/domain/member/MemberRoleConverter.kt
@@ -19,6 +19,6 @@ object MemberRoleConverter {
         val blankRemovedRole = role.replace(" ", "")
 
         return stringToRole[blankRemovedRole]
-            ?: throw IllegalArgumentException("Unknown role: $role")
+            ?: throw IllegalArgumentException("Unknown Member Role: $role")
     }
 }

--- a/src/main/kotlin/com/yourssu/scouter/hrms/business/domain/member/MemberStateConverter.kt
+++ b/src/main/kotlin/com/yourssu/scouter/hrms/business/domain/member/MemberStateConverter.kt
@@ -20,6 +20,6 @@ object MemberStateConverter {
         val blankRemovedState = state.replace(" ", "")
 
         return stringToState[blankRemovedState]
-            ?: throw IllegalArgumentException("Unknown role: $state")
+            ?: throw IllegalArgumentException("Unknown Member State: $state")
     }
 }

--- a/src/main/kotlin/com/yourssu/scouter/hrms/implement/domain/member/MemberReader.kt
+++ b/src/main/kotlin/com/yourssu/scouter/hrms/implement/domain/member/MemberReader.kt
@@ -12,7 +12,5 @@ class MemberReader(
     fun readById(memberId: Long): Member =
         memberRepository.findById(memberId) ?: throw MemberNotFoundException("지정한 멤버를 찾을 수 없습니다.")
 
-    fun readAll(): List<Member> {
-        return memberRepository.findAll()
-    }
+    fun readAll(): List<Member> = memberRepository.findAll()
 }


### PR DESCRIPTION
## 📄 작업 내용 요약
- `common` 패키지에 `학기` 관련 도메인 엔티티, repository/reader에 조회 로직 추가
- 지원자 추가 기능 추가
- 지원자 단일 조회 기능 추가
- 지원자 목록 조회 기능 추가
    - 전체 목록 반환 (검색/필터링은 #19 에서구현 예정)
    - 우선은 저장된 순서대로 조회하도록 구현 (정렬은 #20 에서 구현 예정)
- 지원자 정보 수정 기능 추가
- 지원자 삭제 기능 추가

## 📎 Issue 번호
- closed #18 
