### PR TITLE
feat: #37 학기 도메인 필드 타입 변경 및 학기 추가, 삭제 api 추가

### DIFF
--- a/src/main/kotlin/com/yourssu/scouter/common/application/domain/semester/CreateSemesterRequest.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/application/domain/semester/CreateSemesterRequest.kt
@@ -1,0 +1,15 @@
+package com.yourssu.scouter.common.application.domain.semester
+
+import jakarta.validation.constraints.NotNull
+import jakarta.validation.constraints.Positive
+
+data class CreateSemesterRequest(
+
+    @NotNull(message = "연도를 입력하지 않았습니다.")
+    @Positive(message = "연도는 양수여야 합니다.")
+    val year: Int,
+
+    @NotNull(message = "학기를 입력하지 않았습니다.")
+    @Positive(message = "학기는 양수여야 합니다.")
+    val term: Int,
+)

--- a/src/main/kotlin/com/yourssu/scouter/common/application/domain/semester/SemesterController.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/application/domain/semester/SemesterController.kt
@@ -2,8 +2,14 @@ package com.yourssu.scouter.common.application.domain.semester
 
 import com.yourssu.scouter.common.business.domain.semester.SemesterDto
 import com.yourssu.scouter.common.business.domain.semester.SemesterService
+import jakarta.validation.Valid
+import java.net.URI
 import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
@@ -11,11 +17,29 @@ class SemesterController(
     private val semesterService: SemesterService,
 ) {
 
+    @PostMapping("/semesters")
+    fun create(
+        @RequestBody @Valid request: CreateSemesterRequest,
+    ): ResponseEntity<Unit> {
+        val semesterId: Long = semesterService.create(request.year, request.term)
+
+        return ResponseEntity.created(URI.create("/semesters/$semesterId")).build()
+    }
+
     @GetMapping("/semesters")
     fun readAll(): ResponseEntity<List<ReadSemesterResponse>> {
         val semesterDtos: List<SemesterDto> = semesterService.readAll()
         val response: List<ReadSemesterResponse> = semesterDtos.map { ReadSemesterResponse.from(it) }
 
         return ResponseEntity.ok(response)
+    }
+
+    @DeleteMapping("/semesters/{semesterId}")
+    fun deleteById(
+        @PathVariable semesterId: Long,
+    ): ResponseEntity<Unit> {
+        semesterService.deleteById(semesterId)
+
+        return ResponseEntity.noContent().build()
     }
 }

--- a/src/main/kotlin/com/yourssu/scouter/common/business/domain/semester/SemesterConverter.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/business/domain/semester/SemesterConverter.kt
@@ -3,6 +3,9 @@ package com.yourssu.scouter.common.business.domain.semester
 object SemesterConverter {
 
     fun convertToString(semester: SemesterDto): String {
-        return "${semester.year}-${semester.semester}학기"
+        val year: Int = semester.year.value % 100
+        val term: Int = semester.term.intValue
+
+        return "${year}-${term}학기"
     }
 }

--- a/src/main/kotlin/com/yourssu/scouter/common/business/domain/semester/SemesterDto.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/business/domain/semester/SemesterDto.kt
@@ -1,24 +1,26 @@
 package com.yourssu.scouter.common.business.domain.semester
 
 import com.yourssu.scouter.common.implement.domain.semester.Semester
+import com.yourssu.scouter.common.implement.domain.semester.Term
+import java.time.Year
 
 data class SemesterDto(
     val id: Long,
-    val year: Int,
-    val semester: Int,
+    val year: Year,
+    val term: Term,
 ) {
 
     companion object {
         fun from(semester: Semester): SemesterDto = SemesterDto(
             id = semester.id!!,
             year = semester.year,
-            semester = semester.semester,
+            term = semester.term,
         )
     }
 
     fun toDomain(): Semester = Semester(
         id = id,
         year = year,
-        semester = semester,
+        term = term,
     )
 }

--- a/src/main/kotlin/com/yourssu/scouter/common/business/domain/semester/SemesterService.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/business/domain/semester/SemesterService.kt
@@ -2,15 +2,31 @@ package com.yourssu.scouter.common.business.domain.semester
 
 import com.yourssu.scouter.common.implement.domain.semester.Semester
 import com.yourssu.scouter.common.implement.domain.semester.SemesterReader
+import com.yourssu.scouter.common.implement.domain.semester.SemesterWriter
 import org.springframework.stereotype.Service
 
 @Service
 class SemesterService(
+    private val semesterWriter: SemesterWriter,
     private val semesterReader: SemesterReader,
 ) {
+
+    fun create(year: Int, term: Int): Long {
+        val toWriteSemester = Semester(year, term)
+        val writtenSemester: Semester = semesterWriter.write(toWriteSemester)
+
+        return writtenSemester.id!!
+    }
+
     fun readAll(): List<SemesterDto> {
         val semesters: List<Semester> = semesterReader.readAll()
 
         return semesters.map { SemesterDto.from(it) }
+    }
+
+    fun deleteById(semesterId: Long) {
+        val target: Semester = semesterReader.readById(semesterId)
+
+        semesterWriter.delete(target)
     }
 }

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/domain/semester/Semester.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/domain/semester/Semester.kt
@@ -1,5 +1,6 @@
 package com.yourssu.scouter.common.implement.domain.semester
 
+import java.time.LocalDate
 import java.time.Year
 
 class Semester(
@@ -7,6 +8,13 @@ class Semester(
     val year: Year,
     val term: Term,
 ) {
+
+    companion object {
+        fun of(date: LocalDate): Semester = Semester(
+            year = Year.of(date.year),
+            term = Term.of(date)
+        )
+    }
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/domain/semester/Semester.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/domain/semester/Semester.kt
@@ -8,6 +8,7 @@ class Semester(
     val year: Year,
     val term: Term,
 ) {
+    constructor(year: Int, term: Int) : this(null, Year.of(year), Term.from(term))
 
     companion object {
         fun of(date: LocalDate): Semester = Semester(

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/domain/semester/Semester.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/domain/semester/Semester.kt
@@ -1,9 +1,11 @@
 package com.yourssu.scouter.common.implement.domain.semester
 
+import java.time.Year
+
 class Semester(
     val id: Long? = null,
-    val year: Int,
-    val semester: Int,
+    val year: Year,
+    val term: Term,
 ) {
 
     override fun equals(other: Any?): Boolean {
@@ -20,6 +22,6 @@ class Semester(
     }
 
     override fun toString(): String {
-        return "Semester(id=$id, year=$year, semester=$semester)"
+        return "Semester(id=$id, year=$year, semester=$term)"
     }
 }

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/domain/semester/SemesterRepository.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/domain/semester/SemesterRepository.kt
@@ -2,6 +2,8 @@ package com.yourssu.scouter.common.implement.domain.semester
 
 interface SemesterRepository {
 
+    fun save(semester: Semester): Semester
     fun findById(semesterId: Long): Semester?
     fun findAll(): List<Semester>
+    fun deleteById(semesterId: Long)
 }

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/domain/semester/SemesterWriter.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/domain/semester/SemesterWriter.kt
@@ -1,0 +1,19 @@
+package com.yourssu.scouter.common.implement.domain.semester
+
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+
+@Component
+@Transactional
+class SemesterWriter(
+    private val semesterRepository: SemesterRepository,
+) {
+
+    fun write(semester: Semester): Semester {
+        return semesterRepository.save(semester)
+    }
+
+    fun delete(semester: Semester) {
+        semesterRepository.deleteById(semester.id!!)
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/domain/semester/Term.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/domain/semester/Term.kt
@@ -1,7 +1,15 @@
 package com.yourssu.scouter.common.implement.domain.semester
 
-enum class Term(val intValue: Int) {
-    SPRING(1),
-    FALL(2),
+import java.time.LocalDate
+
+enum class Term(val intValue: Int, val targetMonthRange: IntRange) {
+    SPRING(1, 1..6),
+    FALL(2, 7..12),
     ;
+
+    companion object {
+        fun of(date: LocalDate): Term {
+            return entries.first {date.monthValue in it.targetMonthRange }
+        }
+    }
 }

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/domain/semester/Term.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/domain/semester/Term.kt
@@ -1,0 +1,7 @@
+package com.yourssu.scouter.common.implement.domain.semester
+
+enum class Term(val intValue: Int) {
+    SPRING(1),
+    FALL(2),
+    ;
+}

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/domain/semester/Term.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/domain/semester/Term.kt
@@ -11,5 +11,9 @@ enum class Term(val intValue: Int, val targetMonthRange: IntRange) {
         fun of(date: LocalDate): Term {
             return entries.first {date.monthValue in it.targetMonthRange }
         }
+
+        fun from(term: Int): Term {
+            return entries.first { it.intValue == term }
+        }
     }
 }

--- a/src/main/kotlin/com/yourssu/scouter/common/storage/domain/semester/SemesterEntity.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/storage/domain/semester/SemesterEntity.kt
@@ -1,12 +1,16 @@
 package com.yourssu.scouter.common.storage.domain.semester
 
 import com.yourssu.scouter.common.implement.domain.semester.Semester
+import com.yourssu.scouter.common.implement.domain.semester.Term
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
 import jakarta.persistence.GeneratedValue
 import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
 import jakarta.persistence.Table
+import java.time.Year
 
 @Entity
 @Table(name = "semester")
@@ -17,23 +21,24 @@ class SemesterEntity(
     val id: Long? = null,
 
     @Column(name = "academic_year", nullable = false)
-    val year: Int,
+    val year: Year,
 
     @Column(nullable = false)
-    val semester: Int,
+    @Enumerated(EnumType.STRING)
+    val term: Term,
 ) {
 
     companion object {
         fun from(semester: Semester): SemesterEntity = SemesterEntity(
             id = semester.id,
             year = semester.year,
-            semester = semester.semester
+            term = semester.term
         )
     }
 
     fun toDomain(): Semester = Semester(
         id = id,
         year = year,
-        semester = semester
+        term = term
     )
 }

--- a/src/main/kotlin/com/yourssu/scouter/common/storage/domain/semester/SemesterRepositoryImpl.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/storage/domain/semester/SemesterRepositoryImpl.kt
@@ -10,11 +10,19 @@ class SemesterRepositoryImpl(
     private val jpaSemesterRepository: JpaSemesterRepository,
 ) : SemesterRepository {
 
+    override fun save(semester: Semester): Semester {
+        return jpaSemesterRepository.save(SemesterEntity.from(semester)).toDomain()
+    }
+
     override fun findById(semesterId: Long): Semester? {
         return jpaSemesterRepository.findByIdOrNull(semesterId)?.toDomain()
     }
 
     override fun findAll(): List<Semester> {
         return jpaSemesterRepository.findAll().map { it.toDomain() }
+    }
+
+    override fun deleteById(semesterId: Long) {
+        jpaSemesterRepository.deleteById(semesterId)
     }
 }


### PR DESCRIPTION
## 📄 작업 내용 요약
- Semester 도메인 필드 타입 변경
  - 학기를 나타내는  `Term` enum 클래스 추가
  - 필드 타입으로 연도는 `Year`, 학기는 `Term` 사용
  - 이에 따라 converter와 entity 수정
- 날짜에 해당하는 학기를 구하는 기능 추가
- 학기 추가 api 추가
- 학기 삭제 api 추가

## 📎 Issue 번호
- closed #37
