### PR TITLE
fix: #39 지원자 목록 조회, 멤버 생성 시 api 명세에 맞지 않게 동작하는 문제 해결

### DIFF
--- a/src/main/kotlin/com/yourssu/scouter/ats/application/domain/applicant/CreateApplicantRequest.kt
+++ b/src/main/kotlin/com/yourssu/scouter/ats/application/domain/applicant/CreateApplicantRequest.kt
@@ -21,14 +21,14 @@ data class CreateApplicantRequest(
     val state: String,
 
     @field:NotNull(message = "지원일을 입력하지 않았습니다.")
-    @JsonFormat(pattern = "yyyy.MM.dd")
+    @field:JsonFormat(pattern = "yyyy.MM.dd")
     val applicationDate: LocalDate,
 
     @field:Email(message = "이메일 형식이 아닙니다.")
     val email: String,
 
     @field:NotBlank(message = "전화번호를 입력하지 않았습니다.")
-    @Pattern(
+    @field:Pattern(
         regexp = "^010-\\d{4}-\\d{4}\$",
         message = "전화번호는 \\{ 010-xxxx-xxxx \\} 형식이어야 합니다"
     )

--- a/src/main/kotlin/com/yourssu/scouter/ats/application/domain/applicant/CreateApplicantRequest.kt
+++ b/src/main/kotlin/com/yourssu/scouter/ats/application/domain/applicant/CreateApplicantRequest.kt
@@ -1,7 +1,7 @@
 package com.yourssu.scouter.ats.application.domain.applicant
 
 import com.fasterxml.jackson.annotation.JsonFormat
-import com.yourssu.scouter.ats.business.domain.applicant.ApplicantStateConverter
+import com.yourssu.scouter.ats.business.support.utils.ApplicantStateConverter
 import com.yourssu.scouter.ats.business.domain.applicant.CreateApplicantCommand
 import jakarta.validation.constraints.Email
 import jakarta.validation.constraints.NotBlank

--- a/src/main/kotlin/com/yourssu/scouter/ats/application/domain/applicant/ReadApplicantResponse.kt
+++ b/src/main/kotlin/com/yourssu/scouter/ats/application/domain/applicant/ReadApplicantResponse.kt
@@ -46,7 +46,7 @@ data class ReadApplicantResponse(
             phoneNumber = applicantDto.phoneNumber,
             department = applicantDto.department.name,
             studentId = applicantDto.studentId,
-            semester = SemesterConverter.convertToString(applicantDto.applicationSemester),
+            semester = SemesterConverter.convertToIntString(applicantDto.applicationSemester),
             age = applicantDto.age,
         )
     }

--- a/src/main/kotlin/com/yourssu/scouter/ats/application/domain/applicant/ReadApplicantResponse.kt
+++ b/src/main/kotlin/com/yourssu/scouter/ats/application/domain/applicant/ReadApplicantResponse.kt
@@ -2,8 +2,8 @@ package com.yourssu.scouter.ats.application.domain.applicant
 
 import com.fasterxml.jackson.annotation.JsonFormat
 import com.yourssu.scouter.ats.business.domain.applicant.ApplicantDto
-import com.yourssu.scouter.ats.business.domain.applicant.ApplicantStateConverter
-import com.yourssu.scouter.common.business.domain.semester.SemesterConverter
+import com.yourssu.scouter.ats.business.support.utils.ApplicantStateConverter
+import com.yourssu.scouter.common.business.support.utils.SemesterConverter
 import java.time.LocalDate
 
 data class ReadApplicantResponse(

--- a/src/main/kotlin/com/yourssu/scouter/ats/application/domain/applicant/UpdateApplicantRequest.kt
+++ b/src/main/kotlin/com/yourssu/scouter/ats/application/domain/applicant/UpdateApplicantRequest.kt
@@ -1,7 +1,7 @@
 package com.yourssu.scouter.ats.application.domain.applicant
 
 import com.fasterxml.jackson.annotation.JsonFormat
-import com.yourssu.scouter.ats.business.domain.applicant.ApplicantStateConverter
+import com.yourssu.scouter.ats.business.support.utils.ApplicantStateConverter
 import com.yourssu.scouter.ats.business.domain.applicant.UpdateApplicantCommand
 import jakarta.validation.constraints.Pattern
 import java.time.LocalDate

--- a/src/main/kotlin/com/yourssu/scouter/ats/application/domain/applicant/UpdateApplicantRequest.kt
+++ b/src/main/kotlin/com/yourssu/scouter/ats/application/domain/applicant/UpdateApplicantRequest.kt
@@ -14,12 +14,12 @@ data class UpdateApplicantRequest(
 
     val state: String? = null,
 
-    @JsonFormat(pattern = "yyyy.MM.dd")
+    @field:JsonFormat(pattern = "yyyy.MM.dd")
     val applicationDate: LocalDate? = null,
 
     val email: String? = null,
 
-    @Pattern(
+    @field:Pattern(
         regexp = "^010-\\d{4}-\\d{4}\$",
         message = "전화번호는 \\{ 010-xxxx-xxxx \\} 형식이어야 합니다"
     )

--- a/src/main/kotlin/com/yourssu/scouter/ats/business/domain/applicant/ApplicantService.kt
+++ b/src/main/kotlin/com/yourssu/scouter/ats/business/domain/applicant/ApplicantService.kt
@@ -1,5 +1,6 @@
 package com.yourssu.scouter.ats.business.domain.applicant
 
+import com.yourssu.scouter.ats.business.support.utils.ApplicantStateConverter
 import com.yourssu.scouter.ats.implement.domain.applicant.Applicant
 import com.yourssu.scouter.ats.implement.domain.applicant.ApplicantReader
 import com.yourssu.scouter.ats.implement.domain.applicant.ApplicantState

--- a/src/main/kotlin/com/yourssu/scouter/ats/business/support/utils/ApplicantStateConverter.kt
+++ b/src/main/kotlin/com/yourssu/scouter/ats/business/support/utils/ApplicantStateConverter.kt
@@ -1,4 +1,4 @@
-package com.yourssu.scouter.ats.business.domain.applicant
+package com.yourssu.scouter.ats.business.support.utils
 
 import com.yourssu.scouter.ats.implement.domain.applicant.ApplicantState
 

--- a/src/main/kotlin/com/yourssu/scouter/common/application/domain/semester/CreateSemesterRequest.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/application/domain/semester/CreateSemesterRequest.kt
@@ -5,11 +5,11 @@ import jakarta.validation.constraints.Positive
 
 data class CreateSemesterRequest(
 
-    @NotNull(message = "연도를 입력하지 않았습니다.")
-    @Positive(message = "연도는 양수여야 합니다.")
+    @field:NotNull(message = "연도를 입력하지 않았습니다.")
+    @field:Positive(message = "연도는 양수여야 합니다.")
     val year: Int,
 
-    @NotNull(message = "학기를 입력하지 않았습니다.")
-    @Positive(message = "학기는 양수여야 합니다.")
+    @field:NotNull(message = "학기를 입력하지 않았습니다.")
+    @field:Positive(message = "학기는 양수여야 합니다.")
     val term: Int,
 )

--- a/src/main/kotlin/com/yourssu/scouter/common/application/domain/semester/ReadSemesterResponse.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/application/domain/semester/ReadSemesterResponse.kt
@@ -1,6 +1,6 @@
 package com.yourssu.scouter.common.application.domain.semester
 
-import com.yourssu.scouter.common.business.domain.semester.SemesterConverter
+import com.yourssu.scouter.common.business.support.utils.SemesterConverter
 import com.yourssu.scouter.common.business.domain.semester.SemesterDto
 
 data class ReadSemesterResponse(

--- a/src/main/kotlin/com/yourssu/scouter/common/business/support/utils/SemesterConverter.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/business/support/utils/SemesterConverter.kt
@@ -10,4 +10,11 @@ object SemesterConverter {
 
         return "${year}-${term}학기"
     }
+
+    fun convertToIntString(semester: SemesterDto): String {
+        val year: Int = semester.year.value
+        val term: Int = semester.term.intValue
+
+        return "${year}-${term}"
+    }
 }

--- a/src/main/kotlin/com/yourssu/scouter/common/business/support/utils/SemesterConverter.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/business/support/utils/SemesterConverter.kt
@@ -1,4 +1,6 @@
-package com.yourssu.scouter.common.business.domain.semester
+package com.yourssu.scouter.common.business.support.utils
+
+import com.yourssu.scouter.common.business.domain.semester.SemesterDto
 
 object SemesterConverter {
 

--- a/src/main/kotlin/com/yourssu/scouter/hrms/application/domain/member/CreateMemberRequest.kt
+++ b/src/main/kotlin/com/yourssu/scouter/hrms/application/domain/member/CreateMemberRequest.kt
@@ -2,9 +2,9 @@ package com.yourssu.scouter.hrms.application.domain.member
 
 import com.fasterxml.jackson.annotation.JsonFormat
 import com.yourssu.scouter.hrms.business.domain.member.CreateMemberCommand
-import com.yourssu.scouter.hrms.business.domain.member.MemberRoleConverter
-import com.yourssu.scouter.hrms.business.domain.member.MemberStateConverter
-import com.yourssu.scouter.hrms.business.domain.member.NicknameConverter
+import com.yourssu.scouter.hrms.business.support.utils.MemberRoleConverter
+import com.yourssu.scouter.hrms.business.support.utils.MemberStateConverter
+import com.yourssu.scouter.hrms.business.support.utils.NicknameConverter
 import jakarta.validation.constraints.Email
 import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.NotNull

--- a/src/main/kotlin/com/yourssu/scouter/hrms/application/domain/member/CreateMemberRequest.kt
+++ b/src/main/kotlin/com/yourssu/scouter/hrms/application/domain/member/CreateMemberRequest.kt
@@ -23,7 +23,7 @@ data class CreateMemberRequest(
     val name: String,
 
     @field:NotBlank(message = "닉네임을 입력하지 않았습니다.")
-    @Pattern(
+    @field:Pattern(
         regexp = "^[a-zA-Z]+\\([가-힣]+\\)$",
         message = "닉네임은 \\{ 영어(발음) \\} 형식이어야 합니다."
     )
@@ -33,14 +33,14 @@ data class CreateMemberRequest(
     val state: String,
 
     @field:NotNull(message = "가입일을 입력하지 않았습니다.")
-    @JsonFormat(pattern = "yyyy.MM.dd")
+    @field:JsonFormat(pattern = "yyyy.MM.dd")
     val joinDate: LocalDate,
 
     @field:Email(message = "이메일 형식이 아닙니다.")
     val email: String,
 
     @field:NotBlank(message = "전화번호를 입력하지 않았습니다.")
-    @Pattern(
+    @field:Pattern(
         regexp = "^010-\\d{4}-\\d{4}\$",
         message = "전화번호는 \\{ 010-xxxx-xxxx \\} 형식이어야 합니다"
     )
@@ -53,7 +53,7 @@ data class CreateMemberRequest(
     val studentId: String,
 
     @field:NotNull(message = "가입일을 입력하지 않았습니다.")
-    @JsonFormat(pattern = "yyyy.MM.dd")
+    @field:JsonFormat(pattern = "yyyy.MM.dd")
     val birthDate: LocalDate,
 
     @field:NotNull(message = "회비 납부 여부를 입력하지 않았습니다.")

--- a/src/main/kotlin/com/yourssu/scouter/hrms/application/domain/member/CreateMemberRequest.kt
+++ b/src/main/kotlin/com/yourssu/scouter/hrms/application/domain/member/CreateMemberRequest.kt
@@ -59,7 +59,7 @@ data class CreateMemberRequest(
     @field:NotNull(message = "회비 납부 여부를 입력하지 않았습니다.")
     val membershipFee: Boolean,
 
-    @field:NotBlank(message = "비고를 입력하지 않았습니다.")
+    @field:NotNull(message = "비고에 빈 문자열이라도 입력하세요.")
     val note: String,
 ) {
 

--- a/src/main/kotlin/com/yourssu/scouter/hrms/application/domain/member/ReadMemberResponse.kt
+++ b/src/main/kotlin/com/yourssu/scouter/hrms/application/domain/member/ReadMemberResponse.kt
@@ -2,9 +2,9 @@ package com.yourssu.scouter.hrms.application.domain.member
 
 import com.fasterxml.jackson.annotation.JsonFormat
 import com.yourssu.scouter.hrms.business.domain.member.MemberDto
-import com.yourssu.scouter.hrms.business.domain.member.MemberRoleConverter
-import com.yourssu.scouter.hrms.business.domain.member.MemberStateConverter
-import com.yourssu.scouter.hrms.business.domain.member.NicknameConverter
+import com.yourssu.scouter.hrms.business.support.utils.MemberRoleConverter
+import com.yourssu.scouter.hrms.business.support.utils.MemberStateConverter
+import com.yourssu.scouter.hrms.business.support.utils.NicknameConverter
 import java.time.LocalDate
 
 data class ReadMemberResponse(

--- a/src/main/kotlin/com/yourssu/scouter/hrms/application/domain/member/UpdateMemberRequest.kt
+++ b/src/main/kotlin/com/yourssu/scouter/hrms/application/domain/member/UpdateMemberRequest.kt
@@ -1,9 +1,9 @@
 package com.yourssu.scouter.hrms.application.domain.member
 
 import com.fasterxml.jackson.annotation.JsonFormat
-import com.yourssu.scouter.hrms.business.domain.member.MemberRoleConverter
-import com.yourssu.scouter.hrms.business.domain.member.MemberStateConverter
-import com.yourssu.scouter.hrms.business.domain.member.NicknameConverter
+import com.yourssu.scouter.hrms.business.support.utils.MemberRoleConverter
+import com.yourssu.scouter.hrms.business.support.utils.MemberStateConverter
+import com.yourssu.scouter.hrms.business.support.utils.NicknameConverter
 import com.yourssu.scouter.hrms.business.domain.member.UpdateMemberCommand
 import java.time.LocalDate
 

--- a/src/main/kotlin/com/yourssu/scouter/hrms/application/domain/member/UpdateMemberRequest.kt
+++ b/src/main/kotlin/com/yourssu/scouter/hrms/application/domain/member/UpdateMemberRequest.kt
@@ -19,7 +19,7 @@ data class UpdateMemberRequest(
 
     val state: String? = null,
 
-    @JsonFormat(pattern = "yyyy.MM.dd")
+    @field:JsonFormat(pattern = "yyyy.MM.dd")
     val joinDate: LocalDate? = null,
 
     val email: String? = null,
@@ -30,7 +30,7 @@ data class UpdateMemberRequest(
 
     val studentId: String? = null,
 
-    @JsonFormat(pattern = "yyyy.MM.dd")
+    @field:JsonFormat(pattern = "yyyy.MM.dd")
     val birthDate: LocalDate? = null,
 
     val membershipFee: Boolean? = null,

--- a/src/main/kotlin/com/yourssu/scouter/hrms/business/domain/member/MemberService.kt
+++ b/src/main/kotlin/com/yourssu/scouter/hrms/business/domain/member/MemberService.kt
@@ -4,6 +4,8 @@ import com.yourssu.scouter.common.implement.domain.department.Department
 import com.yourssu.scouter.common.implement.domain.department.DepartmentReader
 import com.yourssu.scouter.common.implement.domain.part.Part
 import com.yourssu.scouter.common.implement.domain.part.PartReader
+import com.yourssu.scouter.hrms.business.support.utils.MemberRoleConverter
+import com.yourssu.scouter.hrms.business.support.utils.MemberStateConverter
 import com.yourssu.scouter.hrms.implement.domain.member.Member
 import com.yourssu.scouter.hrms.implement.domain.member.MemberReader
 import com.yourssu.scouter.hrms.implement.domain.member.MemberRole

--- a/src/main/kotlin/com/yourssu/scouter/hrms/business/support/utils/MemberRoleConverter.kt
+++ b/src/main/kotlin/com/yourssu/scouter/hrms/business/support/utils/MemberRoleConverter.kt
@@ -1,4 +1,4 @@
-package com.yourssu.scouter.hrms.business.domain.member
+package com.yourssu.scouter.hrms.business.support.utils
 
 import com.yourssu.scouter.hrms.implement.domain.member.MemberRole
 

--- a/src/main/kotlin/com/yourssu/scouter/hrms/business/support/utils/MemberStateConverter.kt
+++ b/src/main/kotlin/com/yourssu/scouter/hrms/business/support/utils/MemberStateConverter.kt
@@ -1,4 +1,4 @@
-package com.yourssu.scouter.hrms.business.domain.member
+package com.yourssu.scouter.hrms.business.support.utils
 
 import com.yourssu.scouter.hrms.implement.domain.member.MemberState
 

--- a/src/main/kotlin/com/yourssu/scouter/hrms/business/support/utils/NicknameConverter.kt
+++ b/src/main/kotlin/com/yourssu/scouter/hrms/business/support/utils/NicknameConverter.kt
@@ -1,4 +1,4 @@
-package com.yourssu.scouter.hrms.business.domain.member
+package com.yourssu.scouter.hrms.business.support.utils
 
 import java.util.regex.Pattern
 


### PR DESCRIPTION
## 📄 작업 내용 요약
- 지원자 목록 조회 시 재학 학기를  `yy-n학기` 형식이 아니라 `yy-n` 형식으로 응답하도록 수정
- 멤버 생성 request dto에서 '비고' 필드에 대한 검증을 `@NotNull`로 수정
- request dto에서 필드 validation이 필드 레벨에서 동작하도록 어노테이션에 `@field:` 접두사 추가
- converter 클래스들을 `support.utils` 패키지로 이동

## 📎 Issue 번호
- closed #39 
