### PR TITLE
feat: #24 구글 소셜 로그인 기능 추가

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,10 +21,17 @@ repositories {
 
 val jwtVersion = "0.12.6"
 
+dependencyManagement {
+	imports {
+		mavenBom("org.springframework.cloud:spring-cloud-dependencies:2024.0.0")
+	}
+}
+
 dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-data-jpa")
 	implementation("org.springframework.boot:spring-boot-starter-validation")
 	implementation("org.springframework.boot:spring-boot-starter-web")
+	implementation("org.springframework.cloud:spring-cloud-starter-openfeign")
 	implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
 	implementation("org.jetbrains.kotlin:kotlin-reflect")
 	implementation ("io.jsonwebtoken:jjwt-api:$jwtVersion")

--- a/src/main/kotlin/com/yourssu/scouter/common/application/domain/authentication/AuthenticationController.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/application/domain/authentication/AuthenticationController.kt
@@ -1,0 +1,29 @@
+package com.yourssu.scouter.common.application.domain.authentication
+
+import com.yourssu.scouter.common.business.domain.authentication.AuthenticationService
+import com.yourssu.scouter.common.business.domain.authentication.LoginResult
+import com.yourssu.scouter.common.implement.domain.authentication.OAuth2Type
+import jakarta.validation.Valid
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+class AuthenticationController(
+    private val authenticationService: AuthenticationService,
+) {
+
+    @PostMapping("oauth2/login/{oauth2Type}")
+    fun login(
+        @PathVariable oauth2Type: OAuth2Type,
+        @RequestBody @Valid request: OAuth2LoginRequest,
+    ): ResponseEntity<LoginResponse> {
+
+        val loginResult: LoginResult = authenticationService.login(oauth2Type, request.authorizationCode)
+        val response: LoginResponse = LoginResponse.from(loginResult)
+
+        return ResponseEntity.ok(response)
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/common/application/domain/authentication/LoginResponse.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/application/domain/authentication/LoginResponse.kt
@@ -1,0 +1,15 @@
+package com.yourssu.scouter.common.application.domain.authentication
+
+import com.yourssu.scouter.common.business.domain.authentication.LoginResult
+
+data class LoginResponse(
+    val accessToken: String,
+    val refreshToken: String,
+) {
+    companion object {
+        fun from(loginResult: LoginResult): LoginResponse = LoginResponse(
+            accessToken = loginResult.accessToken,
+            refreshToken = loginResult.refreshToken
+        )
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/common/application/domain/authentication/OAuth2Controller.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/application/domain/authentication/OAuth2Controller.kt
@@ -1,0 +1,26 @@
+package com.yourssu.scouter.common.application.domain.authentication
+
+import com.yourssu.scouter.common.business.domain.authentication.OAuth2Service
+import com.yourssu.scouter.common.implement.domain.authentication.OAuth2Type
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+class OAuth2Controller(
+    private val oauth2Service: OAuth2Service
+) {
+
+    @GetMapping("/oauth2/{oauth2Type}")
+    fun redirectAuthCodeRequestUrl(
+        @PathVariable oauth2Type: OAuth2Type,
+        response: HttpServletResponse,
+    ): ResponseEntity<Unit> {
+        val redirectUrl: String = oauth2Service.getAuthCodeRequestUrl(oauth2Type)
+        response.sendRedirect(redirectUrl)
+
+        return ResponseEntity.ok().build()
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/common/application/domain/authentication/OAuth2LoginRequest.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/application/domain/authentication/OAuth2LoginRequest.kt
@@ -1,0 +1,5 @@
+package com.yourssu.scouter.common.application.domain.authentication
+
+data class OAuth2LoginRequest(
+    val authorizationCode: String,
+)

--- a/src/main/kotlin/com/yourssu/scouter/common/application/support/configuration/OAuth2WebConfiguration.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/application/support/configuration/OAuth2WebConfiguration.kt
@@ -1,0 +1,22 @@
+package com.yourssu.scouter.common.application.support.configuration
+
+import com.yourssu.scouter.common.implement.domain.authentication.OAuth2Type
+import org.springframework.context.annotation.Configuration
+import org.springframework.core.convert.converter.Converter
+import org.springframework.format.FormatterRegistry
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
+
+@Configuration
+class OAuth2WebConfiguration : WebMvcConfigurer {
+
+    override fun addFormatters(registry: FormatterRegistry) {
+        registry.addConverter(OAuth2TypeConverter())
+    }
+}
+
+class OAuth2TypeConverter : Converter<String, OAuth2Type> {
+
+    override fun convert(source: String): OAuth2Type {
+        return OAuth2Type.from(source)
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/common/business/domain/authentication/AuthenticationService.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/business/domain/authentication/AuthenticationService.kt
@@ -1,0 +1,62 @@
+package com.yourssu.scouter.common.business.domain.authentication
+
+import com.yourssu.scouter.common.implement.domain.authentication.OAuth2Type
+import com.yourssu.scouter.common.implement.domain.authentication.OAuth2User
+import com.yourssu.scouter.common.implement.domain.authentication.PrivateClaims
+import com.yourssu.scouter.common.implement.domain.authentication.TokenProcessor
+import com.yourssu.scouter.common.implement.domain.authentication.TokenType
+import com.yourssu.scouter.common.implement.domain.user.User
+import com.yourssu.scouter.common.implement.domain.user.UserReader
+import com.yourssu.scouter.common.implement.domain.user.UserWriter
+import java.time.LocalDateTime
+import org.springframework.stereotype.Service
+
+@Service
+class AuthenticationService(
+    private val oauth2Service: OAuth2Service,
+    private val userReader: UserReader,
+    private val userWriter: UserWriter,
+    private val tokenProcessor: TokenProcessor,
+) {
+
+    fun login(oauth2Type: OAuth2Type, oauth2AuthorizationCode: String): LoginResult {
+        val oauth2User = oauth2Service.fetchOAuth2User(oauth2Type, oauth2AuthorizationCode)
+        val loginUser: User = findOrPersistUser(oauth2User)
+        val token: TokenDto = generateTokens(loginUser)
+
+        return LoginResult(
+            id = loginUser.id!!,
+            accessToken = token.accessToken,
+            refreshToken = token.refreshToken,
+        )
+    }
+
+    private fun generateTokens(user: User): TokenDto {
+        val privateClaims = PrivateClaims(user.id!!)
+        val tokenIssueTime = LocalDateTime.now()
+
+        val accessToken = tokenProcessor.encode(
+            issueTime = tokenIssueTime,
+            tokenType = TokenType.ACCESS,
+            privateClaims = privateClaims.toMap(),
+        )
+
+        val refreshToken = tokenProcessor.encode(
+            issueTime = tokenIssueTime,
+            tokenType = TokenType.REFRESH,
+            privateClaims = privateClaims.toMap(),
+        )
+        return TokenDto(accessToken, refreshToken)
+    }
+
+    private fun findOrPersistUser(oauth2User: OAuth2User): User {
+        val findUser: User? = userReader.find(oauth2User)
+
+        return findUser ?: userWriter.write(oauth2User)
+    }
+}
+
+data class TokenDto(
+    val accessToken: String,
+    val refreshToken: String,
+)

--- a/src/main/kotlin/com/yourssu/scouter/common/business/domain/authentication/LoginResult.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/business/domain/authentication/LoginResult.kt
@@ -1,0 +1,7 @@
+package com.yourssu.scouter.common.business.domain.authentication
+
+data class LoginResult(
+    val id: Long,
+    val accessToken: String,
+    val refreshToken: String,
+)

--- a/src/main/kotlin/com/yourssu/scouter/common/business/domain/authentication/OAuth2Service.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/business/domain/authentication/OAuth2Service.kt
@@ -1,0 +1,18 @@
+package com.yourssu.scouter.common.business.domain.authentication
+
+import com.yourssu.scouter.common.implement.domain.authentication.OAuth2Handler
+import com.yourssu.scouter.common.implement.domain.authentication.OAuth2HandlerComposite
+import com.yourssu.scouter.common.implement.domain.authentication.OAuth2Type
+import org.springframework.stereotype.Service
+
+@Service
+class OAuth2Service(
+    private val oauth2HandlerComposite: OAuth2HandlerComposite,
+) {
+
+    fun getAuthCodeRequestUrl(oauth2Type: OAuth2Type): String {
+        val oauth2Handler: OAuth2Handler = oauth2HandlerComposite.findHandler(oauth2Type)
+
+        return oauth2Handler.provideAuthCodeRequestUrl()
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/common/business/domain/authentication/OAuth2Service.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/business/domain/authentication/OAuth2Service.kt
@@ -3,6 +3,7 @@ package com.yourssu.scouter.common.business.domain.authentication
 import com.yourssu.scouter.common.implement.domain.authentication.OAuth2Handler
 import com.yourssu.scouter.common.implement.domain.authentication.OAuth2HandlerComposite
 import com.yourssu.scouter.common.implement.domain.authentication.OAuth2Type
+import com.yourssu.scouter.common.implement.domain.authentication.OAuth2User
 import org.springframework.stereotype.Service
 
 @Service
@@ -14,5 +15,11 @@ class OAuth2Service(
         val oauth2Handler: OAuth2Handler = oauth2HandlerComposite.findHandler(oauth2Type)
 
         return oauth2Handler.provideAuthCodeRequestUrl()
+    }
+
+    fun fetchOAuth2User(oauth2Type: OAuth2Type, authorizationCode: String): OAuth2User {
+        val oauth2Handler: OAuth2Handler = oauth2HandlerComposite.findHandler(oauth2Type)
+
+        return oauth2Handler.fetchOAuth2User(authorizationCode)
     }
 }

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/domain/authentication/OAuth2Handler.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/domain/authentication/OAuth2Handler.kt
@@ -1,0 +1,7 @@
+package com.yourssu.scouter.common.implement.domain.authentication
+
+interface OAuth2Handler {
+
+    fun getSupportingOAuth2Type(): OAuth2Type
+    fun provideAuthCodeRequestUrl(): String
+}

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/domain/authentication/OAuth2Handler.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/domain/authentication/OAuth2Handler.kt
@@ -4,4 +4,5 @@ interface OAuth2Handler {
 
     fun getSupportingOAuth2Type(): OAuth2Type
     fun provideAuthCodeRequestUrl(): String
+    fun fetchOAuth2User(authorizationCode: String): OAuth2User
 }

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/domain/authentication/OAuth2HandlerComposite.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/domain/authentication/OAuth2HandlerComposite.kt
@@ -1,0 +1,16 @@
+package com.yourssu.scouter.common.implement.domain.authentication
+
+import com.yourssu.scouter.common.implement.support.exception.UnsupportedOAuth2LoginException
+import org.springframework.stereotype.Component
+
+@Component
+class OAuth2HandlerComposite(
+    handlers: Set<OAuth2Handler>
+) {
+
+    private val handlerMappings: Map<OAuth2Type, OAuth2Handler> = handlers.associateBy { it.getSupportingOAuth2Type() }
+
+    fun findHandler(oauth2Type: OAuth2Type): OAuth2Handler {
+        return handlerMappings[oauth2Type] ?: throw UnsupportedOAuth2LoginException("지원하는 OAuth2 타입이 아닙니다.")
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/domain/authentication/OAuth2Type.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/domain/authentication/OAuth2Type.kt
@@ -1,0 +1,19 @@
+package com.yourssu.scouter.common.implement.domain.authentication
+
+import com.yourssu.scouter.common.implement.support.exception.UnsupportedOAuth2LoginException
+
+enum class OAuth2Type {
+
+    GOOGLE,
+    ;
+
+    companion object {
+        fun from(typeName: String): OAuth2Type {
+            try {
+                return valueOf(typeName.uppercase())
+            } catch (e: IllegalArgumentException) {
+                throw UnsupportedOAuth2LoginException("지원하는 OAuth2 타입이 아닙니다.")
+            }
+        }
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/domain/authentication/OAuth2User.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/domain/authentication/OAuth2User.kt
@@ -1,0 +1,21 @@
+package com.yourssu.scouter.common.implement.domain.authentication
+
+data class OAuth2User(
+    val userInfo: OAuth2UserInfo,
+    val token: OAuth2TokenInfo,
+)
+
+data class OAuth2UserInfo(
+    val oauthId: String,
+    val oauth2Type: OAuth2Type,
+    val name: String,
+    val email: String,
+    val profileImageUrl: String,
+)
+
+data class OAuth2TokenInfo(
+    val accessToken: String,
+    val refreshToken: String,
+    val tokenPrefix: String,
+    val expiresIn: Long,
+)

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/domain/authentication/PrivateClaims.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/domain/authentication/PrivateClaims.kt
@@ -1,0 +1,20 @@
+package com.yourssu.scouter.common.implement.domain.authentication
+
+import io.jsonwebtoken.Claims
+
+data class PrivateClaims(
+    val userId: Long,
+) {
+
+    companion object {
+        private const val USER_ID_KEY_NAME = "userId"
+
+        fun from(claims: Claims): PrivateClaims {
+            return PrivateClaims((claims[USER_ID_KEY_NAME] as Number).toLong())
+        }
+    }
+
+    fun toMap(): Map<String, Any> {
+        return mapOf(USER_ID_KEY_NAME to userId)
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/domain/authentication/TokenProcessor.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/domain/authentication/TokenProcessor.kt
@@ -1,4 +1,4 @@
-package com.yourssu.scouter.common.implement.support.security.token
+package com.yourssu.scouter.common.implement.domain.authentication
 
 import io.jsonwebtoken.Claims
 import java.time.LocalDateTime

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/domain/authentication/TokenType.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/domain/authentication/TokenType.kt
@@ -1,0 +1,7 @@
+package com.yourssu.scouter.common.implement.domain.authentication
+
+enum class TokenType {
+    ACCESS,
+    REFRESH,
+}
+

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/domain/user/User.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/domain/user/User.kt
@@ -1,0 +1,43 @@
+package com.yourssu.scouter.common.implement.domain.user
+
+import com.yourssu.scouter.common.implement.domain.authentication.OAuth2Type
+import java.time.LocalDateTime
+
+class User(
+    val id: Long? = null,
+    val userInfo: UserInfo,
+    val tokenInfo: TokenInfo,
+) {
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as User
+
+        return id == other.id
+    }
+
+    override fun hashCode(): Int {
+        return id?.hashCode() ?: 0
+    }
+
+    override fun toString(): String {
+        return "User(id=$id, userInfo=$userInfo, tokenInfo=$tokenInfo)"
+    }
+}
+
+class UserInfo(
+    val name: String,
+    val email: String,
+    val profileImageUrl: String,
+    val oauthId: String,
+    val oauth2Type: OAuth2Type,
+)
+
+class TokenInfo(
+    val tokenPrefix: String,
+    val accessToken: String,
+    val refreshToken: String,
+    val accessTokenExpirationDateTime: LocalDateTime,
+)

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/domain/user/UserReader.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/domain/user/UserReader.kt
@@ -1,0 +1,18 @@
+package com.yourssu.scouter.common.implement.domain.user
+
+import com.yourssu.scouter.common.implement.domain.authentication.OAuth2User
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+
+@Component
+@Transactional(readOnly = true)
+class UserReader(
+    private val userRepository: UserRepository,
+) {
+
+    fun find(oauth2User: OAuth2User): User? {
+        val oauthId: String = oauth2User.userInfo.oauthId
+
+        return userRepository.findByOAuthId(oauthId)
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/domain/user/UserRepository.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/domain/user/UserRepository.kt
@@ -1,0 +1,7 @@
+package com.yourssu.scouter.common.implement.domain.user
+
+interface UserRepository {
+
+    fun save(user: User): User
+    fun findByOAuthId(oauthId: String): User?
+}

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/domain/user/UserWriter.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/domain/user/UserWriter.kt
@@ -1,0 +1,37 @@
+package com.yourssu.scouter.common.implement.domain.user
+
+import com.yourssu.scouter.common.implement.domain.authentication.OAuth2User
+import java.time.LocalDateTime
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+
+@Component
+@Transactional
+class UserWriter(
+    private val userRepository: UserRepository,
+) {
+
+    fun write(oauth2User: OAuth2User): User {
+        val userInfo = UserInfo(
+            name = oauth2User.userInfo.name,
+            email = oauth2User.userInfo.email,
+            profileImageUrl = oauth2User.userInfo.profileImageUrl,
+            oauthId = oauth2User.userInfo.oauthId,
+            oauth2Type = oauth2User.userInfo.oauth2Type,
+        )
+
+        val tokenInfo = TokenInfo(
+            tokenPrefix = oauth2User.token.tokenPrefix,
+            accessToken = oauth2User.token.accessToken,
+            refreshToken = oauth2User.token.refreshToken,
+            accessTokenExpirationDateTime = LocalDateTime.now().plusSeconds(oauth2User.token.expiresIn)
+        )
+
+        val toSave = User(
+            userInfo = userInfo,
+            tokenInfo = tokenInfo,
+        )
+
+        return userRepository.save(toSave)
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/support/configuration/OpenFeignConfiguration.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/support/configuration/OpenFeignConfiguration.kt
@@ -1,0 +1,9 @@
+package com.yourssu.scouter.common.implement.support.configuration
+
+import org.springframework.cloud.openfeign.EnableFeignClients
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+@EnableFeignClients(basePackages = ["com.yourssu.scouter"])
+class OpenFeignConfiguration {
+}

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/support/configuration/PropertiesConfiguration.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/support/configuration/PropertiesConfiguration.kt
@@ -1,9 +1,10 @@
 package com.yourssu.scouter.common.implement.support.configuration
 
+import com.yourssu.scouter.common.implement.support.security.oauth2.GoogleOAuth2Properties
 import com.yourssu.scouter.common.implement.support.security.token.JwtProperties
 import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Configuration
 
 @Configuration
-@EnableConfigurationProperties(JwtProperties::class)
+@EnableConfigurationProperties(JwtProperties::class, GoogleOAuth2Properties::class)
 class PropertiesConfiguration

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/support/exception/UnsupportedOAuth2LoginException.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/support/exception/UnsupportedOAuth2LoginException.kt
@@ -1,0 +1,7 @@
+package com.yourssu.scouter.common.implement.support.exception
+
+import org.springframework.http.HttpStatus
+
+class UnsupportedOAuth2LoginException(
+    message: String,
+) : CustomException(message, "Auth-002", HttpStatus.BAD_REQUEST)

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/support/security/oauth2/GoogleOAuth2Handler.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/support/security/oauth2/GoogleOAuth2Handler.kt
@@ -1,0 +1,30 @@
+package com.yourssu.scouter.common.implement.support.security.oauth2
+
+import com.yourssu.scouter.common.implement.domain.authentication.OAuth2Handler
+import com.yourssu.scouter.common.implement.domain.authentication.OAuth2Type
+import org.springframework.stereotype.Component
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder
+import org.springframework.web.util.UriComponentsBuilder
+
+@Component
+class GoogleOAuth2Handler(
+    val googleOAuth2Properties: GoogleOAuth2Properties
+) : OAuth2Handler {
+
+    override fun getSupportingOAuth2Type() = OAuth2Type.GOOGLE
+
+    override fun provideAuthCodeRequestUrl(): String {
+        val redirectUri = ServletUriComponentsBuilder.fromCurrentContextPath()
+            .path(googleOAuth2Properties.relativeRedirectUri).toUriString()
+
+        return UriComponentsBuilder.fromUriString("https://accounts.google.com/o/oauth2/auth")
+            .queryParam("client_id", googleOAuth2Properties.clientId)
+            .queryParam("redirect_uri", redirectUri)
+            .queryParam("response_type", "code")
+            .queryParam("scope", googleOAuth2Properties.scope.joinToString(" "))
+            .queryParam("access_type", "offline")
+            .queryParam("prompt", "consent")
+            .build()
+            .toUriString()
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/support/security/oauth2/GoogleOAuth2Handler.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/support/security/oauth2/GoogleOAuth2Handler.kt
@@ -1,20 +1,26 @@
 package com.yourssu.scouter.common.implement.support.security.oauth2
 
 import com.yourssu.scouter.common.implement.domain.authentication.OAuth2Handler
+import com.yourssu.scouter.common.implement.domain.authentication.OAuth2TokenInfo
 import com.yourssu.scouter.common.implement.domain.authentication.OAuth2Type
+import com.yourssu.scouter.common.implement.domain.authentication.OAuth2User
+import com.yourssu.scouter.common.implement.domain.authentication.OAuth2UserInfo
 import org.springframework.stereotype.Component
+import org.springframework.util.LinkedMultiValueMap
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder
 import org.springframework.web.util.UriComponentsBuilder
 
 @Component
 class GoogleOAuth2Handler(
-    val googleOAuth2Properties: GoogleOAuth2Properties
+    val googleOAuth2Properties: GoogleOAuth2Properties,
+    val googleOAuth2TokenClient: GoogleOAuth2TokenClient,
+    val googleUserApiClient: GoogleUserApiClient,
 ) : OAuth2Handler {
 
     override fun getSupportingOAuth2Type() = OAuth2Type.GOOGLE
 
     override fun provideAuthCodeRequestUrl(): String {
-        val redirectUri = ServletUriComponentsBuilder.fromCurrentContextPath()
+        val redirectUri: String = ServletUriComponentsBuilder.fromCurrentContextPath()
             .path(googleOAuth2Properties.relativeRedirectUri).toUriString()
 
         return UriComponentsBuilder.fromUriString("https://accounts.google.com/o/oauth2/auth")
@@ -26,5 +32,53 @@ class GoogleOAuth2Handler(
             .queryParam("prompt", "consent")
             .build()
             .toUriString()
+    }
+
+    override fun fetchOAuth2User(authorizationCode: String): OAuth2User {
+        val tokenInfo: OAuth2TokenInfo = fetchTokenInfo(authorizationCode)
+
+        val authorizationHeaderValue = StringBuilder()
+            .append(tokenInfo.tokenPrefix)
+            .append(" ")
+            .append(tokenInfo.accessToken)
+            .toString()
+
+        val userInfo: OAuth2UserInfo = fetchUserInfo(authorizationHeaderValue)
+
+        return OAuth2User(userInfo, tokenInfo)
+    }
+
+    private fun fetchTokenInfo(authorizationCode: String): OAuth2TokenInfo {
+        val redirectUri: String = ServletUriComponentsBuilder.fromCurrentContextPath()
+            .path(googleOAuth2Properties.relativeRedirectUri).toUriString()
+
+        val tokenRequest = LinkedMultiValueMap<String, String>().apply {
+            add("client_id", googleOAuth2Properties.clientId)
+            add("client_secret", googleOAuth2Properties.clientSecret)
+            add("code", authorizationCode)
+            add("grant_type", "authorization_code")
+            add("redirect_uri", redirectUri)
+        }
+
+        val tokenResponse: GoogleTokenResponse = googleOAuth2TokenClient.fetchToken(tokenRequest)
+
+        return OAuth2TokenInfo(
+            accessToken = tokenResponse.accessToken,
+            refreshToken = tokenResponse.refreshToken,
+            tokenPrefix = tokenResponse.tokenType,
+            expiresIn = tokenResponse.expiresIn,
+        )
+    }
+
+    private fun fetchUserInfo(typeSpecifiedAccessToken: String): OAuth2UserInfo {
+        val userInfoResponse = googleUserApiClient.fetchUserInfo(typeSpecifiedAccessToken)
+
+        return OAuth2UserInfo(
+            oauthId = userInfoResponse.id,
+            oauth2Type = getSupportingOAuth2Type(),
+            name = userInfoResponse.name,
+            email = userInfoResponse.email,
+            profileImageUrl = userInfoResponse.picture,
+        )
     }
 }

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/support/security/oauth2/GoogleOAuth2Properties.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/support/security/oauth2/GoogleOAuth2Properties.kt
@@ -1,0 +1,11 @@
+package com.yourssu.scouter.common.implement.support.security.oauth2
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+@ConfigurationProperties(prefix = "oauth2.google")
+data class GoogleOAuth2Properties(
+    val clientId: String,
+    val clientSecret: String,
+    val relativeRedirectUri: String,
+    val scope: List<String>
+)

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/support/security/oauth2/GoogleOAuth2TokenClient.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/support/security/oauth2/GoogleOAuth2TokenClient.kt
@@ -1,0 +1,28 @@
+package com.yourssu.scouter.common.implement.support.security.oauth2
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies
+import com.fasterxml.jackson.databind.annotation.JsonNaming
+import org.springframework.cloud.openfeign.FeignClient
+import org.springframework.http.MediaType
+import org.springframework.util.MultiValueMap
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+
+@FeignClient(name = "googleOAuth2TokenClient", url = "https://oauth2.googleapis.com")
+interface GoogleOAuth2TokenClient {
+
+    @PostMapping(
+        "/token",
+        consumes = [MediaType.APPLICATION_FORM_URLENCODED_VALUE]
+    )
+    fun fetchToken(@RequestBody params: MultiValueMap<String, String>): GoogleTokenResponse
+}
+
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy::class)
+data class GoogleTokenResponse(
+    val accessToken: String,
+    val expiresIn: Long,
+    val refreshToken: String,
+    val scope: String,
+    val tokenType: String,
+)

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/support/security/oauth2/GoogleUserApiClient.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/support/security/oauth2/GoogleUserApiClient.kt
@@ -1,0 +1,29 @@
+package com.yourssu.scouter.common.implement.support.security.oauth2
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies
+import com.fasterxml.jackson.databind.annotation.JsonNaming
+import org.springframework.cloud.openfeign.FeignClient
+import org.springframework.http.MediaType
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestHeader
+
+@FeignClient(name = "googleUserApiClient", url = "https://www.googleapis.com")
+interface GoogleUserApiClient {
+
+    @GetMapping(
+        "/oauth2/v2/userinfo",
+        consumes = [MediaType.APPLICATION_JSON_VALUE]
+    )
+    fun fetchUserInfo(@RequestHeader("Authorization") accessToken: String): GoogleUserInfoResponse
+}
+
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy::class)
+data class GoogleUserInfoResponse(
+    val id: String,
+    val name: String,
+    val email: String,
+    val picture: String,
+    val familyName: String,
+    val givenName: String,
+    val verifiedEmail: Boolean,
+)

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/support/security/token/JwtProperties.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/support/security/token/JwtProperties.kt
@@ -1,5 +1,6 @@
 package com.yourssu.scouter.common.implement.support.security.token
 
+import com.yourssu.scouter.common.implement.domain.authentication.TokenType
 import org.springframework.boot.context.properties.ConfigurationProperties
 
 @ConfigurationProperties(prefix = "token.jwt")

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/support/security/token/JwtTokenProcessor.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/support/security/token/JwtTokenProcessor.kt
@@ -1,5 +1,7 @@
 package com.yourssu.scouter.common.implement.support.security.token
 
+import com.yourssu.scouter.common.implement.domain.authentication.TokenProcessor
+import com.yourssu.scouter.common.implement.domain.authentication.TokenType
 import com.yourssu.scouter.common.implement.support.exception.InvalidTokenException
 import io.jsonwebtoken.Claims
 import io.jsonwebtoken.JwtException

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/support/security/token/TokenType.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/support/security/token/TokenType.kt
@@ -1,7 +1,0 @@
-package com.yourssu.scouter.common.implement.support.security.token
-
-enum class TokenType {
-    ACCESS,
-    REFRESH,
-}
-

--- a/src/main/kotlin/com/yourssu/scouter/common/storage/domain/user/JpaUserRepository.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/storage/domain/user/JpaUserRepository.kt
@@ -1,0 +1,8 @@
+package com.yourssu.scouter.common.storage.domain.user
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface JpaUserRepository : JpaRepository<UserEntity, Long> {
+
+    fun findByOauthId(oauthId: String): UserEntity?
+}

--- a/src/main/kotlin/com/yourssu/scouter/common/storage/domain/user/UserEntity.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/storage/domain/user/UserEntity.kt
@@ -1,0 +1,99 @@
+package com.yourssu.scouter.common.storage.domain.user
+
+import com.yourssu.scouter.common.implement.domain.authentication.OAuth2Type
+import com.yourssu.scouter.common.implement.domain.user.TokenInfo
+import com.yourssu.scouter.common.implement.domain.user.User
+import com.yourssu.scouter.common.implement.domain.user.UserInfo
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import java.time.LocalDateTime
+
+
+@Entity
+@Table(name = "users")
+class UserEntity(
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long? = null,
+
+    @Column(nullable = false)
+    val name: String,
+
+    @Column(nullable = false)
+    val email: String,
+
+    @Column(nullable = false)
+    val profileImageUrl: String,
+
+    @Column(nullable = false, unique = true)
+    val oauthId: String,
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    val oauth2Type: OAuth2Type,
+
+    @Column(nullable = false)
+    val tokenPrefix: String,
+
+    @Column(nullable = false)
+    val accessToken: String,
+
+    @Column(nullable = false)
+    val refreshToken: String,
+
+    @Column(nullable = false)
+    val accessTokenExpirationDateTime: LocalDateTime,
+) {
+
+    companion object {
+        fun from(user: User) = UserEntity(
+            id = user.id,
+            name = user.userInfo.name,
+            email = user.userInfo.email,
+            profileImageUrl = user.userInfo.profileImageUrl,
+            oauthId = user.userInfo.oauthId,
+            oauth2Type = user.userInfo.oauth2Type,
+            tokenPrefix = user.tokenInfo.tokenPrefix,
+            accessToken = user.tokenInfo.accessToken,
+            refreshToken = user.tokenInfo.refreshToken,
+            accessTokenExpirationDateTime = user.tokenInfo.accessTokenExpirationDateTime,
+        )
+    }
+
+    fun toDomain() = User(
+        id = id,
+        userInfo = UserInfo(
+            name = name,
+            email = email,
+            profileImageUrl = profileImageUrl,
+            oauthId = oauthId,
+            oauth2Type = oauth2Type,
+        ),
+        tokenInfo = TokenInfo(
+            tokenPrefix = tokenPrefix,
+            accessToken = accessToken,
+            refreshToken = refreshToken,
+            accessTokenExpirationDateTime = accessTokenExpirationDateTime,
+        ),
+    )
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as UserEntity
+
+        return id == other.id
+    }
+
+    override fun hashCode(): Int {
+        return id?.hashCode() ?: 0
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/common/storage/domain/user/UserRepositoryImpl.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/storage/domain/user/UserRepositoryImpl.kt
@@ -1,0 +1,19 @@
+package com.yourssu.scouter.common.storage.domain.user
+
+import com.yourssu.scouter.common.implement.domain.user.User
+import com.yourssu.scouter.common.implement.domain.user.UserRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+class UserRepositoryImpl(
+    private val jpaUserRepository: JpaUserRepository
+) : UserRepository {
+
+    override fun save(user: User): User {
+        return jpaUserRepository.save(UserEntity.from(user)).toDomain()
+    }
+
+    override fun findByOAuthId(oauthId: String): User? {
+        return jpaUserRepository.findByOauthId(oauthId)?.toDomain()
+    }
+}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -27,3 +27,12 @@ token:
     refresh-key: ThisIsLocalRefreshKeyThisIsLocalRefreshKey
     access-expired-hours: 1 # 1시간
     refresh-expired-hours: 336  # 14일
+oauth2:
+  google:
+    client_id: scouter-google-client-id # REST API 키
+    client_secret: scouter-google-secret-key # Client Secret 키
+    relative_redirect_uri: /relative/redirect/uri
+    scope:
+      - openid
+      - https://www.googleapis.com/auth/userinfo.email
+      - https://www.googleapis.com/auth/userinfo.profile

--- a/src/test/kotlin/com/yourssu/scouter/common/implement/support/security/token/JwtTokenProcessorTest.kt
+++ b/src/test/kotlin/com/yourssu/scouter/common/implement/support/security/token/JwtTokenProcessorTest.kt
@@ -1,5 +1,6 @@
 package com.yourssu.scouter.common.implement.support.security.token
 
+import com.yourssu.scouter.common.implement.domain.authentication.TokenType
 import com.yourssu.scouter.common.implement.support.exception.InvalidTokenException
 import io.jsonwebtoken.Claims
 import java.time.LocalDateTime


### PR DESCRIPTION
## 📄 작업 내용 요약

  - [x] 구글 로그인 페이지로 리다이렉트하는 api 추가
  - [x] 구글 Access Token과 Refresh Token을 발급받는 기능 추가
  - [x] 구글로부터 사용자 정보를 조회하는 기능 추가
  - [x] 로그인 완료 후 Access Token과 Refresh Token 발급 (jwt 사용)

## 📎 Issue 번호
- closed #24 