### PR TITLE
fix: #43 개발 환경에서 구글 소셜 로그인 시 400 오류가 발생하는 버그 해결

### DIFF
--- a/src/main/kotlin/com/yourssu/scouter/common/implement/support/security/oauth2/GoogleOAuth2Handler.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/support/security/oauth2/GoogleOAuth2Handler.kt
@@ -7,7 +7,6 @@ import com.yourssu.scouter.common.implement.domain.authentication.OAuth2User
 import com.yourssu.scouter.common.implement.domain.authentication.OAuth2UserInfo
 import org.springframework.stereotype.Component
 import org.springframework.util.LinkedMultiValueMap
-import org.springframework.web.servlet.support.ServletUriComponentsBuilder
 import org.springframework.web.util.UriComponentsBuilder
 
 @Component
@@ -20,12 +19,9 @@ class GoogleOAuth2Handler(
     override fun getSupportingOAuth2Type() = OAuth2Type.GOOGLE
 
     override fun provideAuthCodeRequestUrl(): String {
-        val redirectUri: String = ServletUriComponentsBuilder.fromCurrentContextPath()
-            .path(googleOAuth2Properties.relativeRedirectUri).toUriString()
-
         return UriComponentsBuilder.fromUriString("https://accounts.google.com/o/oauth2/auth")
             .queryParam("client_id", googleOAuth2Properties.clientId)
-            .queryParam("redirect_uri", redirectUri)
+            .queryParam("redirect_uri", googleOAuth2Properties.redirectUri)
             .queryParam("response_type", "code")
             .queryParam("scope", googleOAuth2Properties.scope.joinToString(" "))
             .queryParam("access_type", "offline")
@@ -49,15 +45,12 @@ class GoogleOAuth2Handler(
     }
 
     private fun fetchTokenInfo(authorizationCode: String): OAuth2TokenInfo {
-        val redirectUri: String = ServletUriComponentsBuilder.fromCurrentContextPath()
-            .path(googleOAuth2Properties.relativeRedirectUri).toUriString()
-
         val tokenRequest = LinkedMultiValueMap<String, String>().apply {
             add("client_id", googleOAuth2Properties.clientId)
             add("client_secret", googleOAuth2Properties.clientSecret)
             add("code", authorizationCode)
             add("grant_type", "authorization_code")
-            add("redirect_uri", redirectUri)
+            add("redirect_uri", googleOAuth2Properties.redirectUri)
         }
 
         val tokenResponse: GoogleTokenResponse = googleOAuth2TokenClient.fetchToken(tokenRequest)

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/support/security/oauth2/GoogleOAuth2Properties.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/support/security/oauth2/GoogleOAuth2Properties.kt
@@ -6,6 +6,6 @@ import org.springframework.boot.context.properties.ConfigurationProperties
 data class GoogleOAuth2Properties(
     val clientId: String,
     val clientSecret: String,
-    val relativeRedirectUri: String,
+    val redirectUri: String,
     val scope: List<String>
 )

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -31,7 +31,7 @@ oauth2:
   google:
     client_id: scouter-google-client-id # REST API 키
     client_secret: scouter-google-secret-key # Client Secret 키
-    relative_redirect_uri: /relative/redirect/uri
+    redirect_uri: redirect-uri
     scope:
       - openid
       - https://www.googleapis.com/auth/userinfo.email


### PR DESCRIPTION
## 📄 작업 내용 요약
[문제]
![Image](https://github.com/user-attachments/assets/d7e20d46-f839-415b-a028-35202474db84)
- 개발 서버에 배포한 후 구글 소셜 로그인 테스트를 시도하였는데, 구글 소셜 로그인을 위한 리다이렉트 uri를 요청하였을 때 `액세스 차단됨: 이 앱의 요청이 잘못되었습니다` `400 오류: redirect_uri_mismatch` 발생

[원인]
- 기존에는 `oauth2.gogle.relative_redirect_uri`값을 설정해두고, `ServletUriComponentsBuilder.fromCurrentContextPath()`를 사용해서 요청이 들어온 uri를 기준으로 redirect_uri를 만들어서 사용했음
- 개발 서버에서는 로컬과 달리 ngix로 https 요청을 내부적으로 http 요청으로 변경함.
- 구글 클라우드 프로젝트에 등록한 redirect_uri는 `https://`로 시작하는 uri였기 때문에 uri_mismatch 오류 발생
- 구글 클라우드 프로젝트에서 Authorized redirect URI를 `http://`로 시작하는 uri로 변경하려고 했으나 정책 상 불가능 
![image](https://github.com/user-attachments/assets/19e134e1-b0e8-4156-9faa-9afb4a110381)

[해결]
- `oauth2.google.redirect_uri` 설정값에 redirect_uri 직접 설정
- `ServletUriComponentsBuilder.fromCurrentContextPath()`와 조합하여 사용하지 않고 설정파일의 redirect_uri를 그대로 사용

## 📎 Issue 번호
- closed #43 
