### PR TITLE
feature: #35 변경된 UI 및 기능명세에 따른 멤버 수정 api 수정

### DIFF
--- a/src/main/kotlin/com/yourssu/scouter/common/implement/domain/part/PartReader.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/domain/part/PartReader.kt
@@ -14,4 +14,8 @@ class PartReader(
         ?: throw PartNotFoundException("지정한 파트를 찾을 수 없습니다.")
 
     fun readAll(): List<Part> = partRepository.findAll()
+
+    fun readAllByIds(partIds: List<Long>): List<Part> {
+        return partRepository.findAllByIds(partIds)
+    }
 }

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/domain/part/PartRepository.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/domain/part/PartRepository.kt
@@ -5,4 +5,5 @@ interface PartRepository {
     fun saveAll(parts: List<Part>)
     fun findById(id: Long): Part?
     fun findAll(): List<Part>
+    fun findAllByIds(partIds: List<Long>): List<Part>
 }

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/domain/semester/Semester.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/domain/semester/Semester.kt
@@ -15,6 +15,34 @@ class Semester(
             year = Year.of(date.year),
             term = Term.of(date)
         )
+
+        fun previous(date: LocalDate): Semester {
+            val current: Semester = of(date)
+
+            return current.previousSemester()
+        }
+
+        fun next(date: LocalDate): Semester {
+            val current: Semester = of(date)
+
+            return current.nextSemester()
+        }
+    }
+
+    fun previousSemester(): Semester {
+        if (term == Term.SPRING) {
+            return Semester(year = year.minusYears(1), term = Term.FALL)
+        }
+
+        return Semester(year = year, term = Term.SPRING)
+    }
+
+    fun nextSemester(): Semester {
+        if (term == Term.FALL) {
+            return Semester(year = year.plusYears(1), term = Term.SPRING)
+        }
+
+        return Semester(year = year, term = Term.FALL)
     }
 
     override fun equals(other: Any?): Boolean {

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/domain/semester/Semester.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/domain/semester/Semester.kt
@@ -19,17 +19,11 @@ class Semester(
         fun previous(date: LocalDate): Semester {
             val current: Semester = of(date)
 
-            return current.previousSemester()
-        }
-
-        fun next(date: LocalDate): Semester {
-            val current: Semester = of(date)
-
-            return current.nextSemester()
+            return current.previous()
         }
     }
 
-    fun previousSemester(): Semester {
+    fun previous(): Semester {
         if (term == Term.SPRING) {
             return Semester(year = year.minusYears(1), term = Term.FALL)
         }
@@ -37,7 +31,7 @@ class Semester(
         return Semester(year = year, term = Term.SPRING)
     }
 
-    fun nextSemester(): Semester {
+    fun next(): Semester {
         if (term == Term.FALL) {
             return Semester(year = year.plusYears(1), term = Term.SPRING)
         }

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/domain/semester/SemesterReader.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/domain/semester/SemesterReader.kt
@@ -10,8 +10,13 @@ class SemesterReader(
     private val semesterRepository: SemesterRepository,
 ) {
 
-    fun readById(semesterId: Long): Semester =
-        semesterRepository.findById(semesterId) ?: throw SemesterNotFoundException("지정한 학기를 찾을 수 없습니다.")
+    fun readById(semesterId: Long): Semester {
+        return semesterRepository.findById(semesterId) ?: throw SemesterNotFoundException("지정한 학기를 찾을 수 없습니다.")
+    }
+
+    fun read(semester: Semester): Semester {
+        return semesterRepository.find(semester) ?: throw SemesterNotFoundException("지정한 학기를 찾을 수 없습니다.")
+    }
 
     fun readAll(): List<Semester> = semesterRepository.findAll()
 }

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/domain/semester/SemesterRepository.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/domain/semester/SemesterRepository.kt
@@ -4,6 +4,7 @@ interface SemesterRepository {
 
     fun save(semester: Semester): Semester
     fun findById(semesterId: Long): Semester?
+    fun find(semester: Semester): Semester?
     fun findAll(): List<Semester>
     fun deleteById(semesterId: Long)
 }

--- a/src/main/kotlin/com/yourssu/scouter/common/storage/domain/part/PartRepositoryImpl.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/storage/domain/part/PartRepositoryImpl.kt
@@ -14,7 +14,15 @@ class PartRepositoryImpl(
         jpaPartRepository.saveAll(parts.map { PartEntity.from(it) })
     }
 
-    override fun findById(id: Long): Part? = jpaPartRepository.findByIdOrNull(id)?.toDomain()
+    override fun findById(id: Long): Part? {
+        return jpaPartRepository.findByIdOrNull(id)?.toDomain()
+    }
 
-    override fun findAll(): List<Part> = jpaPartRepository.findAll().map { it.toDomain() }
+    override fun findAll(): List<Part> {
+        return jpaPartRepository.findAll().map { it.toDomain() }
+    }
+
+    override fun findAllByIds(partIds: List<Long>): List<Part> {
+        return jpaPartRepository.findAllById(partIds).map { it.toDomain() }
+    }
 }

--- a/src/main/kotlin/com/yourssu/scouter/common/storage/domain/semester/JpaSemesterRepository.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/storage/domain/semester/JpaSemesterRepository.kt
@@ -1,6 +1,10 @@
 package com.yourssu.scouter.common.storage.domain.semester
 
+import com.yourssu.scouter.common.implement.domain.semester.Term
+import java.time.Year
 import org.springframework.data.jpa.repository.JpaRepository
 
 interface JpaSemesterRepository : JpaRepository<SemesterEntity, Long> {
+
+    fun findByYearAndTerm(year: Year, term: Term): SemesterEntity
 }

--- a/src/main/kotlin/com/yourssu/scouter/common/storage/domain/semester/JpaSemesterRepository.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/storage/domain/semester/JpaSemesterRepository.kt
@@ -6,5 +6,5 @@ import org.springframework.data.jpa.repository.JpaRepository
 
 interface JpaSemesterRepository : JpaRepository<SemesterEntity, Long> {
 
-    fun findByYearAndTerm(year: Year, term: Term): SemesterEntity
+    fun findByYearAndTerm(year: Year, term: Term): SemesterEntity?
 }

--- a/src/main/kotlin/com/yourssu/scouter/common/storage/domain/semester/SemesterRepositoryImpl.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/storage/domain/semester/SemesterRepositoryImpl.kt
@@ -19,7 +19,7 @@ class SemesterRepositoryImpl(
     }
 
     override fun find(semester: Semester): Semester? {
-        return jpaSemesterRepository.findByYearAndTerm(semester.year, semester.term).toDomain()
+        return jpaSemesterRepository.findByYearAndTerm(semester.year, semester.term)?.toDomain()
     }
 
     override fun findAll(): List<Semester> {

--- a/src/main/kotlin/com/yourssu/scouter/common/storage/domain/semester/SemesterRepositoryImpl.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/storage/domain/semester/SemesterRepositoryImpl.kt
@@ -18,6 +18,10 @@ class SemesterRepositoryImpl(
         return jpaSemesterRepository.findByIdOrNull(semesterId)?.toDomain()
     }
 
+    override fun find(semester: Semester): Semester? {
+        return jpaSemesterRepository.findByYearAndTerm(semester.year, semester.term).toDomain()
+    }
+
     override fun findAll(): List<Semester> {
         return jpaSemesterRepository.findAll().map { it.toDomain() }
     }

--- a/src/main/kotlin/com/yourssu/scouter/hrms/application/domain/member/MemberController.kt
+++ b/src/main/kotlin/com/yourssu/scouter/hrms/application/domain/member/MemberController.kt
@@ -4,9 +4,17 @@ import com.yourssu.scouter.hrms.business.domain.member.ActiveMemberDto
 import com.yourssu.scouter.hrms.business.domain.member.GraduatedMemberDto
 import com.yourssu.scouter.hrms.business.domain.member.InactiveMemberDto
 import com.yourssu.scouter.hrms.business.domain.member.MemberService
+import com.yourssu.scouter.hrms.business.domain.member.UpdateActiveMemberCommand
+import com.yourssu.scouter.hrms.business.domain.member.UpdateGraduatedMemberCommand
+import com.yourssu.scouter.hrms.business.domain.member.UpdateInactiveMemberCommand
+import com.yourssu.scouter.hrms.business.domain.member.UpdateWithdrawnMemberCommand
 import com.yourssu.scouter.hrms.business.domain.member.WithdrawnMemberDto
+import jakarta.validation.Valid
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PatchMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 
@@ -67,6 +75,50 @@ class MemberController(
             withdrawnMemberDtos.map { ReadWithdrawnMemberResponse.from(it) }
 
         return ResponseEntity.ok(responses)
+    }
+
+    @PatchMapping("/members/active/{memberId}")
+    fun updateActiveById(
+        @PathVariable memberId: Long,
+        @RequestBody @Valid request: UpdateActiveMemberRequest,
+    ): ResponseEntity<Unit> {
+        val command: UpdateActiveMemberCommand = request.toCommand(memberId)
+        memberService.updateActiveById(command)
+
+        return ResponseEntity.ok().build()
+    }
+
+    @PatchMapping("/members/inactive/{memberId}")
+    fun updateInactiveById(
+        @PathVariable memberId: Long,
+        @RequestBody @Valid request: UpdateInactiveMemberRequest,
+    ): ResponseEntity<Unit> {
+        val command: UpdateInactiveMemberCommand = request.toCommand(memberId)
+        memberService.updateInactiveById(command)
+
+        return ResponseEntity.ok().build()
+    }
+
+    @PatchMapping("/members/graduated/{memberId}")
+    fun updateGraduatedById(
+        @PathVariable memberId: Long,
+        @RequestBody @Valid request: UpdateGraduatedMemberRequest,
+    ): ResponseEntity<Unit> {
+        val command: UpdateGraduatedMemberCommand = request.toCommand(memberId)
+        memberService.updateGraduatedById(command)
+
+        return ResponseEntity.ok().build()
+    }
+
+    @PatchMapping("/members/withdrawn/{memberId}")
+    fun updateWithdrawnById(
+        @PathVariable memberId: Long,
+        @RequestBody @Valid request: UpdateWithdrawnMemberRequest,
+    ): ResponseEntity<Unit> {
+        val command: UpdateWithdrawnMemberCommand = request.toCommand(memberId)
+        memberService.updateWithdrawnById(command)
+
+        return ResponseEntity.ok().build()
     }
 
     @GetMapping("/members/roles")

--- a/src/main/kotlin/com/yourssu/scouter/hrms/application/domain/member/UpdateActiveMemberRequest.kt
+++ b/src/main/kotlin/com/yourssu/scouter/hrms/application/domain/member/UpdateActiveMemberRequest.kt
@@ -1,0 +1,62 @@
+package com.yourssu.scouter.hrms.application.domain.member
+
+import com.fasterxml.jackson.annotation.JsonFormat
+import com.yourssu.scouter.hrms.business.domain.member.UpdateActiveMemberCommand
+import com.yourssu.scouter.hrms.business.domain.member.UpdateMemberInfoCommand
+import com.yourssu.scouter.hrms.business.support.utils.MemberRoleConverter
+import com.yourssu.scouter.hrms.business.support.utils.MemberStateConverter
+import com.yourssu.scouter.hrms.business.support.utils.NicknameConverter
+import java.time.LocalDate
+
+class UpdateActiveMemberRequest(
+
+    val partIds: List<Long>? = null,
+
+    val role: String? = null,
+
+    val name: String? = null,
+
+    val nickname: String? = null,
+
+    val state: String? = null,
+
+    val email: String? = null,
+
+    val phoneNumber: String? = null,
+
+    val departmentId: Long? = null,
+
+    val studentId: String? = null,
+
+    @field:JsonFormat(pattern = "yyyy.MM.dd")
+    val birthDate: LocalDate? = null,
+
+    @field:JsonFormat(pattern = "yyyy.MM.dd")
+    val joinDate: LocalDate? = null,
+
+    val membershipFee: Boolean? = null,
+
+    val note: String? = null,
+) {
+
+    fun toCommand(targetMemberId: Long) = UpdateActiveMemberCommand(
+        targetMemberId = targetMemberId,
+        updateMemberInfoCommand = UpdateMemberInfoCommand(
+            targetMemberId = targetMemberId,
+            partIds = partIds,
+            role = role?.let { MemberRoleConverter.convertToEnum(it) },
+            name = name,
+            nicknameEnglish = nickname?.let { NicknameConverter.extractNickname(it) },
+            nicknameKorean = nickname?.let { NicknameConverter.extractPronunciation(it) },
+            state = state?.let { MemberStateConverter.convertToEnum(it) },
+            email = email,
+            phoneNumber = phoneNumber,
+            departmentId = departmentId,
+            studentId = studentId,
+            birthDate = birthDate,
+            joinDate = joinDate,
+            note = note,
+        ),
+        isMembershipFeePaid = membershipFee,
+    )
+}

--- a/src/main/kotlin/com/yourssu/scouter/hrms/application/domain/member/UpdateActiveMemberRequest.kt
+++ b/src/main/kotlin/com/yourssu/scouter/hrms/application/domain/member/UpdateActiveMemberRequest.kt
@@ -3,9 +3,6 @@ package com.yourssu.scouter.hrms.application.domain.member
 import com.fasterxml.jackson.annotation.JsonFormat
 import com.yourssu.scouter.hrms.business.domain.member.UpdateActiveMemberCommand
 import com.yourssu.scouter.hrms.business.domain.member.UpdateMemberInfoCommand
-import com.yourssu.scouter.hrms.business.support.utils.MemberRoleConverter
-import com.yourssu.scouter.hrms.business.support.utils.MemberStateConverter
-import com.yourssu.scouter.hrms.business.support.utils.NicknameConverter
 import java.time.LocalDate
 
 class UpdateActiveMemberRequest(
@@ -41,14 +38,13 @@ class UpdateActiveMemberRequest(
 
     fun toCommand(targetMemberId: Long) = UpdateActiveMemberCommand(
         targetMemberId = targetMemberId,
-        updateMemberInfoCommand = UpdateMemberInfoCommand(
+        updateMemberInfoCommand = UpdateMemberInfoCommand.from(
             targetMemberId = targetMemberId,
             partIds = partIds,
-            role = role?.let { MemberRoleConverter.convertToEnum(it) },
+            role = role,
             name = name,
-            nicknameEnglish = nickname?.let { NicknameConverter.extractNickname(it) },
-            nicknameKorean = nickname?.let { NicknameConverter.extractPronunciation(it) },
-            state = state?.let { MemberStateConverter.convertToEnum(it) },
+            nickname = nickname,
+            state = state,
             email = email,
             phoneNumber = phoneNumber,
             departmentId = departmentId,

--- a/src/main/kotlin/com/yourssu/scouter/hrms/application/domain/member/UpdateGraduatedMemberRequest.kt
+++ b/src/main/kotlin/com/yourssu/scouter/hrms/application/domain/member/UpdateGraduatedMemberRequest.kt
@@ -1,0 +1,62 @@
+package com.yourssu.scouter.hrms.application.domain.member
+
+import com.fasterxml.jackson.annotation.JsonFormat
+import com.yourssu.scouter.hrms.business.domain.member.UpdateGraduatedMemberCommand
+import com.yourssu.scouter.hrms.business.domain.member.UpdateMemberInfoCommand
+import com.yourssu.scouter.hrms.business.support.utils.MemberRoleConverter
+import com.yourssu.scouter.hrms.business.support.utils.MemberStateConverter
+import com.yourssu.scouter.hrms.business.support.utils.NicknameConverter
+import java.time.LocalDate
+
+data class UpdateGraduatedMemberRequest(
+
+    val partIds: List<Long>? = null,
+
+    val role: String? = null,
+
+    val name: String? = null,
+
+    val nickname: String? = null,
+
+    val state: String? = null,
+
+    val email: String? = null,
+
+    val phoneNumber: String? = null,
+
+    val departmentId: Long? = null,
+
+    val studentId: String? = null,
+
+    @field:JsonFormat(pattern = "yyyy.MM.dd")
+    val birthDate: LocalDate? = null,
+
+    @field:JsonFormat(pattern = "yyyy.MM.dd")
+    val joinDate: LocalDate? = null,
+
+    val isAdvisorDesired: Boolean? = null,
+
+    val note: String? = null,
+) {
+
+    fun toCommand(targetMemberId: Long) = UpdateGraduatedMemberCommand(
+        targetMemberId = targetMemberId,
+        updateMemberInfoCommand = UpdateMemberInfoCommand(
+            targetMemberId = targetMemberId,
+            partIds = partIds,
+            role = role?.let { MemberRoleConverter.convertToEnum(it) },
+            name = name,
+            nicknameEnglish = nickname?.let { NicknameConverter.extractNickname(it) },
+            nicknameKorean = nickname?.let { NicknameConverter.extractPronunciation(it) },
+            state = state?.let { MemberStateConverter.convertToEnum(it) },
+            email = email,
+            phoneNumber = phoneNumber,
+            departmentId = departmentId,
+            studentId = studentId,
+            birthDate = birthDate,
+            joinDate = joinDate,
+            note = note,
+        ),
+        isAdvisorDesired = isAdvisorDesired,
+    )
+}

--- a/src/main/kotlin/com/yourssu/scouter/hrms/application/domain/member/UpdateGraduatedMemberRequest.kt
+++ b/src/main/kotlin/com/yourssu/scouter/hrms/application/domain/member/UpdateGraduatedMemberRequest.kt
@@ -3,9 +3,6 @@ package com.yourssu.scouter.hrms.application.domain.member
 import com.fasterxml.jackson.annotation.JsonFormat
 import com.yourssu.scouter.hrms.business.domain.member.UpdateGraduatedMemberCommand
 import com.yourssu.scouter.hrms.business.domain.member.UpdateMemberInfoCommand
-import com.yourssu.scouter.hrms.business.support.utils.MemberRoleConverter
-import com.yourssu.scouter.hrms.business.support.utils.MemberStateConverter
-import com.yourssu.scouter.hrms.business.support.utils.NicknameConverter
 import java.time.LocalDate
 
 data class UpdateGraduatedMemberRequest(
@@ -41,14 +38,13 @@ data class UpdateGraduatedMemberRequest(
 
     fun toCommand(targetMemberId: Long) = UpdateGraduatedMemberCommand(
         targetMemberId = targetMemberId,
-        updateMemberInfoCommand = UpdateMemberInfoCommand(
+        updateMemberInfoCommand = UpdateMemberInfoCommand.from(
             targetMemberId = targetMemberId,
             partIds = partIds,
-            role = role?.let { MemberRoleConverter.convertToEnum(it) },
+            role = role,
             name = name,
-            nicknameEnglish = nickname?.let { NicknameConverter.extractNickname(it) },
-            nicknameKorean = nickname?.let { NicknameConverter.extractPronunciation(it) },
-            state = state?.let { MemberStateConverter.convertToEnum(it) },
+            nickname = nickname,
+            state = state,
             email = email,
             phoneNumber = phoneNumber,
             departmentId = departmentId,

--- a/src/main/kotlin/com/yourssu/scouter/hrms/application/domain/member/UpdateInactiveMemberRequest.kt
+++ b/src/main/kotlin/com/yourssu/scouter/hrms/application/domain/member/UpdateInactiveMemberRequest.kt
@@ -1,0 +1,62 @@
+package com.yourssu.scouter.hrms.application.domain.member
+
+import com.fasterxml.jackson.annotation.JsonFormat
+import com.yourssu.scouter.hrms.business.domain.member.UpdateInactiveMemberCommand
+import com.yourssu.scouter.hrms.business.domain.member.UpdateMemberInfoCommand
+import com.yourssu.scouter.hrms.business.support.utils.MemberRoleConverter
+import com.yourssu.scouter.hrms.business.support.utils.MemberStateConverter
+import com.yourssu.scouter.hrms.business.support.utils.NicknameConverter
+import java.time.LocalDate
+
+data class UpdateInactiveMemberRequest(
+
+    val partIds: List<Long>? = null,
+
+    val role: String? = null,
+
+    val name: String? = null,
+
+    val nickname: String? = null,
+
+    val state: String? = null,
+
+    val email: String? = null,
+
+    val phoneNumber: String? = null,
+
+    val departmentId: Long? = null,
+
+    val studentId: String? = null,
+
+    @field:JsonFormat(pattern = "yyyy.MM.dd")
+    val birthDate: LocalDate? = null,
+
+    @field:JsonFormat(pattern = "yyyy.MM.dd")
+    val joinDate: LocalDate? = null,
+
+    val expectedReturnSemesterId: Long? = null,
+
+    val note: String? = null,
+) {
+
+    fun toCommand(targetMemberId: Long) = UpdateInactiveMemberCommand(
+        targetMemberId = targetMemberId,
+        updateMemberInfoCommand = UpdateMemberInfoCommand(
+            targetMemberId = targetMemberId,
+            partIds = partIds,
+            role = role?.let { MemberRoleConverter.convertToEnum(it) },
+            name = name,
+            nicknameEnglish = nickname?.let { NicknameConverter.extractNickname(it) },
+            nicknameKorean = nickname?.let { NicknameConverter.extractPronunciation(it) },
+            state = state?.let { MemberStateConverter.convertToEnum(it) },
+            email = email,
+            phoneNumber = phoneNumber,
+            departmentId = departmentId,
+            studentId = studentId,
+            birthDate = birthDate,
+            joinDate = joinDate,
+            note = note,
+        ),
+        expectedReturnSemesterId = expectedReturnSemesterId,
+    )
+}

--- a/src/main/kotlin/com/yourssu/scouter/hrms/application/domain/member/UpdateInactiveMemberRequest.kt
+++ b/src/main/kotlin/com/yourssu/scouter/hrms/application/domain/member/UpdateInactiveMemberRequest.kt
@@ -3,9 +3,6 @@ package com.yourssu.scouter.hrms.application.domain.member
 import com.fasterxml.jackson.annotation.JsonFormat
 import com.yourssu.scouter.hrms.business.domain.member.UpdateInactiveMemberCommand
 import com.yourssu.scouter.hrms.business.domain.member.UpdateMemberInfoCommand
-import com.yourssu.scouter.hrms.business.support.utils.MemberRoleConverter
-import com.yourssu.scouter.hrms.business.support.utils.MemberStateConverter
-import com.yourssu.scouter.hrms.business.support.utils.NicknameConverter
 import java.time.LocalDate
 
 data class UpdateInactiveMemberRequest(
@@ -41,14 +38,13 @@ data class UpdateInactiveMemberRequest(
 
     fun toCommand(targetMemberId: Long) = UpdateInactiveMemberCommand(
         targetMemberId = targetMemberId,
-        updateMemberInfoCommand = UpdateMemberInfoCommand(
+        updateMemberInfoCommand = UpdateMemberInfoCommand.from(
             targetMemberId = targetMemberId,
             partIds = partIds,
-            role = role?.let { MemberRoleConverter.convertToEnum(it) },
+            role = role,
             name = name,
-            nicknameEnglish = nickname?.let { NicknameConverter.extractNickname(it) },
-            nicknameKorean = nickname?.let { NicknameConverter.extractPronunciation(it) },
-            state = state?.let { MemberStateConverter.convertToEnum(it) },
+            nickname = nickname,
+            state = state,
             email = email,
             phoneNumber = phoneNumber,
             departmentId = departmentId,

--- a/src/main/kotlin/com/yourssu/scouter/hrms/application/domain/member/UpdateWithdrawnMemberRequest.kt
+++ b/src/main/kotlin/com/yourssu/scouter/hrms/application/domain/member/UpdateWithdrawnMemberRequest.kt
@@ -1,0 +1,59 @@
+package com.yourssu.scouter.hrms.application.domain.member
+
+import com.fasterxml.jackson.annotation.JsonFormat
+import com.yourssu.scouter.hrms.business.domain.member.UpdateMemberInfoCommand
+import com.yourssu.scouter.hrms.business.domain.member.UpdateWithdrawnMemberCommand
+import com.yourssu.scouter.hrms.business.support.utils.MemberRoleConverter
+import com.yourssu.scouter.hrms.business.support.utils.MemberStateConverter
+import com.yourssu.scouter.hrms.business.support.utils.NicknameConverter
+import java.time.LocalDate
+
+data class UpdateWithdrawnMemberRequest(
+
+    val partIds: List<Long>? = null,
+
+    val role: String? = null,
+
+    val name: String? = null,
+
+    val nickname: String? = null,
+
+    val state: String? = null,
+
+    val email: String? = null,
+
+    val phoneNumber: String? = null,
+
+    val departmentId: Long? = null,
+
+    val studentId: String? = null,
+
+    @field:JsonFormat(pattern = "yyyy.MM.dd")
+    val birthDate: LocalDate? = null,
+
+    @field:JsonFormat(pattern = "yyyy.MM.dd")
+    val joinDate: LocalDate? = null,
+
+    val note: String? = null,
+) {
+
+    fun toCommand(targetMemberId: Long) = UpdateWithdrawnMemberCommand(
+        targetMemberId = targetMemberId,
+        updateMemberInfoCommand = UpdateMemberInfoCommand(
+            targetMemberId = targetMemberId,
+            partIds = partIds,
+            role = role?.let { MemberRoleConverter.convertToEnum(it) },
+            name = name,
+            nicknameEnglish = nickname?.let { NicknameConverter.extractNickname(it) },
+            nicknameKorean = nickname?.let { NicknameConverter.extractPronunciation(it) },
+            state = state?.let { MemberStateConverter.convertToEnum(it) },
+            email = email,
+            phoneNumber = phoneNumber,
+            departmentId = departmentId,
+            studentId = studentId,
+            birthDate = birthDate,
+            joinDate = joinDate,
+            note = note,
+        ),
+    )
+}

--- a/src/main/kotlin/com/yourssu/scouter/hrms/application/domain/member/UpdateWithdrawnMemberRequest.kt
+++ b/src/main/kotlin/com/yourssu/scouter/hrms/application/domain/member/UpdateWithdrawnMemberRequest.kt
@@ -3,9 +3,6 @@ package com.yourssu.scouter.hrms.application.domain.member
 import com.fasterxml.jackson.annotation.JsonFormat
 import com.yourssu.scouter.hrms.business.domain.member.UpdateMemberInfoCommand
 import com.yourssu.scouter.hrms.business.domain.member.UpdateWithdrawnMemberCommand
-import com.yourssu.scouter.hrms.business.support.utils.MemberRoleConverter
-import com.yourssu.scouter.hrms.business.support.utils.MemberStateConverter
-import com.yourssu.scouter.hrms.business.support.utils.NicknameConverter
 import java.time.LocalDate
 
 data class UpdateWithdrawnMemberRequest(
@@ -39,14 +36,13 @@ data class UpdateWithdrawnMemberRequest(
 
     fun toCommand(targetMemberId: Long) = UpdateWithdrawnMemberCommand(
         targetMemberId = targetMemberId,
-        updateMemberInfoCommand = UpdateMemberInfoCommand(
+        updateMemberInfoCommand = UpdateMemberInfoCommand.from(
             targetMemberId = targetMemberId,
             partIds = partIds,
-            role = role?.let { MemberRoleConverter.convertToEnum(it) },
+            role = role,
             name = name,
-            nicknameEnglish = nickname?.let { NicknameConverter.extractNickname(it) },
-            nicknameKorean = nickname?.let { NicknameConverter.extractPronunciation(it) },
-            state = state?.let { MemberStateConverter.convertToEnum(it) },
+            nickname = nickname,
+            state = state,
             email = email,
             phoneNumber = phoneNumber,
             departmentId = departmentId,

--- a/src/main/kotlin/com/yourssu/scouter/hrms/business/domain/member/MemberService.kt
+++ b/src/main/kotlin/com/yourssu/scouter/hrms/business/domain/member/MemberService.kt
@@ -102,7 +102,7 @@ class MemberService(
         val updated = ActiveMember(
             id = target.id,
             member = target.member,
-            isMembershipFeePaid = command.membershipFee ?: target.isMembershipFeePaid
+            isMembershipFeePaid = command.isMembershipFeePaid ?: target.isMembershipFeePaid,
         )
 
         memberWriter.update(updated)
@@ -111,7 +111,7 @@ class MemberService(
     private fun countNotNullFields(command: UpdateActiveMemberCommand): Int {
         return listOf(
             command.updateMemberInfoCommand,
-            command.membershipFee
+            command.isMembershipFeePaid,
         ).count { it != null }
     }
 
@@ -141,6 +141,35 @@ class MemberService(
         return listOf(
             command.updateMemberInfoCommand,
             command.expectedReturnSemesterId,
+        ).count { it != null }
+    }
+
+    fun updateGraduatedById(command: UpdateGraduatedMemberCommand) {
+        if (countNotNullFields(command) > 1) {
+            throw IllegalMemberUpdateException("한 번에 하나의 필드만 수정할 수 있습니다.")
+        }
+
+        if (command.updateMemberInfoCommand != null) {
+            updateMemberInfo(command.updateMemberInfoCommand)
+
+            return
+        }
+
+        val target: GraduatedMember = memberReader.readGraduatedByMemberId(command.targetMemberId)
+        val updated = GraduatedMember(
+            id = target.id,
+            member = target.member,
+            activePeriod = target.activePeriod,
+            isAdvisorDesired = command.isAdvisorDesired ?: target.isAdvisorDesired,
+        )
+
+        memberWriter.update(updated)
+    }
+
+    private fun countNotNullFields(command: UpdateGraduatedMemberCommand): Int {
+        return listOf(
+            command.updateMemberInfoCommand,
+            command.isAdvisorDesired,
         ).count { it != null }
     }
 

--- a/src/main/kotlin/com/yourssu/scouter/hrms/business/domain/member/MemberService.kt
+++ b/src/main/kotlin/com/yourssu/scouter/hrms/business/domain/member/MemberService.kt
@@ -297,6 +297,23 @@ class MemberService(
             note = target.note,
         )
 
+        deletePreviousStateData(target)
+        updateNewStateData(newState, updateMember)
+    }
+
+    private fun deletePreviousStateData(target: Member) {
+        when (target.state) {
+            MemberState.ACTIVE -> memberWriter.deleteFromActiveMember(target)
+            MemberState.INACTIVE -> memberWriter.deleteFromInactiveMember(target)
+            MemberState.GRADUATED -> memberWriter.deleteFromGraduatedMember(target)
+            MemberState.WITHDRAWN -> memberWriter.deleteFromWithdrawnMember(target)
+        }
+    }
+
+    private fun updateNewStateData(
+        newState: MemberState,
+        updateMember: Member
+    ) {
         when (newState) {
             MemberState.ACTIVE -> {
                 memberWriter.writeMemberWithActiveStatus(

--- a/src/main/kotlin/com/yourssu/scouter/hrms/business/domain/member/MemberService.kt
+++ b/src/main/kotlin/com/yourssu/scouter/hrms/business/domain/member/MemberService.kt
@@ -90,7 +90,7 @@ class MemberService(
     }
 
     fun updateActiveById(command: UpdateActiveMemberCommand) {
-        if (countNotNullFields(command) > 1) {
+        if (countFilledFields(command) > 1) {
             throw IllegalMemberUpdateException("한 번에 하나의 필드만 수정할 수 있습니다.")
         }
 
@@ -110,7 +110,7 @@ class MemberService(
         memberWriter.update(updated)
     }
 
-    private fun countNotNullFields(command: UpdateActiveMemberCommand): Int {
+    private fun countFilledFields(command: UpdateActiveMemberCommand): Int {
         return listOf(
             command.updateMemberInfoCommand,
             command.isMembershipFeePaid,
@@ -118,7 +118,7 @@ class MemberService(
     }
 
     fun updateInactiveById(command: UpdateInactiveMemberCommand) {
-        if (countNotNullFields(command) > 1) {
+        if (countFilledFields(command) > 1) {
             throw IllegalMemberUpdateException("한 번에 하나의 필드만 수정할 수 있습니다.")
         }
 
@@ -145,7 +145,7 @@ class MemberService(
         }
     }
 
-    private fun countNotNullFields(command: UpdateInactiveMemberCommand): Int {
+    private fun countFilledFields(command: UpdateInactiveMemberCommand): Int {
         return listOf(
             command.updateMemberInfoCommand,
             command.expectedReturnSemesterId,
@@ -153,7 +153,7 @@ class MemberService(
     }
 
     fun updateGraduatedById(command: UpdateGraduatedMemberCommand) {
-        if (countNotNullFields(command) > 1) {
+        if (countFilledFields(command) > 1) {
             throw IllegalMemberUpdateException("한 번에 하나의 필드만 수정할 수 있습니다.")
         }
 
@@ -174,7 +174,7 @@ class MemberService(
         memberWriter.update(updated)
     }
 
-    private fun countNotNullFields(command: UpdateGraduatedMemberCommand): Int {
+    private fun countFilledFields(command: UpdateGraduatedMemberCommand): Int {
         return listOf(
             command.updateMemberInfoCommand,
             command.isAdvisorDesired,
@@ -182,7 +182,7 @@ class MemberService(
     }
 
     fun updateWithdrawnById(command: UpdateWithdrawnMemberCommand) {
-        if (countNotNullFields(command) > 1) {
+        if (countFilledFields(command) > 1) {
             throw IllegalMemberUpdateException("한 번에 하나의 필드만 수정할 수 있습니다.")
         }
 
@@ -193,14 +193,14 @@ class MemberService(
         }
     }
 
-    private fun countNotNullFields(command: UpdateWithdrawnMemberCommand): Int {
+    private fun countFilledFields(command: UpdateWithdrawnMemberCommand): Int {
         return listOf(
             command.updateMemberInfoCommand,
         ).count { it != null }
     }
 
     private fun updateMemberInfo(command: UpdateMemberInfoCommand) {
-        countNotNullFields(command)
+        countFilledFields(command)
         val target: Member = memberReader.readById(command.targetMemberId)
         if (command.role != null) {
             updateMemberRole(target, command.role)
@@ -229,7 +229,7 @@ class MemberService(
         memberWriter.update(updateMember)
     }
 
-    private fun countNotNullFields(command: UpdateMemberInfoCommand): Int {
+    private fun countFilledFields(command: UpdateMemberInfoCommand): Int {
         return listOf(
             command.name,
             command.email,

--- a/src/main/kotlin/com/yourssu/scouter/hrms/business/domain/member/MemberService.kt
+++ b/src/main/kotlin/com/yourssu/scouter/hrms/business/domain/member/MemberService.kt
@@ -130,7 +130,7 @@ class MemberService(
 
         val target: InactiveMember = memberReader.readInactiveByMemberId(command.targetMemberId)
         if (command.expectedReturnSemesterId != null) {
-            val expectedReturnSemester: Semester = semesterReader.read(Semester.of(LocalDate.now()))
+            val expectedReturnSemester: Semester = semesterReader.readById(command.expectedReturnSemesterId)
             val previousSemesterBeforeExpectedReturnSemester: Semester =
                 semesterReader.read(expectedReturnSemester.previous())
 

--- a/src/main/kotlin/com/yourssu/scouter/hrms/business/domain/member/MemberService.kt
+++ b/src/main/kotlin/com/yourssu/scouter/hrms/business/domain/member/MemberService.kt
@@ -181,6 +181,24 @@ class MemberService(
         ).count { it != null }
     }
 
+    fun updateWithdrawnById(command: UpdateWithdrawnMemberCommand) {
+        if (countNotNullFields(command) > 1) {
+            throw IllegalMemberUpdateException("한 번에 하나의 필드만 수정할 수 있습니다.")
+        }
+
+        if (command.updateMemberInfoCommand != null) {
+            updateMemberInfo(command.updateMemberInfoCommand)
+
+            return
+        }
+    }
+
+    private fun countNotNullFields(command: UpdateWithdrawnMemberCommand): Int {
+        return listOf(
+            command.updateMemberInfoCommand,
+        ).count { it != null }
+    }
+
     private fun updateMemberInfo(command: UpdateMemberInfoCommand) {
         countNotNullFields(command)
         val target: Member = memberReader.readById(command.targetMemberId)

--- a/src/main/kotlin/com/yourssu/scouter/hrms/business/domain/member/MemberService.kt
+++ b/src/main/kotlin/com/yourssu/scouter/hrms/business/domain/member/MemberService.kt
@@ -289,7 +289,7 @@ class MemberService(
             department = target.department,
             studentId = target.studentId,
             parts = target.parts,
-            role = target.role,
+            role = MemberRole.MEMBER,
             nicknameEnglish = target.nicknameEnglish,
             nicknameKorean = target.nicknameKorean,
             state = newState,

--- a/src/main/kotlin/com/yourssu/scouter/hrms/business/domain/member/MemberService.kt
+++ b/src/main/kotlin/com/yourssu/scouter/hrms/business/domain/member/MemberService.kt
@@ -31,7 +31,6 @@ class MemberService(
         val member: Member = command.toDomain(department, parts)
         val writtenActiveMember: ActiveMember = memberWriter.writeMemberWithActiveStatus(
             member = member,
-            isMembershipFeePaid = false,
         )
 
         return writtenActiveMember.id!!

--- a/src/main/kotlin/com/yourssu/scouter/hrms/business/domain/member/MemberService.kt
+++ b/src/main/kotlin/com/yourssu/scouter/hrms/business/domain/member/MemberService.kt
@@ -5,6 +5,7 @@ import com.yourssu.scouter.common.implement.domain.department.DepartmentReader
 import com.yourssu.scouter.common.implement.domain.part.Part
 import com.yourssu.scouter.common.implement.domain.part.PartReader
 import com.yourssu.scouter.common.implement.domain.semester.Semester
+import com.yourssu.scouter.common.implement.domain.semester.SemesterReader
 import com.yourssu.scouter.hrms.business.support.exception.IllegalMemberUpdateException
 import com.yourssu.scouter.hrms.business.support.utils.MemberRoleConverter
 import com.yourssu.scouter.hrms.business.support.utils.MemberStateConverter
@@ -26,6 +27,7 @@ class MemberService(
     private val memberReader: MemberReader,
     private val departmentReader: DepartmentReader,
     private val partReader: PartReader,
+    private val semesterReader: SemesterReader,
 ) {
 
     fun createMemberWithActiveState(command: CreateMemberCommand): Long {
@@ -128,8 +130,14 @@ class MemberService(
 
         val target: InactiveMember = memberReader.readInactiveByMemberId(command.targetMemberId)
         if (command.expectedReturnSemesterId != null) {
-            val expectedReturnSemester: Semester = Semester.of(LocalDate.now())
-            val updated = target.updateExpectedReturnSemester(expectedReturnSemester)
+            val expectedReturnSemester: Semester = semesterReader.read(Semester.of(LocalDate.now()))
+            val previousSemesterBeforeExpectedReturnSemester: Semester =
+                semesterReader.read(expectedReturnSemester.previous())
+
+            val updated = target.updateExpectedReturnSemester(
+                expectedReturnSemester = expectedReturnSemester,
+                previousSemesterBeforeExpectedReturnSemester = previousSemesterBeforeExpectedReturnSemester,
+            )
 
             memberWriter.update(updated)
 

--- a/src/main/kotlin/com/yourssu/scouter/hrms/business/domain/member/MemberService.kt
+++ b/src/main/kotlin/com/yourssu/scouter/hrms/business/domain/member/MemberService.kt
@@ -115,6 +115,35 @@ class MemberService(
         ).count { it != null }
     }
 
+    fun updateInactiveById(command: UpdateInactiveMemberCommand) {
+        if (countNotNullFields(command) > 1) {
+            throw IllegalMemberUpdateException("한 번에 하나의 필드만 수정할 수 있습니다.")
+        }
+
+        if (command.updateMemberInfoCommand != null) {
+            updateMemberInfo(command.updateMemberInfoCommand)
+
+            return
+        }
+
+        val target: InactiveMember = memberReader.readInactiveByMemberId(command.targetMemberId)
+        if (command.expectedReturnSemesterId != null) {
+            val expectedReturnSemester: Semester = Semester.of(LocalDate.now())
+            val updated = target.updateExpectedReturnSemester(expectedReturnSemester)
+
+            memberWriter.update(updated)
+
+            return
+        }
+    }
+
+    private fun countNotNullFields(command: UpdateInactiveMemberCommand): Int {
+        return listOf(
+            command.updateMemberInfoCommand,
+            command.expectedReturnSemesterId,
+        ).count { it != null }
+    }
+
     private fun updateMemberInfo(command: UpdateMemberInfoCommand) {
         countNotNullFields(command)
         val target: Member = memberReader.readById(command.targetMemberId)

--- a/src/main/kotlin/com/yourssu/scouter/hrms/business/domain/member/MemberService.kt
+++ b/src/main/kotlin/com/yourssu/scouter/hrms/business/domain/member/MemberService.kt
@@ -204,9 +204,11 @@ class MemberService(
         val target: Member = memberReader.readById(command.targetMemberId)
         if (command.role != null) {
             updateMemberRole(target, command.role)
+            return
         }
         if (command.state != null) {
             updateMemberState(target, command.state)
+            return
         }
 
         val updateMember = Member(

--- a/src/main/kotlin/com/yourssu/scouter/hrms/business/domain/member/MemberService.kt
+++ b/src/main/kotlin/com/yourssu/scouter/hrms/business/domain/member/MemberService.kt
@@ -183,7 +183,7 @@ class MemberService(
             updateMemberState(target, command.state)
         }
 
-        Member(
+        val updateMember = Member(
             id = target.id,
             name = command.name ?: target.name,
             email = command.email ?: target.email,
@@ -199,6 +199,8 @@ class MemberService(
             joinDate = command.joinDate ?: target.joinDate,
             note = command.note ?: target.note,
         )
+
+        memberWriter.update(updateMember)
     }
 
     private fun countNotNullFields(command: UpdateMemberInfoCommand): Int {

--- a/src/main/kotlin/com/yourssu/scouter/hrms/business/domain/member/MemberService.kt
+++ b/src/main/kotlin/com/yourssu/scouter/hrms/business/domain/member/MemberService.kt
@@ -4,6 +4,8 @@ import com.yourssu.scouter.common.implement.domain.department.Department
 import com.yourssu.scouter.common.implement.domain.department.DepartmentReader
 import com.yourssu.scouter.common.implement.domain.part.Part
 import com.yourssu.scouter.common.implement.domain.part.PartReader
+import com.yourssu.scouter.common.implement.domain.semester.Semester
+import com.yourssu.scouter.hrms.business.support.exception.IllegalMemberUpdateException
 import com.yourssu.scouter.hrms.business.support.utils.MemberRoleConverter
 import com.yourssu.scouter.hrms.business.support.utils.MemberStateConverter
 import com.yourssu.scouter.hrms.implement.domain.member.ActiveMember
@@ -15,6 +17,7 @@ import com.yourssu.scouter.hrms.implement.domain.member.MemberRole
 import com.yourssu.scouter.hrms.implement.domain.member.MemberState
 import com.yourssu.scouter.hrms.implement.domain.member.MemberWriter
 import com.yourssu.scouter.hrms.implement.domain.member.WithdrawnMember
+import java.time.LocalDate
 import org.springframework.stereotype.Service
 
 @Service
@@ -82,6 +85,127 @@ class MemberService(
         val members: List<WithdrawnMember> = memberReader.searchAllWithdrawnByNameOrNickname(query)
 
         return members.map { WithdrawnMemberDto.from(it) }
+    }
+
+    private fun updateMemberInfo(targetMemberId: Long, command: UpdateMemberInfoCommand) {
+        countNotNullFields(command)
+        val target: Member = memberReader.readById(targetMemberId)
+        if (command.role != null) {
+            updateMemberRole(target, command.role)
+        }
+        if (command.state != null) {
+            updateMemberState(target, command.state)
+        }
+
+        Member(
+            id = target.id,
+            name = command.name ?: target.name,
+            email = command.email ?: target.email,
+            phoneNumber = command.phoneNumber ?: target.phoneNumber,
+            birthDate = command.birthDate ?: target.birthDate,
+            department = command.departmentId?.let { departmentReader.readById(it) } ?: target.department,
+            studentId = command.studentId ?: target.studentId,
+            parts = command.partIds?.let { partReader.readAllByIds(it) } ?: target.parts,
+            role = target.role,
+            nicknameEnglish = command.nicknameEnglish ?: target.nicknameEnglish,
+            nicknameKorean = command.nicknameKorean ?: target.nicknameKorean,
+            state = target.state,
+            joinDate = command.joinDate ?: target.joinDate,
+            note = command.note ?: target.note,
+        )
+    }
+
+    private fun countNotNullFields(command: UpdateMemberInfoCommand): Int {
+        return listOf(
+            command.name,
+            command.email,
+            command.phoneNumber,
+            command.birthDate,
+            command.departmentId,
+            command.studentId,
+            command.partIds,
+            command.role,
+            command.nicknameEnglish,
+            command.nicknameKorean,
+            command.state,
+            command.joinDate,
+            command.note,
+        ).count { it != null }
+    }
+
+    private fun updateMemberRole(target: Member, newRole: MemberRole) {
+        var newNote = ""
+        if (newRole in listOf(MemberRole.LEAD, MemberRole.VICE_LEAD)) {
+            val (currentYear, currentTerm) = Semester.of(LocalDate.now()).run { year to term.intValue }
+            val partName: String = target.parts.first().name // TODO : 1멤버 2파트인 경우 어떻게 처리할지 물어보고 수정하기
+            val newRoleName: String = MemberRoleConverter.convertToString(newRole)
+
+            newNote = "${currentYear}년 ${currentTerm}학기 $partName 파트 $newRoleName 역임\n"
+        }
+
+        val updateMember = Member(
+            id = target.id,
+            name = target.name,
+            email = target.email,
+            phoneNumber = target.phoneNumber,
+            birthDate = target.birthDate,
+            department = target.department,
+            studentId = target.studentId,
+            parts = target.parts,
+            role = newRole,
+            nicknameEnglish = target.nicknameEnglish,
+            nicknameKorean = target.nicknameKorean,
+            state = target.state,
+            joinDate = target.joinDate,
+            note = "${newNote}${target.note}",
+        )
+
+        memberWriter.update(updateMember)
+    }
+
+    private fun updateMemberState(target: Member, newState: MemberState) {
+        val updateMember = Member(
+            id = target.id,
+            name = target.name,
+            email = target.email,
+            phoneNumber = target.phoneNumber,
+            birthDate = target.birthDate,
+            department = target.department,
+            studentId = target.studentId,
+            parts = target.parts,
+            role = target.role,
+            nicknameEnglish = target.nicknameEnglish,
+            nicknameKorean = target.nicknameKorean,
+            state = newState,
+            joinDate = target.joinDate,
+            note = target.note,
+        )
+
+        when (newState) {
+            MemberState.ACTIVE -> {
+                memberWriter.writeMemberWithActiveStatus(
+                    member = updateMember,
+                )
+            }
+
+            MemberState.INACTIVE -> {
+                memberWriter.writeMemberWithInactiveState(
+                    member = updateMember,
+                    currentDate = LocalDate.now(),
+                )
+            }
+
+            MemberState.GRADUATED -> {
+                memberWriter.writeMemberWithGraduatedState(
+                    member = updateMember,
+                    currentDate = LocalDate.now(),
+                )
+            }
+
+            MemberState.WITHDRAWN -> {
+                memberWriter.writeMemberWithWithdrawnState(updateMember)
+            }
+        }
     }
 
     fun readAllRoles(): List<String> {

--- a/src/main/kotlin/com/yourssu/scouter/hrms/business/domain/member/UpdateActiveMemberCommand.kt
+++ b/src/main/kotlin/com/yourssu/scouter/hrms/business/domain/member/UpdateActiveMemberCommand.kt
@@ -1,0 +1,7 @@
+package com.yourssu.scouter.hrms.business.domain.member
+
+data class UpdateActiveMemberCommand(
+    val targetMemberId: Long,
+    val updateMemberInfoCommand: UpdateMemberInfoCommand? = null,
+    val membershipFee: Boolean? = null,
+)

--- a/src/main/kotlin/com/yourssu/scouter/hrms/business/domain/member/UpdateGraduatedMemberCommand.kt
+++ b/src/main/kotlin/com/yourssu/scouter/hrms/business/domain/member/UpdateGraduatedMemberCommand.kt
@@ -1,7 +1,7 @@
 package com.yourssu.scouter.hrms.business.domain.member
 
-data class UpdateActiveMemberCommand(
+data class UpdateGraduatedMemberCommand(
     val targetMemberId: Long,
     val updateMemberInfoCommand: UpdateMemberInfoCommand? = null,
-    val isMembershipFeePaid: Boolean? = null,
+    val isAdvisorDesired: Boolean? = null,
 )

--- a/src/main/kotlin/com/yourssu/scouter/hrms/business/domain/member/UpdateInactiveMemberCommand.kt
+++ b/src/main/kotlin/com/yourssu/scouter/hrms/business/domain/member/UpdateInactiveMemberCommand.kt
@@ -1,0 +1,7 @@
+package com.yourssu.scouter.hrms.business.domain.member
+
+data class UpdateInactiveMemberCommand(
+    val targetMemberId: Long,
+    val updateMemberInfoCommand: UpdateMemberInfoCommand? = null,
+    val expectedReturnSemesterId: Long? = null,
+)

--- a/src/main/kotlin/com/yourssu/scouter/hrms/business/domain/member/UpdateMemberInfoCommand.kt
+++ b/src/main/kotlin/com/yourssu/scouter/hrms/business/domain/member/UpdateMemberInfoCommand.kt
@@ -1,0 +1,22 @@
+package com.yourssu.scouter.hrms.business.domain.member
+
+import com.yourssu.scouter.hrms.implement.domain.member.MemberRole
+import com.yourssu.scouter.hrms.implement.domain.member.MemberState
+import java.time.LocalDate
+
+data class UpdateMemberInfoCommand(
+    val targetMemberId: Long,
+    val partIds: List<Long>? = null,
+    val role: MemberRole? = null,
+    val name: String? = null,
+    val nicknameEnglish: String? = null,
+    val nicknameKorean: String? = null,
+    val state: MemberState? = null,
+    val email: String? = null,
+    val phoneNumber: String? = null,
+    val departmentId: Long? = null,
+    val studentId: String? = null,
+    val birthDate: LocalDate? = null,
+    val joinDate: LocalDate? = null,
+    val note: String? = null,
+)

--- a/src/main/kotlin/com/yourssu/scouter/hrms/business/domain/member/UpdateMemberInfoCommand.kt
+++ b/src/main/kotlin/com/yourssu/scouter/hrms/business/domain/member/UpdateMemberInfoCommand.kt
@@ -1,5 +1,8 @@
 package com.yourssu.scouter.hrms.business.domain.member
 
+import com.yourssu.scouter.hrms.business.support.utils.MemberRoleConverter
+import com.yourssu.scouter.hrms.business.support.utils.MemberStateConverter
+import com.yourssu.scouter.hrms.business.support.utils.NicknameConverter
 import com.yourssu.scouter.hrms.implement.domain.member.MemberRole
 import com.yourssu.scouter.hrms.implement.domain.member.MemberState
 import java.time.LocalDate
@@ -19,4 +22,58 @@ data class UpdateMemberInfoCommand(
     val birthDate: LocalDate? = null,
     val joinDate: LocalDate? = null,
     val note: String? = null,
-)
+) {
+    companion object {
+        fun from(
+            targetMemberId: Long,
+            partIds: List<Long>? = null,
+            role: String? = null,
+            name: String? = null,
+            nickname: String? = null,
+            state: String? = null,
+            email: String? = null,
+            phoneNumber: String? = null,
+            departmentId: Long? = null,
+            studentId: String? = null,
+            birthDate: LocalDate? = null,
+            joinDate: LocalDate? = null,
+            note: String? = null,
+        ): UpdateMemberInfoCommand? {
+            val filledFieldCount = listOf(
+                partIds,
+                role,
+                name,
+                nickname,
+                state,
+                email,
+                phoneNumber,
+                departmentId,
+                studentId,
+                birthDate,
+                joinDate,
+                note,
+            ).count { it != null }
+
+            if (filledFieldCount == 0) {
+                return null
+            }
+
+            return UpdateMemberInfoCommand(
+                targetMemberId = targetMemberId,
+                partIds = partIds,
+                role = role?.let { MemberRoleConverter.convertToEnum(it) },
+                name = name,
+                nicknameEnglish = nickname?.let { NicknameConverter.extractNickname(it) },
+                nicknameKorean = nickname?.let { NicknameConverter.extractPronunciation(it) },
+                state = state?.let { MemberStateConverter.convertToEnum(it) },
+                email = email,
+                phoneNumber = phoneNumber,
+                departmentId = departmentId,
+                studentId = studentId,
+                birthDate = birthDate,
+                joinDate = joinDate,
+                note = note,
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/hrms/business/domain/member/UpdateWithdrawnMemberCommand.kt
+++ b/src/main/kotlin/com/yourssu/scouter/hrms/business/domain/member/UpdateWithdrawnMemberCommand.kt
@@ -1,0 +1,6 @@
+package com.yourssu.scouter.hrms.business.domain.member
+
+data class UpdateWithdrawnMemberCommand(
+    val targetMemberId: Long,
+    val updateMemberInfoCommand: UpdateMemberInfoCommand? = null,
+)

--- a/src/main/kotlin/com/yourssu/scouter/hrms/business/support/exception/IllegalMemberUpdateException.kt
+++ b/src/main/kotlin/com/yourssu/scouter/hrms/business/support/exception/IllegalMemberUpdateException.kt
@@ -1,0 +1,8 @@
+package com.yourssu.scouter.hrms.business.support.exception
+
+import com.yourssu.scouter.common.implement.support.exception.CustomException
+import org.springframework.http.HttpStatus
+
+class IllegalMemberUpdateException(
+    message: String,
+) : CustomException(message, "Member-002", HttpStatus.BAD_REQUEST)

--- a/src/main/kotlin/com/yourssu/scouter/hrms/implement/domain/member/ActiveMember.kt
+++ b/src/main/kotlin/com/yourssu/scouter/hrms/implement/domain/member/ActiveMember.kt
@@ -6,6 +6,19 @@ class ActiveMember(
     val isMembershipFeePaid: Boolean = false,
 ) {
 
+    constructor(member: Member) : this(
+        member = member,
+        isMembershipFeePaid = false,
+    )
+
+    fun updateMembershipFeePaid(isMembershipFeePaid: Boolean): ActiveMember {
+        return ActiveMember(
+            id = id,
+            member = member,
+            isMembershipFeePaid = isMembershipFeePaid,
+        )
+    }
+
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (javaClass != other?.javaClass) return false

--- a/src/main/kotlin/com/yourssu/scouter/hrms/implement/domain/member/ActiveMemberRepository.kt
+++ b/src/main/kotlin/com/yourssu/scouter/hrms/implement/domain/member/ActiveMemberRepository.kt
@@ -8,4 +8,5 @@ interface ActiveMemberRepository {
     fun findAllByName(name: String): List<ActiveMember>
     fun findAllByNicknameKorean(nicknameKorean: String): List<ActiveMember>
     fun findAllByNicknameEnglish(nicknameEnglish: String): List<ActiveMember>
+    fun deleteByMemberId(memberId: Long)
 }

--- a/src/main/kotlin/com/yourssu/scouter/hrms/implement/domain/member/ActiveMemberRepository.kt
+++ b/src/main/kotlin/com/yourssu/scouter/hrms/implement/domain/member/ActiveMemberRepository.kt
@@ -3,6 +3,7 @@ package com.yourssu.scouter.hrms.implement.domain.member
 interface ActiveMemberRepository {
 
     fun save(activeMember: ActiveMember): ActiveMember
+    fun findByMemberId(memberId: Long): ActiveMember?
     fun findAll(): List<ActiveMember>
     fun findAllByName(name: String): List<ActiveMember>
     fun findAllByNicknameKorean(nicknameKorean: String): List<ActiveMember>

--- a/src/main/kotlin/com/yourssu/scouter/hrms/implement/domain/member/GraduatedMember.kt
+++ b/src/main/kotlin/com/yourssu/scouter/hrms/implement/domain/member/GraduatedMember.kt
@@ -1,11 +1,32 @@
 package com.yourssu.scouter.hrms.implement.domain.member
 
+import com.yourssu.scouter.common.implement.domain.semester.Semester
+import java.time.LocalDate
+
 class GraduatedMember(
     val id: Long? = null,
     val member: Member,
     val activePeriod: SemesterPeriod,
     val isAdvisorDesired: Boolean,
 ) {
+
+    constructor(member: Member, stateChangeDate: LocalDate) : this(
+        member = member,
+        activePeriod = SemesterPeriod(
+            startSemester = Semester.of(member.joinDate),
+            endSemester = Semester.previous(stateChangeDate)
+        ),
+        isAdvisorDesired = false,
+    )
+
+    fun updateAdvisorDesired(isAdvisorDesired: Boolean): GraduatedMember {
+        return GraduatedMember(
+            id = id,
+            member = member,
+            activePeriod = activePeriod,
+            isAdvisorDesired = isAdvisorDesired,
+        )
+    }
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true

--- a/src/main/kotlin/com/yourssu/scouter/hrms/implement/domain/member/GraduatedMember.kt
+++ b/src/main/kotlin/com/yourssu/scouter/hrms/implement/domain/member/GraduatedMember.kt
@@ -1,7 +1,6 @@
 package com.yourssu.scouter.hrms.implement.domain.member
 
 import com.yourssu.scouter.common.implement.domain.semester.Semester
-import java.time.LocalDate
 
 class GraduatedMember(
     val id: Long? = null,
@@ -10,11 +9,15 @@ class GraduatedMember(
     val isAdvisorDesired: Boolean,
 ) {
 
-    constructor(member: Member, stateChangeDate: LocalDate) : this(
+    constructor(
+        member: Member,
+        joinSemester: Semester,
+        previousSemesterBeforeStateChange: Semester,
+    ) : this(
         member = member,
         activePeriod = SemesterPeriod(
-            startSemester = Semester.of(member.joinDate),
-            endSemester = Semester.previous(stateChangeDate)
+            startSemester = joinSemester,
+            endSemester = previousSemesterBeforeStateChange,
         ),
         isAdvisorDesired = false,
     )

--- a/src/main/kotlin/com/yourssu/scouter/hrms/implement/domain/member/GraduatedMemberRepository.kt
+++ b/src/main/kotlin/com/yourssu/scouter/hrms/implement/domain/member/GraduatedMemberRepository.kt
@@ -2,6 +2,7 @@ package com.yourssu.scouter.hrms.implement.domain.member
 
 interface GraduatedMemberRepository {
 
+    fun save(graduatedMember: GraduatedMember): GraduatedMember
     fun findAll(): List<GraduatedMember>
     fun findAllByName(name: String): List<GraduatedMember>
     fun findAllByNicknameKorean(nicknameKorean: String): List<GraduatedMember>

--- a/src/main/kotlin/com/yourssu/scouter/hrms/implement/domain/member/GraduatedMemberRepository.kt
+++ b/src/main/kotlin/com/yourssu/scouter/hrms/implement/domain/member/GraduatedMemberRepository.kt
@@ -8,4 +8,5 @@ interface GraduatedMemberRepository {
     fun findAllByName(name: String): List<GraduatedMember>
     fun findAllByNicknameKorean(nicknameKorean: String): List<GraduatedMember>
     fun findAllByNicknameEnglish(nicknameEnglish: String): List<GraduatedMember>
+    fun deleteByMemberId(memberId: Long)
 }

--- a/src/main/kotlin/com/yourssu/scouter/hrms/implement/domain/member/GraduatedMemberRepository.kt
+++ b/src/main/kotlin/com/yourssu/scouter/hrms/implement/domain/member/GraduatedMemberRepository.kt
@@ -3,6 +3,7 @@ package com.yourssu.scouter.hrms.implement.domain.member
 interface GraduatedMemberRepository {
 
     fun save(graduatedMember: GraduatedMember): GraduatedMember
+    fun findByMemberId(memberId: Long): GraduatedMember?
     fun findAll(): List<GraduatedMember>
     fun findAllByName(name: String): List<GraduatedMember>
     fun findAllByNicknameKorean(nicknameKorean: String): List<GraduatedMember>

--- a/src/main/kotlin/com/yourssu/scouter/hrms/implement/domain/member/InactiveMember.kt
+++ b/src/main/kotlin/com/yourssu/scouter/hrms/implement/domain/member/InactiveMember.kt
@@ -1,7 +1,6 @@
 package com.yourssu.scouter.hrms.implement.domain.member
 
 import com.yourssu.scouter.common.implement.domain.semester.Semester
-import java.time.LocalDate
 
 class InactiveMember(
     val id: Long? = null,
@@ -11,26 +10,35 @@ class InactiveMember(
     val inactivePeriod: SemesterPeriod,
 ) {
 
-    constructor(member: Member, stateChangeDate: LocalDate) : this(
+    constructor(
+        member: Member,
+        joinSemester: Semester,
+        stateChangeSemester: Semester,
+        previousSemesterBeforeStateChange: Semester,
+        nextSemesterAfterStateChange: Semester
+    ) : this(
         member = member,
         activePeriod = SemesterPeriod(
-            startSemester = Semester.of(member.joinDate),
-            endSemester = Semester.previous(stateChangeDate)
+            startSemester = joinSemester,
+            endSemester = previousSemesterBeforeStateChange
         ),
-        expectedReturnSemester = Semester.next(stateChangeDate),
+        expectedReturnSemester = nextSemesterAfterStateChange,
         inactivePeriod = SemesterPeriod(
-            startSemester = Semester.of(stateChangeDate),
-            endSemester = Semester.of(stateChangeDate)
+            startSemester = stateChangeSemester,
+            endSemester = stateChangeSemester
         ),
     )
 
-    fun updateExpectedReturnSemester(expectedReturnSemester: Semester): InactiveMember {
+    fun updateExpectedReturnSemester(
+        expectedReturnSemester: Semester,
+        previousSemesterBeforeExpectedReturnSemester: Semester,
+    ): InactiveMember {
         return InactiveMember(
             id = id,
             member = member,
             activePeriod = activePeriod,
             expectedReturnSemester = expectedReturnSemester,
-            inactivePeriod = SemesterPeriod(inactivePeriod.startSemester, expectedReturnSemester.previousSemester()),
+            inactivePeriod = SemesterPeriod(inactivePeriod.startSemester, previousSemesterBeforeExpectedReturnSemester),
         )
     }
 

--- a/src/main/kotlin/com/yourssu/scouter/hrms/implement/domain/member/InactiveMember.kt
+++ b/src/main/kotlin/com/yourssu/scouter/hrms/implement/domain/member/InactiveMember.kt
@@ -1,6 +1,7 @@
 package com.yourssu.scouter.hrms.implement.domain.member
 
 import com.yourssu.scouter.common.implement.domain.semester.Semester
+import java.time.LocalDate
 
 class InactiveMember(
     val id: Long? = null,
@@ -9,6 +10,29 @@ class InactiveMember(
     val expectedReturnSemester: Semester,
     val inactivePeriod: SemesterPeriod,
 ) {
+
+    constructor(member: Member, stateChangeDate: LocalDate) : this(
+        member = member,
+        activePeriod = SemesterPeriod(
+            startSemester = Semester.of(member.joinDate),
+            endSemester = Semester.previous(stateChangeDate)
+        ),
+        expectedReturnSemester = Semester.next(stateChangeDate),
+        inactivePeriod = SemesterPeriod(
+            startSemester = Semester.of(stateChangeDate),
+            endSemester = Semester.of(stateChangeDate)
+        ),
+    )
+
+    fun updateExpectedReturnSemester(expectedReturnSemester: Semester): InactiveMember {
+        return InactiveMember(
+            id = id,
+            member = member,
+            activePeriod = activePeriod,
+            expectedReturnSemester = expectedReturnSemester,
+            inactivePeriod = SemesterPeriod(inactivePeriod.startSemester, expectedReturnSemester.previousSemester()),
+        )
+    }
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true

--- a/src/main/kotlin/com/yourssu/scouter/hrms/implement/domain/member/InactiveMemberRepository.kt
+++ b/src/main/kotlin/com/yourssu/scouter/hrms/implement/domain/member/InactiveMemberRepository.kt
@@ -2,6 +2,7 @@ package com.yourssu.scouter.hrms.implement.domain.member
 
 interface InactiveMemberRepository {
 
+    fun save(inactiveMember: InactiveMember): InactiveMember
     fun findAll(): List<InactiveMember>
     fun findAllByName(name: String): List<InactiveMember>
     fun findAllByNicknameKorean(nicknameKorean: String): List<InactiveMember>

--- a/src/main/kotlin/com/yourssu/scouter/hrms/implement/domain/member/InactiveMemberRepository.kt
+++ b/src/main/kotlin/com/yourssu/scouter/hrms/implement/domain/member/InactiveMemberRepository.kt
@@ -3,6 +3,7 @@ package com.yourssu.scouter.hrms.implement.domain.member
 interface InactiveMemberRepository {
 
     fun save(inactiveMember: InactiveMember): InactiveMember
+    fun findByMemberId(memberId: Long): InactiveMember?
     fun findAll(): List<InactiveMember>
     fun findAllByName(name: String): List<InactiveMember>
     fun findAllByNicknameKorean(nicknameKorean: String): List<InactiveMember>

--- a/src/main/kotlin/com/yourssu/scouter/hrms/implement/domain/member/InactiveMemberRepository.kt
+++ b/src/main/kotlin/com/yourssu/scouter/hrms/implement/domain/member/InactiveMemberRepository.kt
@@ -8,4 +8,5 @@ interface InactiveMemberRepository {
     fun findAllByName(name: String): List<InactiveMember>
     fun findAllByNicknameKorean(nicknameKorean: String): List<InactiveMember>
     fun findAllByNicknameEnglish(nicknameEnglish: String): List<InactiveMember>
+    fun deleteByMemberId(memberId: Long)
 }

--- a/src/main/kotlin/com/yourssu/scouter/hrms/implement/domain/member/MemberReader.kt
+++ b/src/main/kotlin/com/yourssu/scouter/hrms/implement/domain/member/MemberReader.kt
@@ -1,5 +1,6 @@
 package com.yourssu.scouter.hrms.implement.domain.member
 
+import com.yourssu.scouter.hrms.implement.support.exception.MemberNotFoundException
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
 
@@ -66,5 +67,10 @@ class MemberReader(
         ).flatten()
 
         return members.distinct()
+    }
+
+    fun readActiveByMemberId(memberId: Long): ActiveMember {
+        return activeMemberRepository.findByMemberId(memberId)
+            ?: throw MemberNotFoundException("해당하는 회원을 찾을 수 없습니다.")
     }
 }

--- a/src/main/kotlin/com/yourssu/scouter/hrms/implement/domain/member/MemberReader.kt
+++ b/src/main/kotlin/com/yourssu/scouter/hrms/implement/domain/member/MemberReader.kt
@@ -79,4 +79,9 @@ class MemberReader(
         return activeMemberRepository.findByMemberId(memberId)
             ?: throw MemberNotFoundException("해당하는 회원을 찾을 수 없습니다.")
     }
+
+    fun readInactiveByMemberId(memberId: Long): InactiveMember {
+        return inactiveMemberRepository.findByMemberId(memberId)
+            ?: throw MemberNotFoundException("해당하는 회원을 찾을 수 없습니다.")
+    }
 }

--- a/src/main/kotlin/com/yourssu/scouter/hrms/implement/domain/member/MemberReader.kt
+++ b/src/main/kotlin/com/yourssu/scouter/hrms/implement/domain/member/MemberReader.kt
@@ -84,4 +84,9 @@ class MemberReader(
         return inactiveMemberRepository.findByMemberId(memberId)
             ?: throw MemberNotFoundException("해당하는 회원을 찾을 수 없습니다.")
     }
+
+    fun readGraduatedByMemberId(memberId: Long): GraduatedMember {
+        return graduatedMemberRepository.findByMemberId(memberId)
+            ?: throw MemberNotFoundException("해당하는 회원을 찾을 수 없습니다.")
+    }
 }

--- a/src/main/kotlin/com/yourssu/scouter/hrms/implement/domain/member/MemberReader.kt
+++ b/src/main/kotlin/com/yourssu/scouter/hrms/implement/domain/member/MemberReader.kt
@@ -7,6 +7,7 @@ import org.springframework.transaction.annotation.Transactional
 @Component
 @Transactional(readOnly = true)
 class MemberReader(
+    private val memberRepository: MemberRepository,
     private val activeMemberRepository: ActiveMemberRepository,
     private val inactiveMemberRepository: InactiveMemberRepository,
     private val graduatedMemberRepository: GraduatedMemberRepository,
@@ -67,6 +68,11 @@ class MemberReader(
         ).flatten()
 
         return members.distinct()
+    }
+
+    fun readById(targetMemberId: Long): Member {
+        return memberRepository.findById(targetMemberId)
+            ?: throw MemberNotFoundException("해당하는 회원을 찾을 수 없습니다.")
     }
 
     fun readActiveByMemberId(memberId: Long): ActiveMember {

--- a/src/main/kotlin/com/yourssu/scouter/hrms/implement/domain/member/MemberReader.kt
+++ b/src/main/kotlin/com/yourssu/scouter/hrms/implement/domain/member/MemberReader.kt
@@ -72,21 +72,21 @@ class MemberReader(
 
     fun readById(targetMemberId: Long): Member {
         return memberRepository.findById(targetMemberId)
-            ?: throw MemberNotFoundException("해당하는 회원을 찾을 수 없습니다.")
+            ?: throw MemberNotFoundException("해당하는 멤버를 찾을 수 없습니다.")
     }
 
     fun readActiveByMemberId(memberId: Long): ActiveMember {
         return activeMemberRepository.findByMemberId(memberId)
-            ?: throw MemberNotFoundException("해당하는 회원을 찾을 수 없습니다.")
+            ?: throw MemberNotFoundException("해당하는 멤버를 찾을 수 없습니다.")
     }
 
     fun readInactiveByMemberId(memberId: Long): InactiveMember {
         return inactiveMemberRepository.findByMemberId(memberId)
-            ?: throw MemberNotFoundException("해당하는 회원을 찾을 수 없습니다.")
+            ?: throw MemberNotFoundException("해당하는 멤버를 찾을 수 없습니다.")
     }
 
     fun readGraduatedByMemberId(memberId: Long): GraduatedMember {
         return graduatedMemberRepository.findByMemberId(memberId)
-            ?: throw MemberNotFoundException("해당하는 회원을 찾을 수 없습니다.")
+            ?: throw MemberNotFoundException("해당하는 멤버를 찾을 수 없습니다.")
     }
 }

--- a/src/main/kotlin/com/yourssu/scouter/hrms/implement/domain/member/MemberRepository.kt
+++ b/src/main/kotlin/com/yourssu/scouter/hrms/implement/domain/member/MemberRepository.kt
@@ -3,4 +3,5 @@ package com.yourssu.scouter.hrms.implement.domain.member
 interface MemberRepository {
 
     fun save(member: Member): Member
+    fun findById(memberId: Long): Member?
 }

--- a/src/main/kotlin/com/yourssu/scouter/hrms/implement/domain/member/MemberWriter.kt
+++ b/src/main/kotlin/com/yourssu/scouter/hrms/implement/domain/member/MemberWriter.kt
@@ -1,5 +1,6 @@
 package com.yourssu.scouter.hrms.implement.domain.member
 
+import java.time.LocalDate
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
 
@@ -8,15 +9,70 @@ import org.springframework.transaction.annotation.Transactional
 class MemberWriter(
     private val memberRepository: MemberRepository,
     private val activeMemberRepository: ActiveMemberRepository,
+    private val inactiveMemberRepository: InactiveMemberRepository,
+    private val graduatedMemberRepository: GraduatedMemberRepository,
+    private val withdrawnMemberRepository: WithdrawnMemberRepository,
 ) {
 
-    fun writeMemberWithActiveStatus(member: Member, isMembershipFeePaid: Boolean): ActiveMember {
+    fun writeMemberWithActiveStatus(member: Member): ActiveMember {
         val savedMember: Member = memberRepository.save(member)
         val activeMember = ActiveMember(
             member = savedMember,
-            isMembershipFeePaid = isMembershipFeePaid
         )
 
         return activeMemberRepository.save(activeMember)
+    }
+
+    fun writeMemberWithInactiveState(member: Member, currentDate: LocalDate) {
+        val savedMember: Member = memberRepository.save(member)
+        val inactiveMember = InactiveMember(
+            member = savedMember,
+            stateChangeDate = currentDate,
+        )
+
+        inactiveMemberRepository.save(inactiveMember)
+    }
+
+    fun writeMemberWithGraduatedState(member: Member, currentDate: LocalDate) {
+        val savedMember: Member = memberRepository.save(member)
+        val graduatedMember = GraduatedMember(
+            member = savedMember,
+            stateChangeDate = currentDate,
+        )
+
+        graduatedMemberRepository.save(graduatedMember)
+    }
+
+    fun writeMemberWithWithdrawnState(updateMember: Member) {
+        val savedMember: Member = memberRepository.save(updateMember)
+        val withdrawnMember = WithdrawnMember(
+            member = savedMember,
+        )
+
+        withdrawnMemberRepository.save(withdrawnMember)
+    }
+
+    fun update(toUpdate: Member) {
+        memberRepository.save(toUpdate)
+    }
+
+    fun update(toUpdate: ActiveMember) {
+        memberRepository.save(toUpdate.member)
+        activeMemberRepository.save(toUpdate)
+    }
+
+    fun update(toUpdate: InactiveMember) {
+        memberRepository.save(toUpdate.member)
+        inactiveMemberRepository.save(toUpdate)
+    }
+
+    fun update(toUpdate: GraduatedMember) {
+        memberRepository.save(toUpdate.member)
+        graduatedMemberRepository.save(toUpdate)
+    }
+
+    fun update(toUpdate: WithdrawnMember) {
+        memberRepository.save(toUpdate.member)
+        withdrawnMemberRepository.save(toUpdate)
     }
 }

--- a/src/main/kotlin/com/yourssu/scouter/hrms/implement/domain/member/MemberWriter.kt
+++ b/src/main/kotlin/com/yourssu/scouter/hrms/implement/domain/member/MemberWriter.kt
@@ -96,4 +96,20 @@ class MemberWriter(
         memberRepository.save(toUpdate.member)
         withdrawnMemberRepository.save(toUpdate)
     }
+
+    fun deleteFromActiveMember(target: Member) {
+        activeMemberRepository.deleteByMemberId(target.id!!)
+    }
+
+    fun deleteFromInactiveMember(target: Member) {
+        inactiveMemberRepository.deleteByMemberId(target.id!!)
+    }
+
+    fun deleteFromGraduatedMember(target: Member) {
+        graduatedMemberRepository.deleteByMemberId(target.id!!)
+    }
+
+    fun deleteFromWithdrawnMember(target: Member) {
+        withdrawnMemberRepository.deleteByMemberId(target.id!!)
+    }
 }

--- a/src/main/kotlin/com/yourssu/scouter/hrms/implement/domain/member/WithdrawnMemberRepository.kt
+++ b/src/main/kotlin/com/yourssu/scouter/hrms/implement/domain/member/WithdrawnMemberRepository.kt
@@ -2,6 +2,7 @@ package com.yourssu.scouter.hrms.implement.domain.member
 
 interface WithdrawnMemberRepository {
 
+    fun save(withdrawnMember: WithdrawnMember): WithdrawnMember
     fun findAll(): List<WithdrawnMember>
     fun findAllByName(name: String): List<WithdrawnMember>
     fun findAllByNicknameKorean(nicknameKorean: String): List<WithdrawnMember>

--- a/src/main/kotlin/com/yourssu/scouter/hrms/implement/domain/member/WithdrawnMemberRepository.kt
+++ b/src/main/kotlin/com/yourssu/scouter/hrms/implement/domain/member/WithdrawnMemberRepository.kt
@@ -7,4 +7,5 @@ interface WithdrawnMemberRepository {
     fun findAllByName(name: String): List<WithdrawnMember>
     fun findAllByNicknameKorean(nicknameKorean: String): List<WithdrawnMember>
     fun findAllByNicknameEnglish(nicknameEnglish: String): List<WithdrawnMember>
+    fun deleteByMemberId(memberId: Long)
 }

--- a/src/main/kotlin/com/yourssu/scouter/hrms/storage/domain/member/ActiveMemberRepositoryImpl.kt
+++ b/src/main/kotlin/com/yourssu/scouter/hrms/storage/domain/member/ActiveMemberRepositoryImpl.kt
@@ -56,4 +56,8 @@ class ActiveMemberRepositoryImpl(
 
         return activeMemberEntities.map { fetchWithParts(it) }
     }
+
+    override fun deleteByMemberId(memberId: Long) {
+        jpaActiveMemberRepository.deleteByMemberId(memberId)
+    }
 }

--- a/src/main/kotlin/com/yourssu/scouter/hrms/storage/domain/member/ActiveMemberRepositoryImpl.kt
+++ b/src/main/kotlin/com/yourssu/scouter/hrms/storage/domain/member/ActiveMemberRepositoryImpl.kt
@@ -19,10 +19,10 @@ class ActiveMemberRepositoryImpl(
         return savedActiveMemberEntity.toDomain(activeMember.member)
     }
 
-    override fun findAll(): List<ActiveMember> {
-        val activeMemberEntities = jpaActiveMemberRepository.findAll()
+    override fun findByMemberId(memberId: Long): ActiveMember? {
+        val activeMemberEntity = jpaActiveMemberRepository.findByMemberId(memberId)
 
-        return activeMemberEntities.map { fetchWithParts(it) }
+        return activeMemberEntity?.let { fetchWithParts(it) }
     }
 
     private fun fetchWithParts(activeMemberEntity: ActiveMemberEntity): ActiveMember {
@@ -31,6 +31,12 @@ class ActiveMemberRepositoryImpl(
         val savedMember: Member = activeMemberEntity.member.toDomain(parts)
 
         return activeMemberEntity.toDomain(savedMember)
+    }
+
+    override fun findAll(): List<ActiveMember> {
+        val activeMemberEntities = jpaActiveMemberRepository.findAll()
+
+        return activeMemberEntities.map { fetchWithParts(it) }
     }
 
     override fun findAllByName(name: String): List<ActiveMember> {

--- a/src/main/kotlin/com/yourssu/scouter/hrms/storage/domain/member/GraduatedMemberRepositoryImpl.kt
+++ b/src/main/kotlin/com/yourssu/scouter/hrms/storage/domain/member/GraduatedMemberRepositoryImpl.kt
@@ -57,4 +57,8 @@ class GraduatedMemberRepositoryImpl(
 
         return graduatedMemberEntities.map { fetchWithParts(it) }
     }
+
+    override fun deleteByMemberId(memberId: Long) {
+        jpaGraduatedMemberRepository.deleteByMemberId(memberId)
+    }
 }

--- a/src/main/kotlin/com/yourssu/scouter/hrms/storage/domain/member/GraduatedMemberRepositoryImpl.kt
+++ b/src/main/kotlin/com/yourssu/scouter/hrms/storage/domain/member/GraduatedMemberRepositoryImpl.kt
@@ -12,6 +12,13 @@ class GraduatedMemberRepositoryImpl(
     private val jpaMemberPartRepository: JpaMemberPartRepository,
 ) : GraduatedMemberRepository {
 
+    override fun save(graduatedMember: GraduatedMember): GraduatedMember {
+        val savedGraduatedMemberEntity: GraduatedMemberEntity =
+            jpaGraduatedMemberRepository.save(GraduatedMemberEntity.from(graduatedMember))
+
+        return savedGraduatedMemberEntity.toDomain(graduatedMember.member)
+    }
+
     override fun findAll(): List<GraduatedMember> {
         val graduatedMemberEntities = jpaGraduatedMemberRepository.findAll()
 

--- a/src/main/kotlin/com/yourssu/scouter/hrms/storage/domain/member/GraduatedMemberRepositoryImpl.kt
+++ b/src/main/kotlin/com/yourssu/scouter/hrms/storage/domain/member/GraduatedMemberRepositoryImpl.kt
@@ -19,6 +19,12 @@ class GraduatedMemberRepositoryImpl(
         return savedGraduatedMemberEntity.toDomain(graduatedMember.member)
     }
 
+    override fun findByMemberId(memberId: Long): GraduatedMember? {
+        val graduatedMemberEntity = jpaGraduatedMemberRepository.findByMemberId(memberId)
+
+        return graduatedMemberEntity?.let { fetchWithParts(it) }
+    }
+
     override fun findAll(): List<GraduatedMember> {
         val graduatedMemberEntities = jpaGraduatedMemberRepository.findAll()
 

--- a/src/main/kotlin/com/yourssu/scouter/hrms/storage/domain/member/InactiveMemberRepositoryImpl.kt
+++ b/src/main/kotlin/com/yourssu/scouter/hrms/storage/domain/member/InactiveMemberRepositoryImpl.kt
@@ -56,4 +56,8 @@ class InactiveMemberRepositoryImpl(
 
         return inactiveMemberEntities.map { fetchWithParts(it) }
     }
+
+    override fun deleteByMemberId(memberId: Long) {
+        jpaInactiveMemberRepository.deleteByMemberId(memberId)
+    }
 }

--- a/src/main/kotlin/com/yourssu/scouter/hrms/storage/domain/member/InactiveMemberRepositoryImpl.kt
+++ b/src/main/kotlin/com/yourssu/scouter/hrms/storage/domain/member/InactiveMemberRepositoryImpl.kt
@@ -19,6 +19,12 @@ class InactiveMemberRepositoryImpl(
         return savedInactiveMemberEntity.toDomain(inactiveMember.member)
     }
 
+    override fun findByMemberId(memberId: Long): InactiveMember? {
+        val inactiveMemberEntity = jpaInactiveMemberRepository.findByMemberId(memberId)
+
+        return inactiveMemberEntity?.let { fetchWithParts(it) }
+    }
+
     override fun findAll(): List<InactiveMember> {
         val inactiveMemberEntities = jpaInactiveMemberRepository.findAll()
 

--- a/src/main/kotlin/com/yourssu/scouter/hrms/storage/domain/member/InactiveMemberRepositoryImpl.kt
+++ b/src/main/kotlin/com/yourssu/scouter/hrms/storage/domain/member/InactiveMemberRepositoryImpl.kt
@@ -12,6 +12,13 @@ class InactiveMemberRepositoryImpl(
     private val jpaMemberPartRepository: JpaMemberPartRepository,
 ) : InactiveMemberRepository {
 
+    override fun save(inactiveMember: InactiveMember): InactiveMember {
+        val savedInactiveMemberEntity: InactiveMemberEntity =
+            jpaInactiveMemberRepository.save(InactiveMemberEntity.from(inactiveMember))
+
+        return savedInactiveMemberEntity.toDomain(inactiveMember.member)
+    }
+
     override fun findAll(): List<InactiveMember> {
         val inactiveMemberEntities = jpaInactiveMemberRepository.findAll()
 

--- a/src/main/kotlin/com/yourssu/scouter/hrms/storage/domain/member/JpaActiveMemberRepository.kt
+++ b/src/main/kotlin/com/yourssu/scouter/hrms/storage/domain/member/JpaActiveMemberRepository.kt
@@ -13,15 +13,21 @@ interface JpaActiveMemberRepository : JpaRepository<ActiveMemberEntity, Long> {
     )
     fun findAllByName(name: String): List<ActiveMemberEntity>
 
-    @Query("""
+    @Query(
+        """
         SELECT am FROM ActiveMemberEntity am 
         WHERE am.member.nicknameKorean = :nicknameKorean
-    """)
+    """
+    )
     fun findAllByNicknameKoreanIgnoreCase(nicknameKorean: String): List<ActiveMemberEntity>
 
-    @Query("""
+    @Query(
+        """
         SELECT am FROM ActiveMemberEntity am 
         WHERE LOWER(am.member.nicknameEnglish) = LOWER(:nicknameEnglish)
-    """)
+    """
+    )
     fun findAllByNicknameEnglishIgnoreCase(nicknameEnglish: String): List<ActiveMemberEntity>
+
+    fun findByMemberId(memberId: Long): ActiveMemberEntity?
 }

--- a/src/main/kotlin/com/yourssu/scouter/hrms/storage/domain/member/JpaActiveMemberRepository.kt
+++ b/src/main/kotlin/com/yourssu/scouter/hrms/storage/domain/member/JpaActiveMemberRepository.kt
@@ -30,4 +30,6 @@ interface JpaActiveMemberRepository : JpaRepository<ActiveMemberEntity, Long> {
     fun findAllByNicknameEnglishIgnoreCase(nicknameEnglish: String): List<ActiveMemberEntity>
 
     fun findByMemberId(memberId: Long): ActiveMemberEntity?
+
+    fun deleteByMemberId(memberId: Long)
 }

--- a/src/main/kotlin/com/yourssu/scouter/hrms/storage/domain/member/JpaGraduatedMemberRepository.kt
+++ b/src/main/kotlin/com/yourssu/scouter/hrms/storage/domain/member/JpaGraduatedMemberRepository.kt
@@ -26,4 +26,6 @@ interface JpaGraduatedMemberRepository : JpaRepository<GraduatedMemberEntity, Lo
         WHERE LOWER(gm.member.nicknameEnglish) = LOWER(:nicknameEnglish)
     """)
     fun findAllByNicknameEnglishIgnoreCase(nicknameEnglish: String): List<GraduatedMemberEntity>
+
+    fun deleteByMemberId(memberId: Long)
 }

--- a/src/main/kotlin/com/yourssu/scouter/hrms/storage/domain/member/JpaGraduatedMemberRepository.kt
+++ b/src/main/kotlin/com/yourssu/scouter/hrms/storage/domain/member/JpaGraduatedMemberRepository.kt
@@ -5,6 +5,8 @@ import org.springframework.data.jpa.repository.Query
 
 interface JpaGraduatedMemberRepository : JpaRepository<GraduatedMemberEntity, Long> {
 
+    fun findByMemberId(memberId: Long): GraduatedMemberEntity?
+
     @Query(
         """
         SELECT gm FROM GraduatedMemberEntity gm 

--- a/src/main/kotlin/com/yourssu/scouter/hrms/storage/domain/member/JpaInactiveMemberRepository.kt
+++ b/src/main/kotlin/com/yourssu/scouter/hrms/storage/domain/member/JpaInactiveMemberRepository.kt
@@ -25,4 +25,6 @@ interface JpaInactiveMemberRepository : JpaRepository<InactiveMemberEntity, Long
         WHERE LOWER(im.member.nicknameEnglish) = LOWER(:nicknameEnglish)
     """)
     fun findAllByNicknameEnglishIgnoreCase(nicknameEnglish: String): List<InactiveMemberEntity>
+
+    fun deleteByMemberId(memberId: Long)
 }

--- a/src/main/kotlin/com/yourssu/scouter/hrms/storage/domain/member/JpaInactiveMemberRepository.kt
+++ b/src/main/kotlin/com/yourssu/scouter/hrms/storage/domain/member/JpaInactiveMemberRepository.kt
@@ -5,6 +5,8 @@ import org.springframework.data.jpa.repository.Query
 
 interface JpaInactiveMemberRepository : JpaRepository<InactiveMemberEntity, Long> {
 
+    fun findByMemberId(memberId: Long): InactiveMemberEntity?
+
     @Query(
         """
         SELECT im FROM InactiveMemberEntity im 
@@ -18,7 +20,6 @@ interface JpaInactiveMemberRepository : JpaRepository<InactiveMemberEntity, Long
         WHERE im.member.nicknameKorean = :nicknameKorean
     """)
     fun findAllByNicknameKoreanIgnoreCase(nicknameKorean: String): List<InactiveMemberEntity>
-
     @Query("""
         SELECT im FROM InactiveMemberEntity im 
         WHERE LOWER(im.member.nicknameEnglish) = LOWER(:nicknameEnglish)

--- a/src/main/kotlin/com/yourssu/scouter/hrms/storage/domain/member/JpaMemberPartRepository.kt
+++ b/src/main/kotlin/com/yourssu/scouter/hrms/storage/domain/member/JpaMemberPartRepository.kt
@@ -11,4 +11,6 @@ interface JpaMemberPartRepository : JpaRepository<MemberPartEntity, Long> {
         WHERE mp.member.id = :memberId
     """)
     fun findAllPartsByMemberId(memberId: Long): List<PartEntity>
+
+    fun deleteAllByMemberId(id: Long)
 }

--- a/src/main/kotlin/com/yourssu/scouter/hrms/storage/domain/member/JpaWithdrawnMemberRepository.kt
+++ b/src/main/kotlin/com/yourssu/scouter/hrms/storage/domain/member/JpaWithdrawnMemberRepository.kt
@@ -24,4 +24,6 @@ interface JpaWithdrawnMemberRepository : JpaRepository<WithdrawnMemberEntity, Lo
         WHERE LOWER(wm.member.nicknameEnglish) = LOWER(:nicknameEnglish)
     """)
     fun findAllByNicknameEnglishIgnoreCase(nicknameEnglish: String): List<WithdrawnMemberEntity>
+
+    fun deleteByMemberId(memberId: Long)
 }

--- a/src/main/kotlin/com/yourssu/scouter/hrms/storage/domain/member/MemberRepositoryImpl.kt
+++ b/src/main/kotlin/com/yourssu/scouter/hrms/storage/domain/member/MemberRepositoryImpl.kt
@@ -1,5 +1,6 @@
 package com.yourssu.scouter.hrms.storage.domain.member
 
+import com.yourssu.scouter.common.implement.domain.part.Part
 import com.yourssu.scouter.common.storage.domain.part.PartEntity
 import com.yourssu.scouter.hrms.implement.domain.member.Member
 import com.yourssu.scouter.hrms.implement.domain.member.MemberRepository
@@ -23,5 +24,18 @@ class MemberRepositoryImpl(
         jpaMemberPartRepository.saveAll(memberPartEntities)
 
         return savedMemberEntity.toDomain(member.parts)
+    }
+
+    override fun findById(memberId: Long): Member? {
+        val memberEntity: MemberEntity? = jpaMemberRepository.findById(memberId).orElse(null)
+
+        return memberEntity?.let { fetchWithParts(it) }
+    }
+
+    private fun fetchWithParts(memberEntity: MemberEntity): Member {
+        val partEntities = jpaMemberPartRepository.findAllPartsByMemberId(memberEntity.id!!)
+        val parts: List<Part> = partEntities.map { it.toDomain() }
+
+        return memberEntity.toDomain(parts)
     }
 }

--- a/src/main/kotlin/com/yourssu/scouter/hrms/storage/domain/member/MemberRepositoryImpl.kt
+++ b/src/main/kotlin/com/yourssu/scouter/hrms/storage/domain/member/MemberRepositoryImpl.kt
@@ -15,6 +15,8 @@ class MemberRepositoryImpl(
     override fun save(member: Member): Member {
         val savedMemberEntity: MemberEntity =
             jpaMemberRepository.save(MemberEntity.from(member))
+
+        jpaMemberPartRepository.deleteAllByMemberId(savedMemberEntity.id!!)
         val memberPartEntities = member.parts.map {
             MemberPartEntity(
                 member = savedMemberEntity,

--- a/src/main/kotlin/com/yourssu/scouter/hrms/storage/domain/member/WithdrawnMemberRepositoryImpl.kt
+++ b/src/main/kotlin/com/yourssu/scouter/hrms/storage/domain/member/WithdrawnMemberRepositoryImpl.kt
@@ -50,4 +50,8 @@ class WithdrawnMemberRepositoryImpl(
 
         return withdrawnMemberEntities.map { fetchWithParts(it) }
     }
+
+    override fun deleteByMemberId(memberId: Long) {
+        jpaWithdrawnMemberRepository.deleteByMemberId(memberId)
+    }
 }

--- a/src/main/kotlin/com/yourssu/scouter/hrms/storage/domain/member/WithdrawnMemberRepositoryImpl.kt
+++ b/src/main/kotlin/com/yourssu/scouter/hrms/storage/domain/member/WithdrawnMemberRepositoryImpl.kt
@@ -12,6 +12,13 @@ class WithdrawnMemberRepositoryImpl(
     private val jpaMemberPartRepository: JpaMemberPartRepository,
 ) : WithdrawnMemberRepository {
 
+    override fun save(withdrawnMember: WithdrawnMember): WithdrawnMember {
+        val savedWithdrawnMemberEntity: WithdrawnMemberEntity =
+            jpaWithdrawnMemberRepository.save(WithdrawnMemberEntity.from(withdrawnMember))
+
+        return savedWithdrawnMemberEntity.toDomain(withdrawnMember.member)
+    }
+
     override fun findAll(): List<WithdrawnMember> {
         val withdrawnMemberEntities = jpaWithdrawnMemberRepository.findAll()
 


### PR DESCRIPTION
## 📄 작업 내용 요약
멤버 수정 api 추가
- 비액티브/졸업/탈퇴로 넘어오는 순간 역할은 무조건 Member로 통일
- 활동기간, 비액티브 기간은 수정 불가 레이블(가입일과 비액티브 전환일, 복귀희망 학기로 결정됨) 
- 비액티브로 상태 변경 시, 복귀희망학기는 바로 다음 학기로 설정이 디폴트
- Lead/Vice Lead로 상태가 변경된 사람은 해당 학기와 함께 `00-0학기 00파트 리드 역임`이라고 비고란에 자동 추가

## 📎 Issue 번호
- closed #35 
