### PR TITLE
feat: #47 지원자 도메인, 엔티티에 재학학기 필드 추가

### DIFF
--- a/src/main/kotlin/com/yourssu/scouter/ats/application/domain/applicant/CreateApplicantRequest.kt
+++ b/src/main/kotlin/com/yourssu/scouter/ats/application/domain/applicant/CreateApplicantRequest.kt
@@ -45,6 +45,13 @@ data class CreateApplicantRequest(
 
     @field:NotBlank(message = "나이를 입력하지 않았습니다.")
     val age: String,
+
+    @field:NotBlank(message = "재학 학기를 입력하지 않았습니다.")
+    @field:Pattern(
+        regexp = "^\\d-\\d\$",
+        message = "재학 학기는 \\{ 학년-학기 \\} 형식이어야 합니다"
+    )
+    val academicSemester: String,
 ) {
 
     fun toCommand(): CreateApplicantCommand = CreateApplicantCommand(
@@ -58,5 +65,6 @@ data class CreateApplicantRequest(
         studentId = studentId,
         applicantSemesterId = semesterId,
         age = age,
+        academicSemester = academicSemester,
     )
 }

--- a/src/main/kotlin/com/yourssu/scouter/ats/application/domain/applicant/ReadApplicantResponse.kt
+++ b/src/main/kotlin/com/yourssu/scouter/ats/application/domain/applicant/ReadApplicantResponse.kt
@@ -3,7 +3,6 @@ package com.yourssu.scouter.ats.application.domain.applicant
 import com.fasterxml.jackson.annotation.JsonFormat
 import com.yourssu.scouter.ats.business.domain.applicant.ApplicantDto
 import com.yourssu.scouter.ats.business.support.utils.ApplicantStateConverter
-import com.yourssu.scouter.common.business.support.utils.SemesterConverter
 import java.time.LocalDate
 
 data class ReadApplicantResponse(
@@ -46,7 +45,7 @@ data class ReadApplicantResponse(
             phoneNumber = applicantDto.phoneNumber,
             department = applicantDto.department.name,
             studentId = applicantDto.studentId,
-            semester = SemesterConverter.convertToIntString(applicantDto.applicationSemester),
+            semester = applicantDto.academicSemester,
             age = applicantDto.age,
         )
     }

--- a/src/main/kotlin/com/yourssu/scouter/ats/application/domain/applicant/UpdateApplicantRequest.kt
+++ b/src/main/kotlin/com/yourssu/scouter/ats/application/domain/applicant/UpdateApplicantRequest.kt
@@ -32,6 +32,12 @@ data class UpdateApplicantRequest(
     val semesterId: Long? = null,
 
     val age: String? = null,
+
+    @field:Pattern(
+        regexp = "^\\d-\\d\$",
+        message = "재학 학기는 \\{ 학년-학기 \\} 형식이어야 합니다"
+    )
+    val academicSemester: String? = null,
 ) {
 
     fun toCommand(applicantId: Long): UpdateApplicantCommand = UpdateApplicantCommand(
@@ -46,5 +52,6 @@ data class UpdateApplicantRequest(
         studentId = studentId,
         applicantSemesterId = semesterId,
         age = age,
+        academicSemester = academicSemester,
     )
 }

--- a/src/main/kotlin/com/yourssu/scouter/ats/business/domain/applicant/ApplicantDto.kt
+++ b/src/main/kotlin/com/yourssu/scouter/ats/business/domain/applicant/ApplicantDto.kt
@@ -19,6 +19,7 @@ data class ApplicantDto(
     val state: ApplicantState,
     val applicationDate: LocalDate,
     val applicationSemester: SemesterDto,
+    val academicSemester: String,
 ) {
 
     companion object {
@@ -34,6 +35,7 @@ data class ApplicantDto(
             state = applicant.state,
             applicationDate = applicant.applicationDate,
             applicationSemester = SemesterDto.from(applicant.applicationSemester),
+            academicSemester = applicant.academicSemester,
         )
     }
 }

--- a/src/main/kotlin/com/yourssu/scouter/ats/business/domain/applicant/ApplicantService.kt
+++ b/src/main/kotlin/com/yourssu/scouter/ats/business/domain/applicant/ApplicantService.kt
@@ -78,7 +78,9 @@ class ApplicantService(
             part = command.partId?.let { partReader.readById(it) } ?: target.part,
             state = command.state ?: target.state,
             applicationDate = command.applicationDate ?: target.applicationDate,
-            applicationSemester = command.applicantSemesterId?.let { semesterReader.readById(it) } ?: target.applicationSemester,
+            applicationSemester = command.applicantSemesterId?.let { semesterReader.readById(it) }
+                ?: target.applicationSemester,
+            academicSemester = command.academicSemester ?: target.academicSemester,
         )
 
         applicantWriter.write(updated)

--- a/src/main/kotlin/com/yourssu/scouter/ats/business/domain/applicant/CreateApplicantCommand.kt
+++ b/src/main/kotlin/com/yourssu/scouter/ats/business/domain/applicant/CreateApplicantCommand.kt
@@ -18,6 +18,7 @@ data class CreateApplicantCommand(
     val state: ApplicantState,
     val applicationDate: LocalDate,
     val applicantSemesterId: Long,
+    val academicSemester: String,
 ) {
 
     fun toDomain(
@@ -35,5 +36,6 @@ data class CreateApplicantCommand(
         state = state,
         applicationDate = applicationDate,
         applicationSemester = applicantSemester,
+        academicSemester = academicSemester,
     )
 }

--- a/src/main/kotlin/com/yourssu/scouter/ats/business/domain/applicant/UpdateApplicantCommand.kt
+++ b/src/main/kotlin/com/yourssu/scouter/ats/business/domain/applicant/UpdateApplicantCommand.kt
@@ -15,4 +15,5 @@ data class UpdateApplicantCommand(
     val state: ApplicantState? = null,
     val applicationDate: LocalDate? = null,
     val applicantSemesterId: Long? = null,
+    val academicSemester: String? = null,
 )

--- a/src/main/kotlin/com/yourssu/scouter/ats/implement/domain/applicant/Applicant.kt
+++ b/src/main/kotlin/com/yourssu/scouter/ats/implement/domain/applicant/Applicant.kt
@@ -18,6 +18,7 @@ class Applicant(
     val state: ApplicantState,
     val applicationDate: LocalDate,
     val applicationSemester: Semester,
+    val academicSemester: String,
 ) {
 
     override fun equals(other: Any?): Boolean {
@@ -34,6 +35,6 @@ class Applicant(
     }
 
     override fun toString(): String {
-        return "Applicant(id=$id, name='$name', email='$email', phoneNumber='$phoneNumber', age='$age', department=$department, studentId='$studentId', part=$part, state=$state, applicationDate=$applicationDate, applicationSemester=$applicationSemester)"
+        return "Applicant(id=$id, name='$name', email='$email', phoneNumber='$phoneNumber', age='$age', department=$department, studentId='$studentId', part=$part, state=$state, applicationDate=$applicationDate, applicationSemester=$applicationSemester, academicSemester='$academicSemester')"
     }
 }

--- a/src/main/kotlin/com/yourssu/scouter/ats/storage/domain/applicant/ApplicantEntity.kt
+++ b/src/main/kotlin/com/yourssu/scouter/ats/storage/domain/applicant/ApplicantEntity.kt
@@ -60,6 +60,9 @@ class ApplicantEntity(
     @ManyToOne(fetch = FetchType.EAGER)
     @JoinColumn(name = "semester_id", nullable = false, foreignKey = ForeignKey(name = "fk_applicant_semester"))
     val applicationSemester: SemesterEntity,
+
+    @Column(nullable = false)
+    val academicSemester: String,
 ) {
 
     companion object {
@@ -75,6 +78,7 @@ class ApplicantEntity(
             state = applicant.state,
             applicationDate = applicant.applicationDate,
             applicationSemester = SemesterEntity.from(applicant.applicationSemester),
+            academicSemester = applicant.academicSemester,
         )
     }
 
@@ -90,6 +94,7 @@ class ApplicantEntity(
         state = state,
         applicationDate = applicationDate,
         applicationSemester = applicationSemester.toDomain(),
+        academicSemester = academicSemester,
     )
 
     override fun equals(other: Any?): Boolean {


### PR DESCRIPTION
## 📄 작업 내용 요약
- 지원자 도메인 엔티티에 재학학기 필드 추가 (누락됨)
- 지원자 목록 조회 시 지원 학기가 아니라 재학 학기를 응답하도록 수정

## 📎 Issue 번호
- closed #47 
