### PR TITLE
feat: #50 구글폼 응답에서 지원자 정보 불러오는 기능 추가

### DIFF
--- a/src/main/kotlin/com/yourssu/scouter/ats/application/domain/applicant/ReadApplicantResponse.kt
+++ b/src/main/kotlin/com/yourssu/scouter/ats/application/domain/applicant/ReadApplicantResponse.kt
@@ -43,7 +43,7 @@ data class ReadApplicantResponse(
             applicationDate = applicantDto.applicationDate,
             email = applicantDto.email,
             phoneNumber = applicantDto.phoneNumber,
-            department = applicantDto.department.name,
+            department = applicantDto.department,
             studentId = applicantDto.studentId,
             semester = applicantDto.academicSemester,
             age = applicantDto.age,

--- a/src/main/kotlin/com/yourssu/scouter/ats/application/domain/applicant/ReadApplicantResponse.kt
+++ b/src/main/kotlin/com/yourssu/scouter/ats/application/domain/applicant/ReadApplicantResponse.kt
@@ -40,7 +40,7 @@ data class ReadApplicantResponse(
             part = applicantDto.part.name,
             name = applicantDto.name,
             state = ApplicantStateConverter.convertToString(applicantDto.state),
-            applicationDate = applicantDto.applicationDate,
+            applicationDate = applicantDto.applicationDateTime.toLocalDate(),
             email = applicantDto.email,
             phoneNumber = applicantDto.phoneNumber,
             department = applicantDto.department,

--- a/src/main/kotlin/com/yourssu/scouter/ats/business/domain/applicant/ApplicantDto.kt
+++ b/src/main/kotlin/com/yourssu/scouter/ats/business/domain/applicant/ApplicantDto.kt
@@ -4,7 +4,7 @@ import com.yourssu.scouter.ats.implement.domain.applicant.Applicant
 import com.yourssu.scouter.ats.implement.domain.applicant.ApplicantState
 import com.yourssu.scouter.common.business.domain.part.PartDto
 import com.yourssu.scouter.common.business.domain.semester.SemesterDto
-import java.time.LocalDate
+import java.time.LocalDateTime
 
 data class ApplicantDto(
     val id: Long,
@@ -16,7 +16,7 @@ data class ApplicantDto(
     val studentId: String,
     val part: PartDto,
     val state: ApplicantState,
-    val applicationDate: LocalDate,
+    val applicationDateTime: LocalDateTime,
     val applicationSemester: SemesterDto,
     val academicSemester: String,
 ) {
@@ -32,7 +32,7 @@ data class ApplicantDto(
             studentId = applicant.studentId,
             part = PartDto.from(applicant.part),
             state = applicant.state,
-            applicationDate = applicant.applicationDate,
+            applicationDateTime = applicant.applicationDateTime,
             applicationSemester = SemesterDto.from(applicant.applicationSemester),
             academicSemester = applicant.academicSemester,
         )

--- a/src/main/kotlin/com/yourssu/scouter/ats/business/domain/applicant/ApplicantDto.kt
+++ b/src/main/kotlin/com/yourssu/scouter/ats/business/domain/applicant/ApplicantDto.kt
@@ -2,7 +2,6 @@ package com.yourssu.scouter.ats.business.domain.applicant
 
 import com.yourssu.scouter.ats.implement.domain.applicant.Applicant
 import com.yourssu.scouter.ats.implement.domain.applicant.ApplicantState
-import com.yourssu.scouter.common.business.domain.department.DepartmentDto
 import com.yourssu.scouter.common.business.domain.part.PartDto
 import com.yourssu.scouter.common.business.domain.semester.SemesterDto
 import java.time.LocalDate
@@ -13,7 +12,7 @@ data class ApplicantDto(
     val email: String,
     val phoneNumber: String,
     val age: String,
-    val department: DepartmentDto,
+    val department: String,
     val studentId: String,
     val part: PartDto,
     val state: ApplicantState,
@@ -29,7 +28,7 @@ data class ApplicantDto(
             email = applicant.email,
             phoneNumber = applicant.phoneNumber,
             age = applicant.age,
-            department = DepartmentDto.from(applicant.department),
+            department = applicant.department,
             studentId = applicant.studentId,
             part = PartDto.from(applicant.part),
             state = applicant.state,

--- a/src/main/kotlin/com/yourssu/scouter/ats/business/domain/applicant/ApplicantService.kt
+++ b/src/main/kotlin/com/yourssu/scouter/ats/business/domain/applicant/ApplicantService.kt
@@ -73,7 +73,7 @@ class ApplicantService(
             email = command.email ?: target.email,
             phoneNumber = command.phoneNumber ?: target.phoneNumber,
             age = command.age ?: target.age,
-            department = command.departmentId?.let { departmentReader.readById(it) } ?: target.department,
+            department = command.departmentId?.let { departmentReader.readById(it).name } ?: target.department,
             studentId = command.studentId ?: target.studentId,
             part = command.partId?.let { partReader.readById(it) } ?: target.part,
             state = command.state ?: target.state,

--- a/src/main/kotlin/com/yourssu/scouter/ats/business/domain/applicant/ApplicantService.kt
+++ b/src/main/kotlin/com/yourssu/scouter/ats/business/domain/applicant/ApplicantService.kt
@@ -77,7 +77,7 @@ class ApplicantService(
             studentId = command.studentId ?: target.studentId,
             part = command.partId?.let { partReader.readById(it) } ?: target.part,
             state = command.state ?: target.state,
-            applicationDate = command.applicationDate ?: target.applicationDate,
+            applicationDateTime = command.applicationDate?.atStartOfDay() ?: target.applicationDateTime,
             applicationSemester = command.applicantSemesterId?.let { semesterReader.readById(it) }
                 ?: target.applicationSemester,
             academicSemester = command.academicSemester ?: target.academicSemester,

--- a/src/main/kotlin/com/yourssu/scouter/ats/business/domain/applicant/ApplicantSyncResult.kt
+++ b/src/main/kotlin/com/yourssu/scouter/ats/business/domain/applicant/ApplicantSyncResult.kt
@@ -1,0 +1,23 @@
+package com.yourssu.scouter.ats.business.domain.applicant
+
+import com.yourssu.scouter.common.implement.support.google.GoogleDriveFile
+
+data class ApplicantSyncResult(
+    val successes: List<FormDto>,
+    val failures: List<FormDto>,
+)
+
+data class FormDto(
+    val id: String,
+    val name: String,
+    val webViewLink: String,
+) {
+
+    companion object {
+        fun from(form: GoogleDriveFile): FormDto = FormDto(
+            id = form.id,
+            name = form.name,
+            webViewLink = form.webViewLink,
+        )
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/ats/business/domain/applicant/ApplicantSyncService.kt
+++ b/src/main/kotlin/com/yourssu/scouter/ats/business/domain/applicant/ApplicantSyncService.kt
@@ -20,7 +20,6 @@ import com.yourssu.scouter.common.implement.support.google.GoogleFormsReader
 import com.yourssu.scouter.common.implement.support.google.UserResponse
 import com.yourssu.scouter.common.implement.support.security.oauth2.GoogleOAuth2Handler
 import java.time.LocalDate
-import java.time.LocalDateTime
 import org.springframework.stereotype.Service
 
 @Service
@@ -103,14 +102,14 @@ class ApplicantSyncService(
 
         return Applicant(
             name = responseMap["이름"] ?: "",
-            email = responseMap["이메일"] ?: responseMap["email"] ?: "",
+            email = userResponse.respondentEmail,
             phoneNumber = responseMap["연락처"] ?: "",
             age = responseMap["나이"] ?: "",
             department = responseMap["학과(부)"] ?: "",
             studentId = responseMap["학번"] ?: "",
             part = part,
             state = ApplicantState.UNDER_REVIEW,
-            applicationDateTime = LocalDateTime.parse(userResponse.createTime),
+            applicationDateTime = userResponse.createTime,
             applicationSemester = applicationSemester,
             academicSemester = responseMap.entries.firstOrNull { it.key.contains("재학중인학기") }?.value ?: ""
         )

--- a/src/main/kotlin/com/yourssu/scouter/ats/business/domain/applicant/ApplicantSyncService.kt
+++ b/src/main/kotlin/com/yourssu/scouter/ats/business/domain/applicant/ApplicantSyncService.kt
@@ -1,0 +1,131 @@
+package com.yourssu.scouter.ats.business.domain.applicant
+
+import com.yourssu.scouter.ats.implement.domain.applicant.Applicant
+import com.yourssu.scouter.ats.implement.domain.applicant.ApplicantState
+import com.yourssu.scouter.ats.implement.domain.applicant.ApplicantWriter
+import com.yourssu.scouter.common.business.support.utils.SemesterConverter
+import com.yourssu.scouter.common.implement.domain.authentication.OAuth2TokenInfo
+import com.yourssu.scouter.common.implement.domain.part.Part
+import com.yourssu.scouter.common.implement.domain.part.PartReader
+import com.yourssu.scouter.common.implement.domain.semester.Semester
+import com.yourssu.scouter.common.implement.domain.semester.SemesterReader
+import com.yourssu.scouter.common.implement.domain.user.User
+import com.yourssu.scouter.common.implement.domain.user.UserReader
+import com.yourssu.scouter.common.implement.domain.user.UserWriter
+import com.yourssu.scouter.common.implement.support.google.GoogleDriveFile
+import com.yourssu.scouter.common.implement.support.google.GoogleDriveMimeType
+import com.yourssu.scouter.common.implement.support.google.GoogleDriveQueryBuilder
+import com.yourssu.scouter.common.implement.support.google.GoogleDriveReader
+import com.yourssu.scouter.common.implement.support.google.GoogleFormsReader
+import com.yourssu.scouter.common.implement.support.google.UserResponse
+import com.yourssu.scouter.common.implement.support.security.oauth2.GoogleOAuth2Handler
+import java.time.LocalDate
+import java.time.LocalDateTime
+import org.springframework.stereotype.Service
+
+@Service
+class ApplicantSyncService(
+    private val userReader: UserReader,
+    private val userWriter: UserWriter,
+    private val applicantWriter: ApplicantWriter,
+    private val partReader: PartReader,
+    private val semesterReader: SemesterReader,
+    private val googleOAuth2Handler: GoogleOAuth2Handler,
+    private val googleDriveReader: GoogleDriveReader,
+    private val googleFormsReader: GoogleFormsReader,
+) {
+
+    fun includeApplicantsFromForms(
+        authUserId: Long,
+        targetSemester: String? = null,
+    ): ApplicantSyncResult {
+        val authUser: User = getAuthUserWithValidToken(authUserId)
+        val googleAccessToken: String = authUser.getBearerAccessToken()
+        val applicationSemesterString = targetSemester ?: SemesterConverter.convertToIntString(LocalDate.now())
+        val query: String = GoogleDriveQueryBuilder()
+            .nameContainsAll("유어슈", "지원서", applicationSemesterString)
+            .mimeType(GoogleDriveMimeType.FORM)
+            .build()
+
+        val forms: List<GoogleDriveFile> = googleDriveReader.getFiles(googleAccessToken, query)
+        val parts: List<Part> = partReader.readAll()
+        val applicationSemester: Semester = semesterReader.readByString(applicationSemesterString)
+
+        val successes = mutableListOf<GoogleDriveFile>()
+        val failures = mutableListOf<GoogleDriveFile>()
+
+        val applicants: List<Applicant> = forms.mapNotNull { form ->
+            extractApplicantsFromForm(form, googleAccessToken, parts, applicationSemester)?.also {
+                successes.add(form)
+            } ?: run {
+                failures.add(form)
+                null
+            }
+        }.flatten()
+
+        applicantWriter.writeAll(applicants)
+
+        return ApplicantSyncResult(
+            successes = successes.map { FormDto.from(it) },
+            failures = failures.map { FormDto.from(it) },
+        )
+    }
+
+    private fun extractApplicantsFromForm(
+        form: GoogleDriveFile,
+        googleAccessToken: String,
+        parts: List<Part>,
+        applicationSemester: Semester
+    ): List<Applicant>? {
+        val userResponses: List<UserResponse> = googleFormsReader.getUserResponses(googleAccessToken, form.id)
+        if (userResponses.isEmpty()) {
+            return null
+        }
+
+        val part: Part? = parts.find { normalizeString(form.name).contains(normalizeString(it.name)) }
+        if (part == null) {
+            return null
+        }
+
+        return userResponses.map { userResponse ->
+            mapResponseToApplicant(userResponse, part, applicationSemester)
+        }
+    }
+
+    private fun normalizeString(value: String): String = value.replace(" ", "").lowercase()
+
+    private fun mapResponseToApplicant(
+        userResponse: UserResponse,
+        part: Part,
+        applicationSemester: Semester
+    ): Applicant {
+        val responseMap = userResponse.responseItems.associate { normalizeString(it.question) to it.answer }
+
+        return Applicant(
+            name = responseMap["이름"] ?: "",
+            email = responseMap["이메일"] ?: responseMap["email"] ?: "",
+            phoneNumber = responseMap["연락처"] ?: "",
+            age = responseMap["나이"] ?: "",
+            department = responseMap["학과(부)"] ?: "",
+            studentId = responseMap["학번"] ?: "",
+            part = part,
+            state = ApplicantState.UNDER_REVIEW,
+            applicationDateTime = LocalDateTime.parse(userResponse.createTime),
+            applicationSemester = applicationSemester,
+            academicSemester = responseMap.entries.firstOrNull { it.key.contains("재학중인학기") }?.value ?: ""
+        )
+    }
+
+    private fun getAuthUserWithValidToken(authUserId: Long): User {
+        val authUser: User = userReader.readById(authUserId)
+        if (authUser.isAccessTokenRemainMoreThan(10)) {
+            return authUser
+        }
+
+        val newAccessTokenInfo: OAuth2TokenInfo =
+            googleOAuth2Handler.refreshAccessToken(authUser.getBearerRefreshToken())
+        authUser.updateToken(newAccessTokenInfo.accessToken, newAccessTokenInfo.expiresIn)
+
+        return userWriter.write(authUser)
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/ats/business/domain/applicant/CreateApplicantCommand.kt
+++ b/src/main/kotlin/com/yourssu/scouter/ats/business/domain/applicant/CreateApplicantCommand.kt
@@ -30,7 +30,7 @@ data class CreateApplicantCommand(
         email = email,
         phoneNumber = phoneNumber,
         age = age,
-        department = department,
+        department = department.name,
         studentId = studentId,
         part = part,
         state = state,

--- a/src/main/kotlin/com/yourssu/scouter/ats/business/domain/applicant/CreateApplicantCommand.kt
+++ b/src/main/kotlin/com/yourssu/scouter/ats/business/domain/applicant/CreateApplicantCommand.kt
@@ -34,7 +34,7 @@ data class CreateApplicantCommand(
         studentId = studentId,
         part = part,
         state = state,
-        applicationDate = applicationDate,
+        applicationDateTime = applicationDate.atStartOfDay(),
         applicationSemester = applicantSemester,
         academicSemester = academicSemester,
     )

--- a/src/main/kotlin/com/yourssu/scouter/ats/implement/domain/applicant/Applicant.kt
+++ b/src/main/kotlin/com/yourssu/scouter/ats/implement/domain/applicant/Applicant.kt
@@ -3,7 +3,7 @@ package com.yourssu.scouter.ats.implement.domain.applicant
 import com.yourssu.scouter.common.implement.domain.part.Part
 import com.yourssu.scouter.common.implement.domain.semester.Semester
 import com.yourssu.scouter.hrms.implement.domain.member.Member
-import java.time.LocalDate
+import java.time.LocalDateTime
 
 class Applicant(
     val id: Long? = null,
@@ -15,7 +15,7 @@ class Applicant(
     val studentId: String,
     val part: Part,
     val state: ApplicantState,
-    val applicationDate: LocalDate,
+    val applicationDateTime: LocalDateTime,
     val applicationSemester: Semester,
     val academicSemester: String,
 ) {
@@ -34,6 +34,6 @@ class Applicant(
     }
 
     override fun toString(): String {
-        return "Applicant(id=$id, name='$name', email='$email', phoneNumber='$phoneNumber', age='$age', department=$department, studentId='$studentId', part=$part, state=$state, applicationDate=$applicationDate, applicationSemester=$applicationSemester, academicSemester='$academicSemester')"
+        return "Applicant(id=$id, name='$name', email='$email', phoneNumber='$phoneNumber', age='$age', department=$department, studentId='$studentId', part=$part, state=$state, applicationDate=$applicationDateTime, applicationSemester=$applicationSemester, academicSemester='$academicSemester')"
     }
 }

--- a/src/main/kotlin/com/yourssu/scouter/ats/implement/domain/applicant/Applicant.kt
+++ b/src/main/kotlin/com/yourssu/scouter/ats/implement/domain/applicant/Applicant.kt
@@ -1,6 +1,5 @@
 package com.yourssu.scouter.ats.implement.domain.applicant
 
-import com.yourssu.scouter.common.implement.domain.department.Department
 import com.yourssu.scouter.common.implement.domain.part.Part
 import com.yourssu.scouter.common.implement.domain.semester.Semester
 import com.yourssu.scouter.hrms.implement.domain.member.Member
@@ -12,7 +11,7 @@ class Applicant(
     val email: String,
     val phoneNumber: String,
     val age: String,
-    val department: Department,
+    val department: String,
     val studentId: String,
     val part: Part,
     val state: ApplicantState,

--- a/src/main/kotlin/com/yourssu/scouter/ats/implement/domain/applicant/ApplicantRepository.kt
+++ b/src/main/kotlin/com/yourssu/scouter/ats/implement/domain/applicant/ApplicantRepository.kt
@@ -3,6 +3,7 @@ package com.yourssu.scouter.ats.implement.domain.applicant
 interface ApplicantRepository {
 
     fun save(applicant: Applicant): Applicant
+    fun saveAll(applicants: List<Applicant>)
     fun findById(applicantId: Long): Applicant?
     fun findAll(): List<Applicant>
     fun findAllByName(name: String): List<Applicant>

--- a/src/main/kotlin/com/yourssu/scouter/ats/implement/domain/applicant/ApplicantWriter.kt
+++ b/src/main/kotlin/com/yourssu/scouter/ats/implement/domain/applicant/ApplicantWriter.kt
@@ -13,6 +13,10 @@ class ApplicantWriter(
         return applicantRepository.save(applicant)
     }
 
+    fun writeAll(applicants: List<Applicant>) {
+        applicantRepository.saveAll(applicants)
+    }
+
     fun delete(applicant: Applicant) {
         applicantRepository.deleteById(applicant.id!!)
     }

--- a/src/main/kotlin/com/yourssu/scouter/ats/storage/domain/applicant/ApplicantEntity.kt
+++ b/src/main/kotlin/com/yourssu/scouter/ats/storage/domain/applicant/ApplicantEntity.kt
@@ -2,7 +2,6 @@ package com.yourssu.scouter.ats.storage.domain.applicant
 
 import com.yourssu.scouter.ats.implement.domain.applicant.Applicant
 import com.yourssu.scouter.ats.implement.domain.applicant.ApplicantState
-import com.yourssu.scouter.common.storage.domain.department.DepartmentEntity
 import com.yourssu.scouter.common.storage.domain.part.PartEntity
 import com.yourssu.scouter.common.storage.domain.semester.SemesterEntity
 import jakarta.persistence.Column
@@ -39,9 +38,8 @@ class ApplicantEntity(
     @Column(nullable = false)
     val age: String,
 
-    @ManyToOne(fetch = FetchType.EAGER)
-    @JoinColumn(name = "department_id", nullable = false, foreignKey = ForeignKey(name = "fk_applicant_department"))
-    val department: DepartmentEntity,
+    @Column(nullable = false)
+    val department: String,
 
     @Column(nullable = false)
     val studentId: String,
@@ -72,7 +70,7 @@ class ApplicantEntity(
             email = applicant.email,
             phoneNumber = applicant.phoneNumber,
             age = applicant.age,
-            department = DepartmentEntity.from(applicant.department),
+            department = applicant.department,
             studentId = applicant.studentId,
             part = PartEntity.from(applicant.part),
             state = applicant.state,
@@ -88,7 +86,7 @@ class ApplicantEntity(
         email = email,
         phoneNumber = phoneNumber,
         age = age,
-        department = department.toDomain(),
+        department = department,
         studentId = studentId,
         part = part.toDomain(),
         state = state,

--- a/src/main/kotlin/com/yourssu/scouter/ats/storage/domain/applicant/ApplicantEntity.kt
+++ b/src/main/kotlin/com/yourssu/scouter/ats/storage/domain/applicant/ApplicantEntity.kt
@@ -16,7 +16,7 @@ import jakarta.persistence.Id
 import jakarta.persistence.JoinColumn
 import jakarta.persistence.ManyToOne
 import jakarta.persistence.Table
-import java.time.LocalDate
+import java.time.LocalDateTime
 
 @Entity
 @Table(name = "applicant")
@@ -53,7 +53,7 @@ class ApplicantEntity(
     val state: ApplicantState,
 
     @Column(nullable = false)
-    val applicationDate: LocalDate,
+    val applicationDateTime: LocalDateTime,
 
     @ManyToOne(fetch = FetchType.EAGER)
     @JoinColumn(name = "semester_id", nullable = false, foreignKey = ForeignKey(name = "fk_applicant_semester"))
@@ -74,7 +74,7 @@ class ApplicantEntity(
             studentId = applicant.studentId,
             part = PartEntity.from(applicant.part),
             state = applicant.state,
-            applicationDate = applicant.applicationDate,
+            applicationDateTime = applicant.applicationDateTime,
             applicationSemester = SemesterEntity.from(applicant.applicationSemester),
             academicSemester = applicant.academicSemester,
         )
@@ -90,7 +90,7 @@ class ApplicantEntity(
         studentId = studentId,
         part = part.toDomain(),
         state = state,
-        applicationDate = applicationDate,
+        applicationDateTime = applicationDateTime,
         applicationSemester = applicationSemester.toDomain(),
         academicSemester = academicSemester,
     )
@@ -109,6 +109,6 @@ class ApplicantEntity(
     }
 
     override fun toString(): String {
-        return "ApplicantEntity(id=$id, name='$name', email='$email', phoneNumber='$phoneNumber', age='$age', department=$department, studentId='$studentId', part=$part, state=$state, applicationDate=$applicationDate, applicationSemester=$applicationSemester)"
+        return "ApplicantEntity(id=$id, name='$name', email='$email', phoneNumber='$phoneNumber', age='$age', department=$department, studentId='$studentId', part=$part, state=$state, applicationDate=$applicationDateTime, applicationSemester=$applicationSemester)"
     }
 }

--- a/src/main/kotlin/com/yourssu/scouter/ats/storage/domain/applicant/ApplicantRepositoryImpl.kt
+++ b/src/main/kotlin/com/yourssu/scouter/ats/storage/domain/applicant/ApplicantRepositoryImpl.kt
@@ -14,6 +14,10 @@ class ApplicantRepositoryImpl(
     override fun save(applicant: Applicant): Applicant =
         jpaApplicantRepository.save(ApplicantEntity.from(applicant)).toDomain()
 
+    override fun saveAll(applicants: List<Applicant>) {
+        jpaApplicantRepository.saveAll(applicants.map { ApplicantEntity.from(it) })
+    }
+
     override fun findById(applicantId: Long): Applicant? {
         return jpaApplicantRepository.findByIdOrNull(applicantId)?.toDomain()
     }

--- a/src/main/kotlin/com/yourssu/scouter/common/business/support/utils/SemesterConverter.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/business/support/utils/SemesterConverter.kt
@@ -1,6 +1,8 @@
 package com.yourssu.scouter.common.business.support.utils
 
 import com.yourssu.scouter.common.business.domain.semester.SemesterDto
+import com.yourssu.scouter.common.implement.domain.semester.Semester
+import java.time.LocalDate
 
 object SemesterConverter {
 
@@ -12,7 +14,17 @@ object SemesterConverter {
     }
 
     fun convertToIntString(semester: SemesterDto): String {
-        val year: Int = semester.year.value
+        val year: Int = semester.year.value % 100
+        val term: Int = semester.term.intValue
+
+        return "${year}-${term}"
+    }
+
+    fun convertToIntString(date: LocalDate): String {
+        val semester = Semester.of(date)
+
+
+        val year: Int = semester.year.value % 100
         val term: Int = semester.term.intValue
 
         return "${year}-${term}"

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/domain/authentication/OAuth2Handler.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/domain/authentication/OAuth2Handler.kt
@@ -5,4 +5,5 @@ interface OAuth2Handler {
     fun getSupportingOAuth2Type(): OAuth2Type
     fun provideAuthCodeRequestUrl(): String
     fun fetchOAuth2User(authorizationCode: String): OAuth2User
+    fun refreshAccessToken(refreshToken: String): OAuth2TokenInfo
 }

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/domain/authentication/OAuth2User.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/domain/authentication/OAuth2User.kt
@@ -15,7 +15,7 @@ data class OAuth2UserInfo(
 
 data class OAuth2TokenInfo(
     val accessToken: String,
-    val refreshToken: String,
+    val refreshToken: String? = null,
     val tokenPrefix: String,
     val expiresIn: Long,
 )

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/domain/semester/SemesterReader.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/domain/semester/SemesterReader.kt
@@ -1,6 +1,7 @@
 package com.yourssu.scouter.common.implement.domain.semester
 
 import com.yourssu.scouter.common.implement.support.exception.SemesterNotFoundException
+import java.time.Year
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
 
@@ -19,4 +20,16 @@ class SemesterReader(
     }
 
     fun readAll(): List<Semester> = semesterRepository.findAll()
+
+    fun readByString(applicationSemesterString: String): Semester {
+        val yearString: String = applicationSemesterString.substringBefore("-")
+        val yearValue = yearString.toInt() % 100 + 2000
+        val termString: String = applicationSemesterString.substringAfter("-")
+
+        val year: Year = Year.of(yearValue)
+        val term: Term = Term.of(termString.toInt())
+        val toFind = Semester(year = year, term = term)
+
+        return semesterRepository.find(toFind) ?: throw SemesterNotFoundException("지정한 학기를 찾을 수 없습니다.")
+    }
 }

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/domain/semester/SemesterReader.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/domain/semester/SemesterReader.kt
@@ -16,7 +16,8 @@ class SemesterReader(
     }
 
     fun read(semester: Semester): Semester {
-        return semesterRepository.find(semester) ?: throw SemesterNotFoundException("지정한 학기를 찾을 수 없습니다.")
+        return semesterRepository.find(semester)
+            ?: throw SemesterNotFoundException("${semester}에 해당하는 학기 정보를 찾을 수 없습니다.")
     }
 
     fun readAll(): List<Semester> = semesterRepository.findAll()
@@ -30,6 +31,7 @@ class SemesterReader(
         val term: Term = Term.of(termString.toInt())
         val toFind = Semester(year = year, term = term)
 
-        return semesterRepository.find(toFind) ?: throw SemesterNotFoundException("지정한 학기를 찾을 수 없습니다.")
+        return semesterRepository.find(toFind)
+            ?: throw SemesterNotFoundException("${applicationSemesterString}에 해당하는 학기 정보를 찾을 수 없습니다.")
     }
 }

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/domain/semester/Term.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/domain/semester/Term.kt
@@ -12,6 +12,10 @@ enum class Term(val intValue: Int, val targetMonthRange: IntRange) {
             return entries.first {date.monthValue in it.targetMonthRange }
         }
 
+        fun of(term: Int): Term {
+            return entries.first { it.intValue == term }
+        }
+
         fun from(term: Int): Term {
             return entries.first { it.intValue == term }
         }

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/domain/user/User.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/domain/user/User.kt
@@ -6,8 +6,28 @@ import java.time.LocalDateTime
 class User(
     val id: Long? = null,
     val userInfo: UserInfo,
-    val tokenInfo: TokenInfo,
+    var tokenInfo: TokenInfo,
 ) {
+    fun getBearerAccessToken(): String {
+        return tokenInfo.getBearerAccessToken()
+    }
+
+    fun getBearerRefreshToken(): String {
+        return tokenInfo.getBearerRefreshToken()
+    }
+
+    fun isAccessTokenRemainMoreThan(minutes: Long): Boolean {
+        return tokenInfo.isAccessTokenRemainMoreThan(minutes)
+    }
+
+    fun updateToken(newAccessToken: String, expiresIn: Long) {
+        tokenInfo = TokenInfo(
+            tokenPrefix = tokenInfo.tokenPrefix,
+            accessToken = newAccessToken,
+            refreshToken = tokenInfo.refreshToken,
+            accessTokenExpirationDateTime = LocalDateTime.now().plusSeconds(expiresIn),
+        )
+    }
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
@@ -40,4 +60,31 @@ class TokenInfo(
     val accessToken: String,
     val refreshToken: String,
     val accessTokenExpirationDateTime: LocalDateTime,
-)
+) {
+    constructor(tokenPrefix: String, accessToken: String, refreshToken: String, accessTokenExpiresIn: Long) : this(
+        tokenPrefix = tokenPrefix,
+        accessToken = accessToken,
+        refreshToken = refreshToken,
+        accessTokenExpirationDateTime = LocalDateTime.now().plusSeconds(accessTokenExpiresIn),
+    )
+
+    fun isAccessTokenRemainMoreThan(minutes: Long): Boolean {
+        return accessTokenExpirationDateTime.minusMinutes(minutes).isAfter(LocalDateTime.now())
+    }
+
+    fun getBearerAccessToken(): String {
+        return StringBuilder()
+            .append(tokenPrefix)
+            .append(" ")
+            .append(accessToken)
+            .toString()
+    }
+
+    fun getBearerRefreshToken(): String {
+        return StringBuilder()
+            .append(tokenPrefix)
+            .append(" ")
+            .append(refreshToken)
+            .toString()
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/domain/user/UserReader.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/domain/user/UserReader.kt
@@ -1,6 +1,7 @@
 package com.yourssu.scouter.common.implement.domain.user
 
 import com.yourssu.scouter.common.implement.domain.authentication.OAuth2User
+import com.yourssu.scouter.common.implement.support.exception.UserNotFoundException
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
 
@@ -14,5 +15,9 @@ class UserReader(
         val oauthId: String = oauth2User.userInfo.oauthId
 
         return userRepository.findByOAuthId(oauthId)
+    }
+
+    fun readById(userId: Long): User {
+        return userRepository.findById(userId) ?: throw UserNotFoundException("지정한 사용자를 찾을 수 없습니다.")
     }
 }

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/domain/user/UserRepository.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/domain/user/UserRepository.kt
@@ -3,5 +3,6 @@ package com.yourssu.scouter.common.implement.domain.user
 interface UserRepository {
 
     fun save(user: User): User
+    fun findById(userId: Long): User?
     fun findByOAuthId(oauthId: String): User?
 }

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/domain/user/UserWriter.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/domain/user/UserWriter.kt
@@ -1,7 +1,6 @@
 package com.yourssu.scouter.common.implement.domain.user
 
 import com.yourssu.scouter.common.implement.domain.authentication.OAuth2User
-import java.time.LocalDateTime
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
 
@@ -23,8 +22,8 @@ class UserWriter(
         val tokenInfo = TokenInfo(
             tokenPrefix = oauth2User.token.tokenPrefix,
             accessToken = oauth2User.token.accessToken,
-            refreshToken = oauth2User.token.refreshToken?: "",
-            accessTokenExpirationDateTime = LocalDateTime.now().plusSeconds(oauth2User.token.expiresIn)
+            refreshToken = oauth2User.token.refreshToken ?: "",
+            accessTokenExpiresIn = oauth2User.token.expiresIn,
         )
 
         val toSave = User(
@@ -33,5 +32,9 @@ class UserWriter(
         )
 
         return userRepository.save(toSave)
+    }
+
+    fun write(user: User): User {
+        return userRepository.save(user)
     }
 }

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/domain/user/UserWriter.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/domain/user/UserWriter.kt
@@ -23,7 +23,7 @@ class UserWriter(
         val tokenInfo = TokenInfo(
             tokenPrefix = oauth2User.token.tokenPrefix,
             accessToken = oauth2User.token.accessToken,
-            refreshToken = oauth2User.token.refreshToken,
+            refreshToken = oauth2User.token.refreshToken?: "",
             accessTokenExpirationDateTime = LocalDateTime.now().plusSeconds(oauth2User.token.expiresIn)
         )
 

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/support/exception/UserNotFoundException.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/support/exception/UserNotFoundException.kt
@@ -1,0 +1,7 @@
+package com.yourssu.scouter.common.implement.support.exception
+
+import org.springframework.http.HttpStatus
+
+class UserNotFoundException(
+    message: String,
+) : CustomException(message, "User-001", HttpStatus.NOT_FOUND)

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/support/google/GoogleDriveClient.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/support/google/GoogleDriveClient.kt
@@ -1,0 +1,28 @@
+package com.yourssu.scouter.common.implement.support.google
+
+import org.springframework.cloud.openfeign.FeignClient
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestHeader
+import org.springframework.web.bind.annotation.RequestParam
+
+@FeignClient(name = "googleDriveClient", url = "https://www.googleapis.com/drive/v3")
+interface GoogleDriveClient {
+
+    @GetMapping("/files")
+    fun searchFiles(
+        @RequestHeader("Authorization") authorization: String,
+        @RequestParam("q") query: String,
+        @RequestParam("fields") fields: String = "files(id, name, mimeType, webViewLink)"
+    ): GoogleDriveResponse
+}
+
+data class GoogleDriveResponse(
+    val files: List<GoogleDriveFile>
+)
+
+data class GoogleDriveFile(
+    val id: String,
+    val name: String,
+    val mimeType: String,
+    val webViewLink: String
+)

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/support/google/GoogleDriveMimeType.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/support/google/GoogleDriveMimeType.kt
@@ -1,0 +1,5 @@
+package com.yourssu.scouter.common.implement.support.google
+
+enum class GoogleDriveMimeType(val value: String) {
+    FORM("application/vnd.google-apps.form"),
+}

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/support/google/GoogleDriveQueryBuilder.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/support/google/GoogleDriveQueryBuilder.kt
@@ -1,0 +1,29 @@
+package com.yourssu.scouter.common.implement.support.google
+
+class GoogleDriveQueryBuilder {
+    private val conditions = mutableListOf<String>()
+
+    fun nameContainsAll(vararg values: String): GoogleDriveQueryBuilder {
+        values.forEach { value ->
+            conditions.add("name contains '$value'")
+        }
+        return this
+    }
+
+    fun mimeType(vararg mimeTypes: GoogleDriveMimeType): GoogleDriveQueryBuilder {
+        mimeTypes.forEach { mimeType ->
+            conditions.add("mimeType = '${mimeType.value}'")
+        }
+        return this
+    }
+
+    fun createdTime(from: String, to: String): GoogleDriveQueryBuilder {
+        conditions.add("createdTime >= '$from' and createdTime <= '$to'")
+
+        return this
+    }
+
+    fun build(): String {
+        return conditions.joinToString(" and ")
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/support/google/GoogleDriveReader.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/support/google/GoogleDriveReader.kt
@@ -1,0 +1,20 @@
+package com.yourssu.scouter.common.implement.support.google
+
+import org.springframework.stereotype.Component
+
+@Component
+class GoogleDriveReader(
+    private val googleDriveClient: GoogleDriveClient,
+) {
+
+    fun getFiles(authorizationHeader: String, query: String): List<GoogleDriveFile> {
+        val response: GoogleDriveResponse = googleDriveClient.searchFiles(
+            authorization = authorizationHeader,
+            query = query,
+        )
+
+        return response.files
+    }
+}
+
+

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/support/google/GoogleFormsClient.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/support/google/GoogleFormsClient.kt
@@ -46,6 +46,8 @@ data class GoogleFormResponses(
 data class GoogleUserResponse(
     val responseId: String,
     val createTime: String,
+    val respondentEmail: String,
+    val lastSubmittedTime: String,
     val answers: Map<String, Answer>
 )
 

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/support/google/GoogleFormsClient.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/support/google/GoogleFormsClient.kt
@@ -1,0 +1,34 @@
+package com.yourssu.scouter.common.implement.support.google
+
+import org.springframework.cloud.openfeign.FeignClient
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestHeader
+
+@FeignClient(name = "googleFormsClient", url = "https://forms.googleapis.com/v1")
+interface GoogleFormsClient {
+
+    @GetMapping("/forms/{formId}")
+    fun getFormQuestions(
+        @RequestHeader("Authorization") authorizationHeader: String,
+        @PathVariable("formId") formId: String
+    ): GoogleFormQuestions
+}
+
+data class GoogleFormQuestions(
+    val items: List<FormItem>?
+)
+
+data class FormItem(
+    val itemId: String,
+    val title: String,
+    val questionItem: QuestionItem?
+)
+
+data class QuestionItem(
+    val question: Question?
+)
+
+data class Question(
+    val questionId: String
+)

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/support/google/GoogleFormsClient.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/support/google/GoogleFormsClient.kt
@@ -13,6 +13,12 @@ interface GoogleFormsClient {
         @RequestHeader("Authorization") authorizationHeader: String,
         @PathVariable("formId") formId: String
     ): GoogleFormQuestions
+
+    @GetMapping("/forms/{formId}/responses")
+    fun getFormResponses(
+        @RequestHeader("Authorization") authorizationHeader: String,
+        @PathVariable("formId") formId: String
+    ): GoogleFormResponses
 }
 
 data class GoogleFormQuestions(
@@ -31,4 +37,26 @@ data class QuestionItem(
 
 data class Question(
     val questionId: String
+)
+
+data class GoogleFormResponses(
+    val responses: List<GoogleUserResponse>?
+)
+
+data class GoogleUserResponse(
+    val responseId: String,
+    val createTime: String,
+    val answers: Map<String, Answer>
+)
+
+data class Answer(
+    val textAnswers: TextAnswers?
+)
+
+data class TextAnswers(
+    val answers: List<TextAnswer>
+)
+
+data class TextAnswer(
+    val value: String
 )

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/support/google/GoogleFormsReader.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/support/google/GoogleFormsReader.kt
@@ -15,7 +15,7 @@ class GoogleFormsReader(
         return formResponses.responses?.map { googleUserResponse ->
             UserResponse(
                 responseId = googleUserResponse.responseId,
-                createTime = googleUserResponse.createTime,
+                createTime = googleUserResponse.createTime.substringBefore("Z"),
                 responseItems = convertToResponseItems(googleUserResponse, questionMap)
             )
         } ?: emptyList()

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/support/google/GoogleFormsReader.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/support/google/GoogleFormsReader.kt
@@ -1,6 +1,5 @@
 package com.yourssu.scouter.common.implement.support.google
 
-import java.time.LocalDateTime
 import org.springframework.stereotype.Component
 
 @Component
@@ -16,9 +15,9 @@ class GoogleFormsReader(
         return formResponses.responses?.map { googleUserResponse ->
             UserResponse(
                 responseId = googleUserResponse.responseId,
-                createTime = LocalDateTime.parse(googleUserResponse.createTime.substringBefore("Z")),
+                createTime = googleUserResponse.createTime,
                 respondentEmail = googleUserResponse.respondentEmail,
-                lastSubmittedTime = LocalDateTime.parse(googleUserResponse.lastSubmittedTime.substringBefore("Z")),
+                lastSubmittedTime = googleUserResponse.lastSubmittedTime,
                 responseItems = convertToResponseItems(googleUserResponse, questionMap)
             )
         } ?: emptyList()
@@ -43,16 +42,3 @@ class GoogleFormsReader(
         return responseItems
     }
 }
-
-data class UserResponse(
-    val responseId: String,
-    val createTime: LocalDateTime,
-    val respondentEmail: String,
-    val lastSubmittedTime: LocalDateTime,
-    val responseItems: List<ResponseItem>
-)
-
-data class ResponseItem(
-    val question: String,
-    val answer: String
-)

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/support/google/GoogleFormsReader.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/support/google/GoogleFormsReader.kt
@@ -1,0 +1,53 @@
+package com.yourssu.scouter.common.implement.support.google
+
+import org.springframework.stereotype.Component
+
+@Component
+class GoogleFormsReader(
+    private val googleFormsClient: GoogleFormsClient,
+) {
+
+    fun getUserResponses(authorizationHeader: String, formId: String): List<UserResponse> {
+        val questionResponse = googleFormsClient.getFormQuestions(authorizationHeader, formId)
+        val questionMap: Map<String, String> = makeQuestionIdAndTitleMap(questionResponse)
+        val formResponses: GoogleFormResponses = googleFormsClient.getFormResponses(authorizationHeader, formId)
+
+        return formResponses.responses?.map { googleUserResponse ->
+            UserResponse(
+                responseId = googleUserResponse.responseId,
+                createTime = googleUserResponse.createTime,
+                responseItems = convertToResponseItems(googleUserResponse, questionMap)
+            )
+        } ?: emptyList()
+    }
+
+    private fun makeQuestionIdAndTitleMap(questionResponse: GoogleFormQuestions) =
+        questionResponse.items
+            ?.mapNotNull { item ->
+                val questionId = item.questionItem?.question?.questionId ?: return@mapNotNull null
+                questionId to item.title
+            }?.toMap() ?: emptyMap()
+
+    private fun convertToResponseItems(
+        googleUserResponse: GoogleUserResponse,
+        questionMap: Map<String, String>
+    ): List<ResponseItem> {
+        val responseItems: List<ResponseItem> = googleUserResponse.answers.mapNotNull { (questionId, answer) ->
+            val questionTitle = questionMap[questionId] ?: return@mapNotNull null
+            val answerText = answer.textAnswers?.answers?.joinToString(", ") { it.value } ?: ""
+            ResponseItem(questionTitle, answerText)
+        }
+        return responseItems
+    }
+}
+
+data class UserResponse(
+    val responseId: String,
+    val createTime: String,
+    val responseItems: List<ResponseItem>
+)
+
+data class ResponseItem(
+    val question: String,
+    val answer: String
+)

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/support/google/GoogleFormsReader.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/support/google/GoogleFormsReader.kt
@@ -1,5 +1,6 @@
 package com.yourssu.scouter.common.implement.support.google
 
+import java.time.LocalDateTime
 import org.springframework.stereotype.Component
 
 @Component
@@ -15,7 +16,9 @@ class GoogleFormsReader(
         return formResponses.responses?.map { googleUserResponse ->
             UserResponse(
                 responseId = googleUserResponse.responseId,
-                createTime = googleUserResponse.createTime.substringBefore("Z"),
+                createTime = LocalDateTime.parse(googleUserResponse.createTime.substringBefore("Z")),
+                respondentEmail = googleUserResponse.respondentEmail,
+                lastSubmittedTime = LocalDateTime.parse(googleUserResponse.lastSubmittedTime.substringBefore("Z")),
                 responseItems = convertToResponseItems(googleUserResponse, questionMap)
             )
         } ?: emptyList()
@@ -43,7 +46,9 @@ class GoogleFormsReader(
 
 data class UserResponse(
     val responseId: String,
-    val createTime: String,
+    val createTime: LocalDateTime,
+    val respondentEmail: String,
+    val lastSubmittedTime: LocalDateTime,
     val responseItems: List<ResponseItem>
 )
 

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/support/google/UserResponse.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/support/google/UserResponse.kt
@@ -1,0 +1,31 @@
+package com.yourssu.scouter.common.implement.support.google
+
+import java.time.LocalDateTime
+
+data class UserResponse(
+    val responseId: String,
+    val createTime: LocalDateTime,
+    val respondentEmail: String,
+    val lastSubmittedTime: LocalDateTime,
+    val responseItems: List<ResponseItem>
+) {
+
+    constructor(
+        responseId: String,
+        createTime: String,
+        respondentEmail: String,
+        lastSubmittedTime: String,
+        responseItems: List<ResponseItem>,
+    ) : this(
+        responseId = responseId,
+        createTime = LocalDateTime.parse(createTime.substringBefore("Z")),
+        respondentEmail = respondentEmail,
+        lastSubmittedTime = LocalDateTime.parse(lastSubmittedTime.substringBefore("Z")),
+        responseItems = responseItems
+    )
+}
+
+data class ResponseItem(
+    val question: String,
+    val answer: String
+)

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/support/initialization/DivisionsAndPartsInitializer.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/support/initialization/DivisionsAndPartsInitializer.kt
@@ -35,7 +35,7 @@ class DivisionsAndPartsInitializer(
         parts.add(Part(division = division, name = "Head lead"))
         parts.add(Part(division = division, name = "finance"))
         parts.add(Part(division = division, name = "HR"))
-        parts.add(Part(division = division, name = "marketing"))
+        parts.add(Part(division = division, name = "Contents Marketing"))
         parts.add(Part(division = division, name = "legal"))
         parts.add(Part(division = division, name = "PM"))
 

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/support/security/oauth2/GoogleOAuth2Handler.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/support/security/oauth2/GoogleOAuth2Handler.kt
@@ -63,6 +63,23 @@ class GoogleOAuth2Handler(
         )
     }
 
+    override fun refreshAccessToken(refreshToken: String): OAuth2TokenInfo {
+        val refreshRequest = LinkedMultiValueMap<String, String>().apply {
+            add("client_id", googleOAuth2Properties.clientId)
+            add("client_secret", googleOAuth2Properties.clientSecret)
+            add("refresh_token", refreshToken)
+            add("grant_type", "refresh_token")
+        }
+
+        val tokenResponse: GoogleTokenResponse = googleOAuth2TokenClient.fetchToken(refreshRequest)
+
+        return OAuth2TokenInfo(
+            accessToken = tokenResponse.accessToken,
+            tokenPrefix = tokenResponse.tokenType,
+            expiresIn = tokenResponse.expiresIn,
+        )
+    }
+
     private fun fetchUserInfo(typeSpecifiedAccessToken: String): OAuth2UserInfo {
         val userInfoResponse = googleUserApiClient.fetchUserInfo(typeSpecifiedAccessToken)
 

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/support/security/oauth2/GoogleOAuth2TokenClient.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/support/security/oauth2/GoogleOAuth2TokenClient.kt
@@ -22,7 +22,7 @@ interface GoogleOAuth2TokenClient {
 data class GoogleTokenResponse(
     val accessToken: String,
     val expiresIn: Long,
-    val refreshToken: String,
+    val refreshToken: String? = null,
     val scope: String,
     val tokenType: String,
 )

--- a/src/main/kotlin/com/yourssu/scouter/common/storage/domain/user/UserRepositoryImpl.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/storage/domain/user/UserRepositoryImpl.kt
@@ -2,6 +2,7 @@ package com.yourssu.scouter.common.storage.domain.user
 
 import com.yourssu.scouter.common.implement.domain.user.User
 import com.yourssu.scouter.common.implement.domain.user.UserRepository
+import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Repository
 
 @Repository
@@ -11,6 +12,10 @@ class UserRepositoryImpl(
 
     override fun save(user: User): User {
         return jpaUserRepository.save(UserEntity.from(user)).toDomain()
+    }
+
+    override fun findById(userId: Long): User? {
+        return jpaUserRepository.findByIdOrNull(userId)?.toDomain()
     }
 
     override fun findByOAuthId(oauthId: String): User? {


### PR DESCRIPTION
## 📄 작업 내용 요약

지원서 양식은 `[OO-O] 유어슈 ## 지원서`임 (##은 파트 이름)
- 구글 드라이브 api에서 지원서 구글폼 필터링
  - oauth2 로그인 시 저장했던 google access token 사용
    - access token 만료일이 10분 미만으로 남았다면 refresh token 사용해서 access token 갱시 후 사용
  - 제목에 현재 날짜에 해당하는 학기(`OO-O`), `"유어슈"`, `"지원서"`를 포함하는 파일
  - mimeType이 `application/vnd.google-apps.form`이어야 함
- 구글폼 제목에서 파트 이름 추출해서 파트 도메인 엔티티 매핑
- 기존에는 지원자 도메인 엔티티의 학과 필드와 재학학기 필드의 타입으로 별도의 도메인 엔티티를 사용했는데, 실제 응답에서 입력 데이터가 정형화되어있지 않아 파싱이 어려워서 모두 String 타입으로 변경
- 구글폼 응답 값을 바탕으로 지원자 도메인 엔티티 생성 후 저장

## 📎 Issue 번호
- closed #50 
