### PR TITLE
fix: #52 로그인 시 가입된 사용자라면 토큰 저장 없이 반환하는 오류 해결

### DIFF
--- a/src/main/kotlin/com/yourssu/scouter/ats/business/domain/applicant/ApplicantSyncService.kt
+++ b/src/main/kotlin/com/yourssu/scouter/ats/business/domain/applicant/ApplicantSyncService.kt
@@ -123,7 +123,7 @@ class ApplicantSyncService(
 
         val newAccessTokenInfo: OAuth2TokenInfo =
             googleOAuth2Handler.refreshAccessToken(authUser.getBearerRefreshToken())
-        authUser.updateToken(newAccessTokenInfo.accessToken, newAccessTokenInfo.expiresIn)
+        authUser.updateToken(newAccessTokenInfo)
 
         return userWriter.write(authUser)
     }

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/domain/user/User.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/domain/user/User.kt
@@ -1,5 +1,6 @@
 package com.yourssu.scouter.common.implement.domain.user
 
+import com.yourssu.scouter.common.implement.domain.authentication.OAuth2TokenInfo
 import com.yourssu.scouter.common.implement.domain.authentication.OAuth2Type
 import java.time.LocalDateTime
 
@@ -20,12 +21,12 @@ class User(
         return tokenInfo.isAccessTokenRemainMoreThan(minutes)
     }
 
-    fun updateToken(newAccessToken: String, expiresIn: Long) {
+    fun updateToken(oauth2TokenInfo: OAuth2TokenInfo) {
         tokenInfo = TokenInfo(
-            tokenPrefix = tokenInfo.tokenPrefix,
-            accessToken = newAccessToken,
-            refreshToken = tokenInfo.refreshToken,
-            accessTokenExpirationDateTime = LocalDateTime.now().plusSeconds(expiresIn),
+            tokenPrefix = oauth2TokenInfo.tokenPrefix,
+            accessToken = oauth2TokenInfo.accessToken,
+            refreshToken = oauth2TokenInfo.refreshToken ?: tokenInfo.refreshToken,
+            accessTokenExpirationDateTime = LocalDateTime.now().plusSeconds(oauth2TokenInfo.expiresIn),
         )
     }
 


### PR DESCRIPTION
## 📄 작업 내용 요약
- oauth2Id에 해당하는 유저가 존재하면 토큰 정보를 저장하지 않고 바로 반환하던 문제 해결
- 새 토큰 저장 후 반환하도록 수정

## 📎 Issue 번호
- closed #52 
