### PR TITLE
feat: #13 멤버 목록 조회 시 정렬 기준 적용하는 기능 추가

### DIFF
--- a/src/main/kotlin/com/yourssu/scouter/ScouterApplication.kt
+++ b/src/main/kotlin/com/yourssu/scouter/ScouterApplication.kt
@@ -7,5 +7,5 @@ import org.springframework.boot.runApplication
 class ScouterApplication
 
 fun main(args: Array<String>) {
-	runApplication<ScouterApplication>(*args)
+    runApplication<ScouterApplication>(*args)
 }

--- a/src/main/kotlin/com/yourssu/scouter/ats/application/domain/applicant/CreateApplicantRequest.kt
+++ b/src/main/kotlin/com/yourssu/scouter/ats/application/domain/applicant/CreateApplicantRequest.kt
@@ -1,8 +1,8 @@
 package com.yourssu.scouter.ats.application.domain.applicant
 
 import com.fasterxml.jackson.annotation.JsonFormat
-import com.yourssu.scouter.ats.business.support.utils.ApplicantStateConverter
 import com.yourssu.scouter.ats.business.domain.applicant.CreateApplicantCommand
+import com.yourssu.scouter.ats.business.support.utils.ApplicantStateConverter
 import jakarta.validation.constraints.Email
 import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.NotNull

--- a/src/main/kotlin/com/yourssu/scouter/ats/application/domain/applicant/UpdateApplicantRequest.kt
+++ b/src/main/kotlin/com/yourssu/scouter/ats/application/domain/applicant/UpdateApplicantRequest.kt
@@ -1,8 +1,8 @@
 package com.yourssu.scouter.ats.application.domain.applicant
 
 import com.fasterxml.jackson.annotation.JsonFormat
-import com.yourssu.scouter.ats.business.support.utils.ApplicantStateConverter
 import com.yourssu.scouter.ats.business.domain.applicant.UpdateApplicantCommand
+import com.yourssu.scouter.ats.business.support.utils.ApplicantStateConverter
 import jakarta.validation.constraints.Pattern
 import java.time.LocalDate
 

--- a/src/main/kotlin/com/yourssu/scouter/ats/implement/domain/applicant/Applicant.kt
+++ b/src/main/kotlin/com/yourssu/scouter/ats/implement/domain/applicant/Applicant.kt
@@ -32,8 +32,4 @@ class Applicant(
     override fun hashCode(): Int {
         return id?.hashCode() ?: 0
     }
-
-    override fun toString(): String {
-        return "Applicant(id=$id, name='$name', email='$email', phoneNumber='$phoneNumber', age='$age', department=$department, studentId='$studentId', part=$part, state=$state, applicationDate=$applicationDateTime, applicationSemester=$applicationSemester, academicSemester='$academicSemester')"
-    }
 }

--- a/src/main/kotlin/com/yourssu/scouter/ats/storage/domain/applicant/ApplicantEntity.kt
+++ b/src/main/kotlin/com/yourssu/scouter/ats/storage/domain/applicant/ApplicantEntity.kt
@@ -107,8 +107,4 @@ class ApplicantEntity(
     override fun hashCode(): Int {
         return id?.hashCode() ?: 0
     }
-
-    override fun toString(): String {
-        return "ApplicantEntity(id=$id, name='$name', email='$email', phoneNumber='$phoneNumber', age='$age', department=$department, studentId='$studentId', part=$part, state=$state, applicationDate=$applicationDateTime, applicationSemester=$applicationSemester)"
-    }
 }

--- a/src/main/kotlin/com/yourssu/scouter/common/application/domain/department/DepartmentController.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/application/domain/department/DepartmentController.kt
@@ -12,7 +12,7 @@ class DepartmentController(
     private val departmentService: DepartmentService,
 ) {
 
-    @GetMapping ("/departments")
+    @GetMapping("/departments")
     fun readAll(): ResponseEntity<List<ReadDepartmentsResponse>> {
         val result: ReadDepartmentsResult = departmentService.readAll()
         val response: List<ReadDepartmentsResponse> = result.departmentDtos.map { ReadDepartmentsResponse.from(it) }

--- a/src/main/kotlin/com/yourssu/scouter/common/application/domain/semester/ReadSemesterResponse.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/application/domain/semester/ReadSemesterResponse.kt
@@ -1,7 +1,7 @@
 package com.yourssu.scouter.common.application.domain.semester
 
-import com.yourssu.scouter.common.business.support.utils.SemesterConverter
 import com.yourssu.scouter.common.business.domain.semester.SemesterDto
+import com.yourssu.scouter.common.business.support.utils.SemesterConverter
 
 data class ReadSemesterResponse(
     val semesterId: Long,

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/domain/basetime/BaseCreateTime.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/domain/basetime/BaseCreateTime.kt
@@ -1,0 +1,7 @@
+package com.yourssu.scouter.common.implement.domain.basetime
+
+import java.time.LocalDateTime
+
+open class BaseCreateTime(
+    val createdTime: LocalDateTime? = null
+)

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/domain/basetime/BaseTime.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/domain/basetime/BaseTime.kt
@@ -1,0 +1,8 @@
+package com.yourssu.scouter.common.implement.domain.basetime
+
+import java.time.LocalDateTime
+
+open class BaseTime(
+    createdTime: LocalDateTime? = null,
+    val updatedTime: LocalDateTime? = null
+) : BaseCreateTime(createdTime)

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/domain/department/Department.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/domain/department/Department.kt
@@ -18,8 +18,4 @@ class Department(
     override fun hashCode(): Int {
         return id?.hashCode() ?: 0
     }
-
-    override fun toString(): String {
-        return "Department(id=$id, collegeId=$collegeId, name='$name')"
-    }
 }

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/domain/division/Division.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/domain/division/Division.kt
@@ -4,7 +4,7 @@ class Division(
     val id: Long? = null,
     val name: String,
     val sortPriority: Int,
-): Comparable<Division> {
+) : Comparable<Division> {
 
     override fun compareTo(other: Division): Int {
         return this.sortPriority.compareTo(other.sortPriority)

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/domain/division/Division.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/domain/division/Division.kt
@@ -7,7 +7,7 @@ class Division(
 ): Comparable<Division> {
 
     override fun compareTo(other: Division): Int {
-        return sortPriority.compareTo(other.sortPriority)
+        return this.sortPriority.compareTo(other.sortPriority)
     }
 
     override fun equals(other: Any?): Boolean {
@@ -21,9 +21,5 @@ class Division(
 
     override fun hashCode(): Int {
         return id?.hashCode() ?: 0
-    }
-
-    override fun toString(): String {
-        return "Division(id=$id, name='$name', sortPriority=$sortPriority)"
     }
 }

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/domain/division/Division.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/domain/division/Division.kt
@@ -3,7 +3,12 @@ package com.yourssu.scouter.common.implement.domain.division
 class Division(
     val id: Long? = null,
     val name: String,
-) {
+    val sortPriority: Int,
+): Comparable<Division> {
+
+    override fun compareTo(other: Division): Int {
+        return sortPriority.compareTo(other.sortPriority)
+    }
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
@@ -19,6 +24,6 @@ class Division(
     }
 
     override fun toString(): String {
-        return "Division(id=$id, name='$name')"
+        return "Division(id=$id, name='$name', sortPriority=$sortPriority)"
     }
 }

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/domain/part/Part.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/domain/part/Part.kt
@@ -7,7 +7,7 @@ class Part(
     val division: Division,
     val name: String,
     val sortPriority: Int,
-): Comparable<Part> {
+) : Comparable<Part> {
 
     override fun compareTo(other: Part): Int {
         val divisionCompare = this.division.compareTo(other.division)

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/domain/part/Part.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/domain/part/Part.kt
@@ -6,7 +6,17 @@ class Part(
     val id: Long? = null,
     val division: Division,
     val name: String,
-) {
+    val sortPriority: Int,
+): Comparable<Part> {
+
+    override fun compareTo(other: Part): Int {
+        val divisionCompare = division.compareTo(other.division)
+        if (divisionCompare != 0) {
+            return divisionCompare
+        }
+
+        return sortPriority.compareTo(other.sortPriority)
+    }
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
@@ -22,6 +32,6 @@ class Part(
     }
 
     override fun toString(): String {
-        return "Part(id=$id, division=$division, name='$name')"
+        return "Part(id=$id, division=$division, name='$name', orderPriority=$sortPriority)"
     }
 }

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/domain/part/Part.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/domain/part/Part.kt
@@ -10,12 +10,12 @@ class Part(
 ): Comparable<Part> {
 
     override fun compareTo(other: Part): Int {
-        val divisionCompare = division.compareTo(other.division)
+        val divisionCompare = this.division.compareTo(other.division)
         if (divisionCompare != 0) {
             return divisionCompare
         }
 
-        return sortPriority.compareTo(other.sortPriority)
+        return this.sortPriority.compareTo(other.sortPriority)
     }
 
     override fun equals(other: Any?): Boolean {
@@ -29,9 +29,5 @@ class Part(
 
     override fun hashCode(): Int {
         return id?.hashCode() ?: 0
-    }
-
-    override fun toString(): String {
-        return "Part(id=$id, division=$division, name='$name', orderPriority=$sortPriority)"
     }
 }

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/domain/semester/Semester.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/domain/semester/Semester.kt
@@ -47,12 +47,12 @@ class Semester(
     }
 
     override fun compareTo(other: Semester): Int {
-        val yearCompare = year.compareTo(other.year)
+        val yearCompare = this.year.compareTo(other.year)
         if (yearCompare != 0) {
             return yearCompare
         }
 
-        return term.intValue.compareTo(other.term.intValue)
+        return this.term.intValue.compareTo(other.term.intValue)
     }
 
     override fun equals(other: Any?): Boolean {
@@ -66,9 +66,5 @@ class Semester(
 
     override fun hashCode(): Int {
         return id?.hashCode() ?: 0
-    }
-
-    override fun toString(): String {
-        return "Semester(id=$id, year=$year, semester=$term)"
     }
 }

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/domain/semester/Semester.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/domain/semester/Semester.kt
@@ -7,8 +7,15 @@ class Semester(
     val id: Long? = null,
     val year: Year,
     val term: Term,
-) {
-    constructor(year: Int, term: Int) : this(null, Year.of(year), Term.from(term))
+) : Comparable<Semester> {
+    constructor(
+        year: Int,
+        term: Int
+    ) : this(
+        id = null,
+        year = Year.of(year),
+        term = Term.from(term)
+    )
 
     companion object {
         fun of(date: LocalDate): Semester = Semester(
@@ -37,6 +44,15 @@ class Semester(
         }
 
         return Semester(year = year, term = Term.FALL)
+    }
+
+    override fun compareTo(other: Semester): Int {
+        val yearCompare = year.compareTo(other.year)
+        if (yearCompare != 0) {
+            return yearCompare
+        }
+
+        return term.intValue.compareTo(other.term.intValue)
     }
 
     override fun equals(other: Any?): Boolean {

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/domain/semester/Term.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/domain/semester/Term.kt
@@ -9,7 +9,7 @@ enum class Term(val intValue: Int, val targetMonthRange: IntRange) {
 
     companion object {
         fun of(date: LocalDate): Term {
-            return entries.first {date.monthValue in it.targetMonthRange }
+            return entries.first { date.monthValue in it.targetMonthRange }
         }
 
         fun of(term: Int): Term {

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/domain/user/User.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/domain/user/User.kt
@@ -42,10 +42,6 @@ class User(
     override fun hashCode(): Int {
         return id?.hashCode() ?: 0
     }
-
-    override fun toString(): String {
-        return "User(id=$id, userInfo=$userInfo, tokenInfo=$tokenInfo)"
-    }
 }
 
 class UserInfo(

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/support/initialization/DivisionsAndPartsInitializer.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/support/initialization/DivisionsAndPartsInitializer.kt
@@ -32,12 +32,12 @@ class DivisionsAndPartsInitializer(
         val division = divisionRepository.save(Division(name = "운영", sortPriority = 1))
 
         val parts = mutableListOf<Part>()
-        parts.add(Part(division = division, name = "Head lead"))
-        parts.add(Part(division = division, name = "finance"))
-        parts.add(Part(division = division, name = "HR"))
-        parts.add(Part(division = division, name = "Contents Marketing"))
-        parts.add(Part(division = division, name = "legal"))
-        parts.add(Part(division = division, name = "PM"))
+        parts.add(Part(division = division, name = "Head lead", sortPriority = 1))
+        parts.add(Part(division = division, name = "finance", sortPriority = 2))
+        parts.add(Part(division = division, name = "HR", sortPriority = 3))
+        parts.add(Part(division = division, name = "Contents Marketing", sortPriority = 34))
+        parts.add(Part(division = division, name = "legal", sortPriority = 5))
+        parts.add(Part(division = division, name = "PM", sortPriority = 6))
 
         partRepository.saveAll(parts)
     }
@@ -45,10 +45,10 @@ class DivisionsAndPartsInitializer(
     private fun initialize_개발() {
         val division = divisionRepository.save(Division(name = "개발", sortPriority = 2))
         val parts = mutableListOf<Part>()
-        parts.add(Part(division = division, name = "Backend"))
-        parts.add(Part(division = division, name = "Android"))
-        parts.add(Part(division = division, name = "iOS"))
-        parts.add(Part(division = division, name = "Web-frontend"))
+        parts.add(Part(division = division, name = "Backend", sortPriority = 1))
+        parts.add(Part(division = division, name = "Android", sortPriority = 2))
+        parts.add(Part(division = division, name = "iOS", sortPriority = 3))
+        parts.add(Part(division = division, name = "Web-frontend", sortPriority = 4))
 
         partRepository.saveAll(parts)
     }
@@ -57,7 +57,7 @@ class DivisionsAndPartsInitializer(
         val division = divisionRepository.save(Division(name = "디자인", sortPriority = 3))
 
         val parts = mutableListOf<Part>()
-        parts.add(Part(division = division, name = "Product Design"))
+        parts.add(Part(division = division, name = "Product Design", sortPriority = 1))
 
         partRepository.saveAll(parts)
     }

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/support/initialization/DivisionsAndPartsInitializer.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/support/initialization/DivisionsAndPartsInitializer.kt
@@ -29,7 +29,7 @@ class DivisionsAndPartsInitializer(
     private fun alreadyInitialized() = divisionRepository.count() != 0L
 
     private fun initialize_운영() {
-        val division = divisionRepository.save(Division(name = "운영"))
+        val division = divisionRepository.save(Division(name = "운영", sortPriority = 1))
 
         val parts = mutableListOf<Part>()
         parts.add(Part(division = division, name = "Head lead"))
@@ -43,7 +43,7 @@ class DivisionsAndPartsInitializer(
     }
 
     private fun initialize_개발() {
-        val division = divisionRepository.save(Division(name = "개발"))
+        val division = divisionRepository.save(Division(name = "개발", sortPriority = 2))
         val parts = mutableListOf<Part>()
         parts.add(Part(division = division, name = "Backend"))
         parts.add(Part(division = division, name = "Android"))
@@ -54,7 +54,7 @@ class DivisionsAndPartsInitializer(
     }
 
     private fun initialize_디자인() {
-        val division = divisionRepository.save(Division(name = "디자인"))
+        val division = divisionRepository.save(Division(name = "디자인", sortPriority = 3))
 
         val parts = mutableListOf<Part>()
         parts.add(Part(division = division, name = "Product Design"))

--- a/src/main/kotlin/com/yourssu/scouter/common/storage/domain/basetime/BaseCreateTimeEntity.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/storage/domain/basetime/BaseCreateTimeEntity.kt
@@ -1,0 +1,18 @@
+package com.yourssu.scouter.common.storage.domain.basetime
+
+import jakarta.persistence.Column
+import jakarta.persistence.EntityListeners
+import jakarta.persistence.MappedSuperclass
+import java.time.LocalDateTime
+import org.springframework.data.annotation.CreatedDate
+import org.springframework.data.jpa.domain.support.AuditingEntityListener
+
+@EntityListeners(AuditingEntityListener::class)
+@MappedSuperclass
+class BaseCreateTimeEntity {
+
+    @CreatedDate
+    @Column(updatable = false, nullable = false)
+    var createdTime: LocalDateTime? = null
+        protected set
+}

--- a/src/main/kotlin/com/yourssu/scouter/common/storage/domain/basetime/BaseTimeEntity.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/storage/domain/basetime/BaseTimeEntity.kt
@@ -1,0 +1,18 @@
+package com.yourssu.scouter.common.storage.domain.basetime
+
+import jakarta.persistence.Column
+import jakarta.persistence.EntityListeners
+import jakarta.persistence.MappedSuperclass
+import java.time.LocalDateTime
+import org.springframework.data.annotation.LastModifiedDate
+import org.springframework.data.jpa.domain.support.AuditingEntityListener
+
+@EntityListeners(AuditingEntityListener::class)
+@MappedSuperclass
+class BaseTimeEntity : BaseCreateTimeEntity() {
+
+    @LastModifiedDate
+    @Column(nullable = false)
+    var updatedTime: LocalDateTime? = null
+        protected set
+}

--- a/src/main/kotlin/com/yourssu/scouter/common/storage/domain/college/CollegeEntity.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/storage/domain/college/CollegeEntity.kt
@@ -44,8 +44,4 @@ class CollegeEntity(
     override fun hashCode(): Int {
         return id?.hashCode() ?: 0
     }
-
-    override fun toString(): String {
-        return "CollegeEntity(id=$id, name='$name')"
-    }
 }

--- a/src/main/kotlin/com/yourssu/scouter/common/storage/domain/department/DepartmentEntity.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/storage/domain/department/DepartmentEntity.kt
@@ -23,6 +23,14 @@ class DepartmentEntity(
     val name: String,
 ) {
 
+    companion object {
+        fun from(department: Department) = DepartmentEntity(
+            id = department.id,
+            collegeId = department.collegeId,
+            name = department.name,
+        )
+    }
+
     fun toDomain() = Department(
         id = id,
         collegeId = collegeId,
@@ -40,17 +48,5 @@ class DepartmentEntity(
 
     override fun hashCode(): Int {
         return id?.hashCode() ?: 0
-    }
-
-    override fun toString(): String {
-        return "DepartmentEntity(id=$id, collegeId=$collegeId, name='$name')"
-    }
-
-    companion object {
-        fun from(department: Department) = DepartmentEntity(
-            id = department.id,
-            collegeId = department.collegeId,
-            name = department.name,
-        )
     }
 }

--- a/src/main/kotlin/com/yourssu/scouter/common/storage/domain/division/DivisionEntity.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/storage/domain/division/DivisionEntity.kt
@@ -18,18 +18,23 @@ class DivisionEntity(
 
     @Column(nullable = false, unique = true)
     val name: String,
+
+    @Column(nullable = false)
+    val sortPriority: Int,
 ) {
 
     companion object {
         fun from(division: Division): DivisionEntity = DivisionEntity(
             id = division.id,
             name = division.name,
+            sortPriority = division.sortPriority,
         )
     }
 
     fun toDomain() = Division(
         id = id,
         name = name,
+        sortPriority = sortPriority,
     )
 
     override fun equals(other: Any?): Boolean {

--- a/src/main/kotlin/com/yourssu/scouter/common/storage/domain/division/DivisionEntity.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/storage/domain/division/DivisionEntity.kt
@@ -49,8 +49,4 @@ class DivisionEntity(
     override fun hashCode(): Int {
         return id?.hashCode() ?: 0
     }
-
-    override fun toString(): String {
-        return "DivisionEntity(id=$id, name='$name')"
-    }
 }

--- a/src/main/kotlin/com/yourssu/scouter/common/storage/domain/part/PartEntity.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/storage/domain/part/PartEntity.kt
@@ -27,6 +27,9 @@ class PartEntity(
 
     @Column(nullable = false, unique = true)
     val name: String,
+
+    @Column(nullable = false)
+    val sortPriority: Int,
 ) {
 
     companion object {
@@ -34,6 +37,7 @@ class PartEntity(
             id = part.id,
             division = DivisionEntity.from(part.division),
             name = part.name,
+            sortPriority = part.sortPriority,
         )
     }
 
@@ -41,6 +45,7 @@ class PartEntity(
         id = id,
         division = division.toDomain(),
         name = name,
+        sortPriority = sortPriority,
     )
 
     override fun equals(other: Any?): Boolean {
@@ -57,6 +62,6 @@ class PartEntity(
     }
 
     override fun toString(): String {
-        return "PartEntity(id=$id, division=$division, name='$name')"
+        return "PartEntity(id=$id, division=$division, name='$name', sortPriority=$sortPriority)"
     }
 }

--- a/src/main/kotlin/com/yourssu/scouter/common/storage/domain/part/PartEntity.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/storage/domain/part/PartEntity.kt
@@ -60,8 +60,4 @@ class PartEntity(
     override fun hashCode(): Int {
         return id?.hashCode() ?: 0
     }
-
-    override fun toString(): String {
-        return "PartEntity(id=$id, division=$division, name='$name', sortPriority=$sortPriority)"
-    }
 }

--- a/src/main/kotlin/com/yourssu/scouter/common/storage/support/configuration/JpaConfiguration.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/storage/support/configuration/JpaConfiguration.kt
@@ -1,0 +1,8 @@
+package com.yourssu.scouter.common.storage.support.configuration
+
+import org.springframework.context.annotation.Configuration
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing
+
+@Configuration
+@EnableJpaAuditing
+class JpaConfiguration

--- a/src/main/kotlin/com/yourssu/scouter/hrms/business/domain/member/CreateMemberCommand.kt
+++ b/src/main/kotlin/com/yourssu/scouter/hrms/business/domain/member/CreateMemberCommand.kt
@@ -6,6 +6,7 @@ import com.yourssu.scouter.hrms.implement.domain.member.Member
 import com.yourssu.scouter.hrms.implement.domain.member.MemberRole
 import com.yourssu.scouter.hrms.implement.domain.member.MemberState
 import java.time.LocalDate
+import java.time.LocalDateTime
 
 data class CreateMemberCommand(
     val name: String,
@@ -36,6 +37,7 @@ data class CreateMemberCommand(
         nicknameKorean = nicknameKorean,
         state = state,
         joinDate = joinDate,
+        stateUpdatedTime = LocalDateTime.now(),
         note = note,
     )
 }

--- a/src/main/kotlin/com/yourssu/scouter/hrms/business/domain/member/CreateMemberCommand.kt
+++ b/src/main/kotlin/com/yourssu/scouter/hrms/business/domain/member/CreateMemberCommand.kt
@@ -30,7 +30,7 @@ data class CreateMemberCommand(
         birthDate = birthDate,
         department = department,
         studentId = studentId,
-        parts = parts,
+        parts = parts.toSortedSet(),
         role = role,
         nicknameEnglish = nicknameEnglish,
         nicknameKorean = nicknameKorean,

--- a/src/main/kotlin/com/yourssu/scouter/hrms/business/domain/member/MemberDto.kt
+++ b/src/main/kotlin/com/yourssu/scouter/hrms/business/domain/member/MemberDto.kt
@@ -6,6 +6,7 @@ import com.yourssu.scouter.hrms.implement.domain.member.Member
 import com.yourssu.scouter.hrms.implement.domain.member.MemberRole
 import com.yourssu.scouter.hrms.implement.domain.member.MemberState
 import java.time.LocalDate
+import java.time.LocalDateTime
 
 data class MemberDto(
     val id: Long,
@@ -22,6 +23,8 @@ data class MemberDto(
     val state: MemberState,
     val joinDate: LocalDate,
     val note: String,
+    val createdTime: LocalDateTime,
+    val updatedTime: LocalDateTime,
 ) {
 
     companion object {
@@ -40,6 +43,8 @@ data class MemberDto(
             state = member.state,
             joinDate = member.joinDate,
             note = member.note,
+            createdTime = member.createdTime!!,
+            updatedTime = member.updatedTime!!,
         )
     }
 }

--- a/src/main/kotlin/com/yourssu/scouter/hrms/business/domain/member/MemberDto.kt
+++ b/src/main/kotlin/com/yourssu/scouter/hrms/business/domain/member/MemberDto.kt
@@ -23,6 +23,7 @@ data class MemberDto(
     val state: MemberState,
     val joinDate: LocalDate,
     val note: String,
+    val stateUpdatedTime: LocalDateTime,
     val createdTime: LocalDateTime,
     val updatedTime: LocalDateTime,
 ) {
@@ -43,6 +44,7 @@ data class MemberDto(
             state = member.state,
             joinDate = member.joinDate,
             note = member.note,
+            stateUpdatedTime = member.stateUpdatedTime,
             createdTime = member.createdTime!!,
             updatedTime = member.updatedTime!!,
         )

--- a/src/main/kotlin/com/yourssu/scouter/hrms/business/domain/member/MemberService.kt
+++ b/src/main/kotlin/com/yourssu/scouter/hrms/business/domain/member/MemberService.kt
@@ -19,6 +19,7 @@ import com.yourssu.scouter.hrms.implement.domain.member.MemberState
 import com.yourssu.scouter.hrms.implement.domain.member.MemberWriter
 import com.yourssu.scouter.hrms.implement.domain.member.WithdrawnMember
 import java.time.LocalDate
+import java.time.LocalDateTime
 import org.springframework.stereotype.Service
 
 @Service
@@ -226,6 +227,7 @@ class MemberService(
             state = target.state,
             joinDate = command.joinDate ?: target.joinDate,
             note = command.note ?: target.note,
+            stateUpdatedTime = target.stateUpdatedTime,
         )
 
         memberWriter.update(updateMember)
@@ -274,6 +276,7 @@ class MemberService(
             state = target.state,
             joinDate = target.joinDate,
             note = "${newNote}${target.note}",
+            stateUpdatedTime = target.stateUpdatedTime,
         )
 
         memberWriter.update(updateMember)
@@ -295,6 +298,7 @@ class MemberService(
             state = newState,
             joinDate = target.joinDate,
             note = target.note,
+            stateUpdatedTime = LocalDateTime.now()
         )
 
         deletePreviousStateData(target)

--- a/src/main/kotlin/com/yourssu/scouter/hrms/business/domain/member/MemberService.kt
+++ b/src/main/kotlin/com/yourssu/scouter/hrms/business/domain/member/MemberService.kt
@@ -42,49 +42,49 @@ class MemberService(
     }
 
     fun readAllActive(): List<ActiveMemberDto> {
-        val members: List<ActiveMember> = memberReader.readAllActive()
+        val members: List<ActiveMember> = memberReader.readAllActive().sorted()
 
         return members.map { ActiveMemberDto.from(it) }
     }
 
     fun readAllInactive(): List<InactiveMemberDto> {
-        val members: List<InactiveMember> = memberReader.readAllInactive()
+        val members: List<InactiveMember> = memberReader.readAllInactive().sorted()
 
         return members.map { InactiveMemberDto.from(it) }
     }
 
     fun readAllGraduated(): List<GraduatedMemberDto> {
-        val members: List<GraduatedMember> = memberReader.readAllGraduated()
+        val members: List<GraduatedMember> = memberReader.readAllGraduated().sorted()
 
         return members.map { GraduatedMemberDto.from(it) }
     }
 
     fun readAllWithdrawn(): List<WithdrawnMemberDto> {
-        val members: List<WithdrawnMember> = memberReader.readAllWithdrawn()
+        val members: List<WithdrawnMember> = memberReader.readAllWithdrawn().sorted()
 
         return members.map { WithdrawnMemberDto.from(it) }
     }
 
     fun searchAllActiveByNameOrNickname(query: String): List<ActiveMemberDto> {
-        val members: List<ActiveMember> = memberReader.searchAllActiveByNameOrNickname(query)
+        val members: List<ActiveMember> = memberReader.searchAllActiveByNameOrNickname(query).sorted()
 
         return members.map { ActiveMemberDto.from(it) }
     }
 
     fun searchAllInactiveByNameOrNickname(query: String): List<InactiveMemberDto> {
-        val members: List<InactiveMember> = memberReader.searchAllInactiveByNameOrNickname(query)
+        val members: List<InactiveMember> = memberReader.searchAllInactiveByNameOrNickname(query).sorted()
 
         return members.map { InactiveMemberDto.from(it) }
     }
 
     fun searchAllGraduatedByNameOrNickname(query: String): List<GraduatedMemberDto> {
-        val members: List<GraduatedMember> = memberReader.searchAllGraduatedByNameOrNickname(query)
+        val members: List<GraduatedMember> = memberReader.searchAllGraduatedByNameOrNickname(query).sorted()
 
         return members.map { GraduatedMemberDto.from(it) }
     }
 
     fun searchAllWithdrawnByNameOrNickname(query: String): List<WithdrawnMemberDto> {
-        val members: List<WithdrawnMember> = memberReader.searchAllWithdrawnByNameOrNickname(query)
+        val members: List<WithdrawnMember> = memberReader.searchAllWithdrawnByNameOrNickname(query).sorted()
 
         return members.map { WithdrawnMemberDto.from(it) }
     }

--- a/src/main/kotlin/com/yourssu/scouter/hrms/business/domain/member/MemberService.kt
+++ b/src/main/kotlin/com/yourssu/scouter/hrms/business/domain/member/MemberService.kt
@@ -219,7 +219,7 @@ class MemberService(
             birthDate = command.birthDate ?: target.birthDate,
             department = command.departmentId?.let { departmentReader.readById(it) } ?: target.department,
             studentId = command.studentId ?: target.studentId,
-            parts = command.partIds?.let { partReader.readAllByIds(it) } ?: target.parts,
+            parts = command.partIds?.let { partReader.readAllByIds(it).toSortedSet() } ?: target.parts,
             role = target.role,
             nicknameEnglish = command.nicknameEnglish ?: target.nicknameEnglish,
             nicknameKorean = command.nicknameKorean ?: target.nicknameKorean,

--- a/src/main/kotlin/com/yourssu/scouter/hrms/implement/domain/member/ActiveMember.kt
+++ b/src/main/kotlin/com/yourssu/scouter/hrms/implement/domain/member/ActiveMember.kt
@@ -12,7 +12,7 @@ class ActiveMember(
     )
 
     override fun compareTo(other: ActiveMember): Int {
-        return member.compareTo(other.member)
+        return this.member.compareTo(other.member)
     }
 
     override fun equals(other: Any?): Boolean {
@@ -26,9 +26,5 @@ class ActiveMember(
 
     override fun hashCode(): Int {
         return id?.hashCode() ?: 0
-    }
-
-    override fun toString(): String {
-        return "ActiveMember(id=$id, member=$member, isMembershipFeePaid=$isMembershipFeePaid)"
     }
 }

--- a/src/main/kotlin/com/yourssu/scouter/hrms/implement/domain/member/ActiveMember.kt
+++ b/src/main/kotlin/com/yourssu/scouter/hrms/implement/domain/member/ActiveMember.kt
@@ -4,19 +4,15 @@ class ActiveMember(
     val id: Long? = null,
     val member: Member,
     val isMembershipFeePaid: Boolean = false,
-) {
+) : Comparable<ActiveMember> {
 
     constructor(member: Member) : this(
         member = member,
         isMembershipFeePaid = false,
     )
 
-    fun updateMembershipFeePaid(isMembershipFeePaid: Boolean): ActiveMember {
-        return ActiveMember(
-            id = id,
-            member = member,
-            isMembershipFeePaid = isMembershipFeePaid,
-        )
+    override fun compareTo(other: ActiveMember): Int {
+        return member.compareTo(other.member)
     }
 
     override fun equals(other: Any?): Boolean {

--- a/src/main/kotlin/com/yourssu/scouter/hrms/implement/domain/member/GraduatedMember.kt
+++ b/src/main/kotlin/com/yourssu/scouter/hrms/implement/domain/member/GraduatedMember.kt
@@ -23,7 +23,7 @@ class GraduatedMember(
     )
 
     override fun compareTo(other: GraduatedMember): Int {
-        return other.member.stateUpdatedTime.compareTo(member.stateUpdatedTime)
+        return other.member.stateUpdatedTime.compareTo(this.member.stateUpdatedTime)
     }
 
     override fun equals(other: Any?): Boolean {
@@ -37,9 +37,5 @@ class GraduatedMember(
 
     override fun hashCode(): Int {
         return id.hashCode()
-    }
-
-    override fun toString(): String {
-        return "GraduatedMember(id=$id, member=$member, activePeriod=$activePeriod, isAdvisorDesired=$isAdvisorDesired)"
     }
 }

--- a/src/main/kotlin/com/yourssu/scouter/hrms/implement/domain/member/GraduatedMember.kt
+++ b/src/main/kotlin/com/yourssu/scouter/hrms/implement/domain/member/GraduatedMember.kt
@@ -23,7 +23,7 @@ class GraduatedMember(
     )
 
     override fun compareTo(other: GraduatedMember): Int {
-        return other.member.updatedTime?.compareTo(member.updatedTime) ?: 0
+        return other.member.stateUpdatedTime.compareTo(member.stateUpdatedTime)
     }
 
     override fun equals(other: Any?): Boolean {

--- a/src/main/kotlin/com/yourssu/scouter/hrms/implement/domain/member/GraduatedMember.kt
+++ b/src/main/kotlin/com/yourssu/scouter/hrms/implement/domain/member/GraduatedMember.kt
@@ -7,7 +7,7 @@ class GraduatedMember(
     val member: Member,
     val activePeriod: SemesterPeriod,
     val isAdvisorDesired: Boolean,
-) {
+) : Comparable<GraduatedMember> {
 
     constructor(
         member: Member,
@@ -22,13 +22,8 @@ class GraduatedMember(
         isAdvisorDesired = false,
     )
 
-    fun updateAdvisorDesired(isAdvisorDesired: Boolean): GraduatedMember {
-        return GraduatedMember(
-            id = id,
-            member = member,
-            activePeriod = activePeriod,
-            isAdvisorDesired = isAdvisorDesired,
-        )
+    override fun compareTo(other: GraduatedMember): Int {
+        return other.member.updatedTime?.compareTo(member.updatedTime) ?: 0
     }
 
     override fun equals(other: Any?): Boolean {

--- a/src/main/kotlin/com/yourssu/scouter/hrms/implement/domain/member/InactiveMember.kt
+++ b/src/main/kotlin/com/yourssu/scouter/hrms/implement/domain/member/InactiveMember.kt
@@ -8,7 +8,7 @@ class InactiveMember(
     val activePeriod: SemesterPeriod,
     val expectedReturnSemester: Semester,
     val inactivePeriod: SemesterPeriod,
-) {
+) : Comparable<InactiveMember> {
 
     constructor(
         member: Member,
@@ -40,6 +40,15 @@ class InactiveMember(
             expectedReturnSemester = expectedReturnSemester,
             inactivePeriod = SemesterPeriod(inactivePeriod.startSemester, previousSemesterBeforeExpectedReturnSemester),
         )
+    }
+
+    override fun compareTo(other: InactiveMember): Int {
+        val returnCompare = expectedReturnSemester.compareTo(other.expectedReturnSemester)
+        if (returnCompare != 0) {
+            return returnCompare
+        }
+
+        return member.compareTo(other.member)
     }
 
     override fun equals(other: Any?): Boolean {

--- a/src/main/kotlin/com/yourssu/scouter/hrms/implement/domain/member/InactiveMember.kt
+++ b/src/main/kotlin/com/yourssu/scouter/hrms/implement/domain/member/InactiveMember.kt
@@ -43,12 +43,12 @@ class InactiveMember(
     }
 
     override fun compareTo(other: InactiveMember): Int {
-        val returnCompare = expectedReturnSemester.compareTo(other.expectedReturnSemester)
+        val returnCompare = this.expectedReturnSemester.compareTo(other.expectedReturnSemester)
         if (returnCompare != 0) {
             return returnCompare
         }
 
-        return member.compareTo(other.member)
+        return this.member.compareTo(other.member)
     }
 
     override fun equals(other: Any?): Boolean {
@@ -62,9 +62,5 @@ class InactiveMember(
 
     override fun hashCode(): Int {
         return id.hashCode()
-    }
-
-    override fun toString(): String {
-        return "InactiveMember(id=$id, member=$member, activePeriod=$activePeriod, expectedReturnSemester=$expectedReturnSemester, inactivePeriod=$inactivePeriod)"
     }
 }

--- a/src/main/kotlin/com/yourssu/scouter/hrms/implement/domain/member/Member.kt
+++ b/src/main/kotlin/com/yourssu/scouter/hrms/implement/domain/member/Member.kt
@@ -19,7 +19,17 @@ class Member(
     val state: MemberState,
     val joinDate: LocalDate,
     val note: String,
-) {
+) : Comparable<Member> {
+
+    override fun compareTo(other: Member): Int {
+        val partCompare = parts.first().compareTo(other.parts.first())
+
+        if (partCompare != 0) {
+            return partCompare
+        }
+
+        return this.joinDate.compareTo(other.joinDate)
+    }
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true

--- a/src/main/kotlin/com/yourssu/scouter/hrms/implement/domain/member/Member.kt
+++ b/src/main/kotlin/com/yourssu/scouter/hrms/implement/domain/member/Member.kt
@@ -22,6 +22,7 @@ class Member(
     val state: MemberState,
     val joinDate: LocalDate,
     val note: String,
+    val stateUpdatedTime: LocalDateTime,
     createdTime: LocalDateTime? = null,
     updatedTime: LocalDateTime? = null,
 ) : BaseTime(createdTime, updatedTime), Comparable<Member> {

--- a/src/main/kotlin/com/yourssu/scouter/hrms/implement/domain/member/Member.kt
+++ b/src/main/kotlin/com/yourssu/scouter/hrms/implement/domain/member/Member.kt
@@ -1,8 +1,10 @@
 package com.yourssu.scouter.hrms.implement.domain.member
 
+import com.yourssu.scouter.common.implement.domain.basetime.BaseTime
 import com.yourssu.scouter.common.implement.domain.department.Department
 import com.yourssu.scouter.common.implement.domain.part.Part
 import java.time.LocalDate
+import java.time.LocalDateTime
 
 class Member(
     val id: Long? = null,
@@ -19,7 +21,9 @@ class Member(
     val state: MemberState,
     val joinDate: LocalDate,
     val note: String,
-) : Comparable<Member> {
+    createdTime: LocalDateTime? = null,
+    updatedTime: LocalDateTime? = null,
+) : BaseTime(createdTime, updatedTime), Comparable<Member> {
 
     override fun compareTo(other: Member): Int {
         val partCompare = parts.first().compareTo(other.parts.first())

--- a/src/main/kotlin/com/yourssu/scouter/hrms/implement/domain/member/Member.kt
+++ b/src/main/kotlin/com/yourssu/scouter/hrms/implement/domain/member/Member.kt
@@ -5,6 +5,7 @@ import com.yourssu.scouter.common.implement.domain.department.Department
 import com.yourssu.scouter.common.implement.domain.part.Part
 import java.time.LocalDate
 import java.time.LocalDateTime
+import java.util.SortedSet
 
 class Member(
     val id: Long? = null,
@@ -14,7 +15,7 @@ class Member(
     val birthDate: LocalDate,
     val department: Department,
     val studentId: String,
-    val parts: List<Part> = listOf(),
+    val parts: SortedSet<Part> = sortedSetOf(),
     val role: MemberRole,
     val nicknameEnglish: String,
     val nicknameKorean: String,

--- a/src/main/kotlin/com/yourssu/scouter/hrms/implement/domain/member/Member.kt
+++ b/src/main/kotlin/com/yourssu/scouter/hrms/implement/domain/member/Member.kt
@@ -28,7 +28,7 @@ class Member(
 ) : BaseTime(createdTime, updatedTime), Comparable<Member> {
 
     override fun compareTo(other: Member): Int {
-        val partCompare = parts.first().compareTo(other.parts.first())
+        val partCompare = this.parts.first().compareTo(other.parts.first())
 
         if (partCompare != 0) {
             return partCompare
@@ -48,9 +48,5 @@ class Member(
 
     override fun hashCode(): Int {
         return id?.hashCode() ?: 0
-    }
-
-    override fun toString(): String {
-        return "Member(id=$id, name='$name', email='$email', phoneNumber='$phoneNumber', birthDate=$birthDate, department=$department, studentId='$studentId', parts=$parts, role=$role, nicknameEnglish='$nicknameEnglish', nicknameKorean='$nicknameKorean', state=$state, joinDate=$joinDate, note='$note')"
     }
 }

--- a/src/main/kotlin/com/yourssu/scouter/hrms/implement/domain/member/SemesterPeriod.kt
+++ b/src/main/kotlin/com/yourssu/scouter/hrms/implement/domain/member/SemesterPeriod.kt
@@ -24,8 +24,4 @@ class SemesterPeriod(
         result = 31 * result + endSemester.hashCode()
         return result
     }
-
-    override fun toString(): String {
-        return "SemesterPeriod(startSemester=$startSemester, endSemester=$endSemester)"
-    }
 }

--- a/src/main/kotlin/com/yourssu/scouter/hrms/implement/domain/member/WithdrawnMember.kt
+++ b/src/main/kotlin/com/yourssu/scouter/hrms/implement/domain/member/WithdrawnMember.kt
@@ -6,7 +6,7 @@ class WithdrawnMember(
 ) : Comparable<WithdrawnMember> {
 
     override fun compareTo(other: WithdrawnMember): Int {
-        return other.member.updatedTime?.compareTo(member.updatedTime) ?: 0
+        return other.member.stateUpdatedTime.compareTo(member.stateUpdatedTime)
     }
 
     override fun equals(other: Any?): Boolean {

--- a/src/main/kotlin/com/yourssu/scouter/hrms/implement/domain/member/WithdrawnMember.kt
+++ b/src/main/kotlin/com/yourssu/scouter/hrms/implement/domain/member/WithdrawnMember.kt
@@ -3,7 +3,12 @@ package com.yourssu.scouter.hrms.implement.domain.member
 class WithdrawnMember(
     val id: Long? = null,
     val member: Member,
-) {
+) : Comparable<WithdrawnMember> {
+
+    override fun compareTo(other: WithdrawnMember): Int {
+        return other.member.updatedTime?.compareTo(member.updatedTime) ?: 0
+    }
+
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (javaClass != other?.javaClass) return false

--- a/src/main/kotlin/com/yourssu/scouter/hrms/implement/domain/member/WithdrawnMember.kt
+++ b/src/main/kotlin/com/yourssu/scouter/hrms/implement/domain/member/WithdrawnMember.kt
@@ -6,7 +6,7 @@ class WithdrawnMember(
 ) : Comparable<WithdrawnMember> {
 
     override fun compareTo(other: WithdrawnMember): Int {
-        return other.member.stateUpdatedTime.compareTo(member.stateUpdatedTime)
+        return other.member.stateUpdatedTime.compareTo(this.member.stateUpdatedTime)
     }
 
     override fun equals(other: Any?): Boolean {
@@ -20,9 +20,5 @@ class WithdrawnMember(
 
     override fun hashCode(): Int {
         return id.hashCode()
-    }
-
-    override fun toString(): String {
-        return "WithdrawnMember(id=$id, member=$member)"
     }
 }

--- a/src/main/kotlin/com/yourssu/scouter/hrms/storage/domain/member/ActiveMemberEntity.kt
+++ b/src/main/kotlin/com/yourssu/scouter/hrms/storage/domain/member/ActiveMemberEntity.kt
@@ -53,8 +53,4 @@ class ActiveMemberEntity(
     override fun hashCode(): Int {
         return id?.hashCode() ?: 0
     }
-
-    override fun toString(): String {
-        return "ActiveMemberEntity(id=$id, member=$member, isMembershipFeePaid=$isMembershipFeePaid)"
-    }
 }

--- a/src/main/kotlin/com/yourssu/scouter/hrms/storage/domain/member/GraduatedMemberEntity.kt
+++ b/src/main/kotlin/com/yourssu/scouter/hrms/storage/domain/member/GraduatedMemberEntity.kt
@@ -78,8 +78,4 @@ class GraduatedMemberEntity(
     override fun hashCode(): Int {
         return id?.hashCode() ?: 0
     }
-
-    override fun toString(): String {
-        return "GraduatedMemberEntity(id=$id, member=$member, activeStartSemester=$activeStartSemester, activeEndSemester=$activeEndSemester, isAdvisorDesired=$isAdvisorDesired)"
-    }
 }

--- a/src/main/kotlin/com/yourssu/scouter/hrms/storage/domain/member/InactiveMemberEntity.kt
+++ b/src/main/kotlin/com/yourssu/scouter/hrms/storage/domain/member/InactiveMemberEntity.kt
@@ -105,8 +105,4 @@ class InactiveMemberEntity(
     override fun hashCode(): Int {
         return id?.hashCode() ?: 0
     }
-
-    override fun toString(): String {
-        return "InactiveMemberEntity(id=$id, member=$member, activeStartSemester=$activeStartSemester, activeEndSemester=$activeEndSemester, expectedReturnSemester=$expectedReturnSemester, inactiveStartSemester=$inactiveStartSemester, inactiveEndSemester=$inactiveEndSemester)"
-    }
 }

--- a/src/main/kotlin/com/yourssu/scouter/hrms/storage/domain/member/JpaActiveMemberRepository.kt
+++ b/src/main/kotlin/com/yourssu/scouter/hrms/storage/domain/member/JpaActiveMemberRepository.kt
@@ -5,28 +5,22 @@ import org.springframework.data.jpa.repository.Query
 
 interface JpaActiveMemberRepository : JpaRepository<ActiveMemberEntity, Long> {
 
-    @Query(
-        """
+    @Query("""
         SELECT am FROM ActiveMemberEntity am 
         WHERE am.member.name = :name
-    """
-    )
+    """)
     fun findAllByName(name: String): List<ActiveMemberEntity>
 
-    @Query(
-        """
+    @Query("""
         SELECT am FROM ActiveMemberEntity am 
         WHERE am.member.nicknameKorean = :nicknameKorean
-    """
-    )
+    """)
     fun findAllByNicknameKoreanIgnoreCase(nicknameKorean: String): List<ActiveMemberEntity>
 
-    @Query(
-        """
+    @Query("""
         SELECT am FROM ActiveMemberEntity am 
         WHERE LOWER(am.member.nicknameEnglish) = LOWER(:nicknameEnglish)
-    """
-    )
+    """)
     fun findAllByNicknameEnglishIgnoreCase(nicknameEnglish: String): List<ActiveMemberEntity>
 
     fun findByMemberId(memberId: Long): ActiveMemberEntity?

--- a/src/main/kotlin/com/yourssu/scouter/hrms/storage/domain/member/JpaGraduatedMemberRepository.kt
+++ b/src/main/kotlin/com/yourssu/scouter/hrms/storage/domain/member/JpaGraduatedMemberRepository.kt
@@ -7,12 +7,10 @@ interface JpaGraduatedMemberRepository : JpaRepository<GraduatedMemberEntity, Lo
 
     fun findByMemberId(memberId: Long): GraduatedMemberEntity?
 
-    @Query(
-        """
+    @Query("""
         SELECT gm FROM GraduatedMemberEntity gm 
         WHERE gm.member.name = :name
-    """
-    )
+    """)
     fun findAllByName(name: String): List<GraduatedMemberEntity>
 
     @Query("""

--- a/src/main/kotlin/com/yourssu/scouter/hrms/storage/domain/member/JpaInactiveMemberRepository.kt
+++ b/src/main/kotlin/com/yourssu/scouter/hrms/storage/domain/member/JpaInactiveMemberRepository.kt
@@ -7,12 +7,10 @@ interface JpaInactiveMemberRepository : JpaRepository<InactiveMemberEntity, Long
 
     fun findByMemberId(memberId: Long): InactiveMemberEntity?
 
-    @Query(
-        """
+    @Query("""
         SELECT im FROM InactiveMemberEntity im 
         WHERE im.member.name = :name
-    """
-    )
+    """)
     fun findAllByName(name: String): List<InactiveMemberEntity>
 
     @Query("""

--- a/src/main/kotlin/com/yourssu/scouter/hrms/storage/domain/member/JpaMemberRepository.kt
+++ b/src/main/kotlin/com/yourssu/scouter/hrms/storage/domain/member/JpaMemberRepository.kt
@@ -2,5 +2,5 @@ package com.yourssu.scouter.hrms.storage.domain.member
 
 import org.springframework.data.jpa.repository.JpaRepository
 
-interface JpaMemberRepository: JpaRepository<MemberEntity, Long> {
+interface JpaMemberRepository : JpaRepository<MemberEntity, Long> {
 }

--- a/src/main/kotlin/com/yourssu/scouter/hrms/storage/domain/member/JpaWithdrawnMemberRepository.kt
+++ b/src/main/kotlin/com/yourssu/scouter/hrms/storage/domain/member/JpaWithdrawnMemberRepository.kt
@@ -5,12 +5,10 @@ import org.springframework.data.jpa.repository.Query
 
 interface JpaWithdrawnMemberRepository : JpaRepository<WithdrawnMemberEntity, Long> {
 
-    @Query(
-        """
+    @Query("""
         SELECT wm FROM WithdrawnMemberEntity wm 
         WHERE wm.member.name = :name
-    """
-    )
+    """)
     fun findAllByName(name: String): List<WithdrawnMemberEntity>
 
     @Query("""

--- a/src/main/kotlin/com/yourssu/scouter/hrms/storage/domain/member/MemberEntity.kt
+++ b/src/main/kotlin/com/yourssu/scouter/hrms/storage/domain/member/MemberEntity.kt
@@ -86,7 +86,7 @@ class MemberEntity(
         )
     }
 
-    fun toDomain(savedParts: List<Part>) = Member(
+    fun toDomain(savedParts: Collection<Part>) = Member(
         id = id,
         name = name,
         email = email,
@@ -94,7 +94,7 @@ class MemberEntity(
         birthDate = birthDate,
         department = department.toDomain(),
         studentId = studentId,
-        parts = savedParts,
+        parts = savedParts.toSortedSet(),
         role = role,
         nicknameEnglish = nicknameEnglish,
         nicknameKorean = nicknameKorean,

--- a/src/main/kotlin/com/yourssu/scouter/hrms/storage/domain/member/MemberEntity.kt
+++ b/src/main/kotlin/com/yourssu/scouter/hrms/storage/domain/member/MemberEntity.kt
@@ -124,8 +124,4 @@ class MemberEntity(
     override fun hashCode(): Int {
         return id?.hashCode() ?: 0
     }
-
-    override fun toString(): String {
-        return "MemberEntity(id=$id, name='$name', email='$email', phoneNumber='$phoneNumber', birthDate=$birthDate, department=$department, studentId='$studentId', role=$role, nicknameEnglish='$nicknameEnglish', nicknameKorean='$nicknameKorean', state=$state, joinDate=$joinDate, note='$note')"
-    }
 }

--- a/src/main/kotlin/com/yourssu/scouter/hrms/storage/domain/member/MemberEntity.kt
+++ b/src/main/kotlin/com/yourssu/scouter/hrms/storage/domain/member/MemberEntity.kt
@@ -1,6 +1,7 @@
 package com.yourssu.scouter.hrms.storage.domain.member
 
 import com.yourssu.scouter.common.implement.domain.part.Part
+import com.yourssu.scouter.common.storage.domain.basetime.BaseTimeEntity
 import com.yourssu.scouter.common.storage.domain.department.DepartmentEntity
 import com.yourssu.scouter.hrms.implement.domain.member.Member
 import com.yourssu.scouter.hrms.implement.domain.member.MemberRole
@@ -65,7 +66,7 @@ class MemberEntity(
 
     @Column(nullable = false)
     val note: String,
-) {
+) : BaseTimeEntity() {
 
     companion object {
         fun from(member: Member) = MemberEntity(
@@ -100,6 +101,8 @@ class MemberEntity(
         state = state,
         joinDate = joinDate,
         note = note,
+        createdTime = createdTime,
+        updatedTime = updatedTime,
     )
 
     override fun equals(other: Any?): Boolean {

--- a/src/main/kotlin/com/yourssu/scouter/hrms/storage/domain/member/MemberEntity.kt
+++ b/src/main/kotlin/com/yourssu/scouter/hrms/storage/domain/member/MemberEntity.kt
@@ -19,6 +19,7 @@ import jakarta.persistence.JoinColumn
 import jakarta.persistence.ManyToOne
 import jakarta.persistence.Table
 import java.time.LocalDate
+import java.time.LocalDateTime
 
 @Entity
 @Table(name = "member")
@@ -66,7 +67,11 @@ class MemberEntity(
 
     @Column(nullable = false)
     val note: String,
-) : BaseTimeEntity() {
+
+    @Column(nullable = false)
+    val stateUpdatedTime: LocalDateTime,
+
+    ) : BaseTimeEntity() {
 
     companion object {
         fun from(member: Member) = MemberEntity(
@@ -83,6 +88,7 @@ class MemberEntity(
             state = member.state,
             joinDate = member.joinDate,
             note = member.note,
+            stateUpdatedTime = member.stateUpdatedTime,
         )
     }
 
@@ -101,6 +107,7 @@ class MemberEntity(
         state = state,
         joinDate = joinDate,
         note = note,
+        stateUpdatedTime = stateUpdatedTime,
         createdTime = createdTime,
         updatedTime = updatedTime,
     )

--- a/src/main/kotlin/com/yourssu/scouter/hrms/storage/domain/member/MemberPartEntity.kt
+++ b/src/main/kotlin/com/yourssu/scouter/hrms/storage/domain/member/MemberPartEntity.kt
@@ -40,8 +40,4 @@ class MemberPartEntity(
     override fun hashCode(): Int {
         return id?.hashCode() ?: 0
     }
-
-    override fun toString(): String {
-        return "MemberPartEntity(id=$id, member=$member, part=$part)"
-    }
 }

--- a/src/main/kotlin/com/yourssu/scouter/hrms/storage/domain/member/WithdrawnMemberEntity.kt
+++ b/src/main/kotlin/com/yourssu/scouter/hrms/storage/domain/member/WithdrawnMemberEntity.kt
@@ -48,8 +48,4 @@ class WithdrawnMemberEntity(
     override fun hashCode(): Int {
         return id?.hashCode() ?: 0
     }
-
-    override fun toString(): String {
-        return "WithdrawnMemberEntity(id=$id, member=$member)"
-    }
 }


### PR DESCRIPTION
## 📄 작업 내용 요약

- 구분, 파트에 우선순위를 나타내는 필드 추가
- 액티브 멤버 정렬 시 구분 > 파트 > 가입일 순으로 정렬
- 비액티브 멤버는 복귀 희망 학기가 임박한 순으로 정렬 후 액티브 멤버 정렬 기준에 따름
- 졸업, 탈퇴 멤버는 최근에 상태가 변경된 순으로 정렬
- toString() 제거 및 전체 코드 재정렬

## 📎 Issue 번호
<!-- closed #번호 -->
