### PR TITLE
feat: #20 지원자 목록 조회 시 정렬 기준 적용하는 기능 추가

### DIFF
--- a/src/main/kotlin/com/yourssu/scouter/ats/business/domain/applicant/ApplicantService.kt
+++ b/src/main/kotlin/com/yourssu/scouter/ats/business/domain/applicant/ApplicantService.kt
@@ -40,27 +40,27 @@ class ApplicantService(
     }
 
     fun readAll(): List<ApplicantDto> {
-        val applicants: List<Applicant> = applicantReader.readAll()
+        val applicants: List<Applicant> = applicantReader.readAll().sorted()
 
         return applicants.map { ApplicantDto.from(it) }
     }
 
     fun searchByName(name: String): List<ApplicantDto> {
-        val applicants: List<Applicant> = applicantReader.searchAlByName(name)
+        val applicants: List<Applicant> = applicantReader.searchAlByName(name).sorted()
 
         return applicants.map { ApplicantDto.from(it) }
     }
 
     fun filterByState(state: String): List<ApplicantDto> {
         val applicantState: ApplicantState = ApplicantStateConverter.convertToEnum(state)
-        val applicants: List<Applicant> = applicantReader.filterByState(applicantState)
+        val applicants: List<Applicant> = applicantReader.filterByState(applicantState).sorted()
 
         return applicants.map { ApplicantDto.from(it) }
     }
 
     fun filterBySemester(semesterId: Long): List<ApplicantDto> {
         val semester: Semester = semesterReader.readById(semesterId)
-        val applicants: List<Applicant> = applicantReader.filterBySemester(semester)
+        val applicants: List<Applicant> = applicantReader.filterBySemester(semester).sorted()
 
         return applicants.map { ApplicantDto.from(it) }
     }

--- a/src/main/kotlin/com/yourssu/scouter/ats/implement/domain/applicant/Applicant.kt
+++ b/src/main/kotlin/com/yourssu/scouter/ats/implement/domain/applicant/Applicant.kt
@@ -18,7 +18,16 @@ class Applicant(
     val applicationDateTime: LocalDateTime,
     val applicationSemester: Semester,
     val academicSemester: String,
-) {
+) : Comparable<Applicant> {
+
+    override fun compareTo(other: Applicant): Int {
+        val partCompare = this.part.compareTo(other.part)
+        if (partCompare != 0) {
+            return partCompare
+        }
+
+        return this.applicationDateTime.compareTo(other.applicationDateTime)
+    }
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true


### PR DESCRIPTION
## 📄 작업 내용 요약

- 지원자 도메인에 Comparable 구현
- 파트별 > 지원날짜 순으로 정렬

## 📎 Issue 번호
- closed #20 
