### PR TITLE
feat: #36 최종합격 지원자를 합격자 구글폼 응답을 바탕으로 동아리 멤버에 반영하는 api 추가

### DIFF
--- a/src/main/kotlin/com/yourssu/scouter/ats/application/domain/applicant/ApplicantController.kt
+++ b/src/main/kotlin/com/yourssu/scouter/ats/application/domain/applicant/ApplicantController.kt
@@ -34,25 +34,25 @@ class ApplicantController(
         return ResponseEntity.created(URI.create("/applicants/$applicantId")).build()
     }
 
-    @PostMapping("/applicants/include-from-forms/{semesterString}")
+    @PostMapping("/applicants/include-from-forms")
     fun includeFromForms(
         @RequestHeader(HttpHeaders.AUTHORIZATION) authorization: String,
-        @PathVariable(required = false) semesterString: String,
     ): ResponseEntity<ApplicantSyncResult> {
         val authUserId = authorization.toLong() // TODO: 임시로 사용자 ID를 Authorization 헤더에서 추출하는 방식으로 구현
 
-        val result: ApplicantSyncResult = applicantSyncService.includeApplicantsFromForms(authUserId, semesterString)
+        val result: ApplicantSyncResult = applicantSyncService.includeFromForms(authUserId)
 
         return ResponseEntity.ok(result)
     }
 
-    @PostMapping("/applicants/include-from-forms")
-    fun includeFromForms2(
+    @PostMapping("/applicants/include-from-forms/{semesterString}")
+    fun includeFromForms(
         @RequestHeader(HttpHeaders.AUTHORIZATION) authorization: String,
+        @PathVariable semesterString: String,
     ): ResponseEntity<ApplicantSyncResult> {
         val authUserId = authorization.toLong() // TODO: 임시로 사용자 ID를 Authorization 헤더에서 추출하는 방식으로 구현
 
-        val result: ApplicantSyncResult = applicantSyncService.includeApplicantsFromForms(authUserId)
+        val result: ApplicantSyncResult = applicantSyncService.includeFromForms(authUserId, semesterString)
 
         return ResponseEntity.ok(result)
     }

--- a/src/main/kotlin/com/yourssu/scouter/ats/business/domain/applicant/ApplicantSyncService.kt
+++ b/src/main/kotlin/com/yourssu/scouter/ats/business/domain/applicant/ApplicantSyncService.kt
@@ -30,7 +30,7 @@ class ApplicantSyncService(
     private val googleFormsReader: GoogleFormsReader,
 ) {
 
-    fun includeApplicantsFromForms(
+    fun includeFromForms(
         authUserId: Long,
         targetSemester: String? = null,
     ): ApplicantSyncResult {

--- a/src/main/kotlin/com/yourssu/scouter/ats/business/domain/applicant/ApplicantSyncService.kt
+++ b/src/main/kotlin/com/yourssu/scouter/ats/business/domain/applicant/ApplicantSyncService.kt
@@ -98,7 +98,7 @@ class ApplicantSyncService(
 
         return Applicant(
             name = responseMap["이름"] ?: "",
-            email = userResponse.respondentEmail,
+            email = userResponse.respondentEmail ?: "",
             phoneNumber = responseMap["연락처"] ?: "",
             age = responseMap["나이"] ?: "",
             department = responseMap["학과(부)"] ?: "",

--- a/src/main/kotlin/com/yourssu/scouter/common/business/domain/authentication/OAuth2Service.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/business/domain/authentication/OAuth2Service.kt
@@ -2,6 +2,7 @@ package com.yourssu.scouter.common.business.domain.authentication
 
 import com.yourssu.scouter.common.implement.domain.authentication.OAuth2Handler
 import com.yourssu.scouter.common.implement.domain.authentication.OAuth2HandlerComposite
+import com.yourssu.scouter.common.implement.domain.authentication.OAuth2TokenInfo
 import com.yourssu.scouter.common.implement.domain.authentication.OAuth2Type
 import com.yourssu.scouter.common.implement.domain.authentication.OAuth2User
 import org.springframework.stereotype.Service
@@ -21,5 +22,11 @@ class OAuth2Service(
         val oauth2Handler: OAuth2Handler = oauth2HandlerComposite.findHandler(oauth2Type)
 
         return oauth2Handler.fetchOAuth2User(authorizationCode)
+    }
+
+    fun refreshAccessToken(oauth2Type: OAuth2Type, bearerRefreshToken: String): OAuth2TokenInfo {
+        val oauth2Handler: OAuth2Handler = oauth2HandlerComposite.findHandler(oauth2Type)
+
+        return oauth2Handler.refreshAccessToken(bearerRefreshToken)
     }
 }

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/support/google/GoogleFormsClient.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/support/google/GoogleFormsClient.kt
@@ -46,7 +46,7 @@ data class GoogleFormResponses(
 data class GoogleUserResponse(
     val responseId: String,
     val createTime: String,
-    val respondentEmail: String,
+    val respondentEmail: String?,
     val lastSubmittedTime: String,
     val answers: Map<String, Answer>
 )

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/support/google/UserResponse.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/support/google/UserResponse.kt
@@ -5,7 +5,7 @@ import java.time.LocalDateTime
 data class UserResponse(
     val responseId: String,
     val createTime: LocalDateTime,
-    val respondentEmail: String,
+    val respondentEmail: String?,
     val lastSubmittedTime: LocalDateTime,
     val responseItems: List<ResponseItem>
 ) {
@@ -13,7 +13,7 @@ data class UserResponse(
     constructor(
         responseId: String,
         createTime: String,
-        respondentEmail: String,
+        respondentEmail: String?,
         lastSubmittedTime: String,
         responseItems: List<ResponseItem>,
     ) : this(

--- a/src/main/kotlin/com/yourssu/scouter/hrms/application/domain/member/MemberController.kt
+++ b/src/main/kotlin/com/yourssu/scouter/hrms/application/domain/member/MemberController.kt
@@ -4,24 +4,52 @@ import com.yourssu.scouter.hrms.business.domain.member.ActiveMemberDto
 import com.yourssu.scouter.hrms.business.domain.member.GraduatedMemberDto
 import com.yourssu.scouter.hrms.business.domain.member.InactiveMemberDto
 import com.yourssu.scouter.hrms.business.domain.member.MemberService
+import com.yourssu.scouter.hrms.business.domain.member.MemberSyncResult
+import com.yourssu.scouter.hrms.business.domain.member.MemberSyncService
 import com.yourssu.scouter.hrms.business.domain.member.UpdateActiveMemberCommand
 import com.yourssu.scouter.hrms.business.domain.member.UpdateGraduatedMemberCommand
 import com.yourssu.scouter.hrms.business.domain.member.UpdateInactiveMemberCommand
 import com.yourssu.scouter.hrms.business.domain.member.UpdateWithdrawnMemberCommand
 import com.yourssu.scouter.hrms.business.domain.member.WithdrawnMemberDto
 import jakarta.validation.Valid
+import org.springframework.http.HttpHeaders
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestHeader
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
 class MemberController(
     private val memberService: MemberService,
+    private val memberSyncService: MemberSyncService,
 ) {
+
+    @PostMapping("/members/include-from-applicants")
+    fun includeFromApplicants(
+        @RequestHeader(HttpHeaders.AUTHORIZATION) authorization: String,
+    ): ResponseEntity<MemberSyncResult> {
+        val authUserId = authorization.toLong() // TODO: 임시로 사용자 ID를 Authorization 헤더에서 추출하는 방식으로 구현
+        val result: MemberSyncResult = memberSyncService.includeAcceptedApplicants(authUserId)
+
+        return ResponseEntity.ok(result)
+    }
+
+    @PostMapping("/members/include-from-applicants/{semesterString}")
+    fun includeFromApplicants(
+        @RequestHeader(HttpHeaders.AUTHORIZATION) authorization: String,
+        @PathVariable semesterString: String,
+    ): ResponseEntity<MemberSyncResult> {
+        val authUserId = authorization.toLong() // TODO: 임시로 사용자 ID를 Authorization 헤더에서 추출하는 방식으로 구현
+        val result: MemberSyncResult =
+            memberSyncService.includeAcceptedApplicants(authUserId, semesterString)
+
+        return ResponseEntity.ok(result)
+    }
 
     @GetMapping("/members/active")
     fun readAllActive(

--- a/src/main/kotlin/com/yourssu/scouter/hrms/business/domain/member/MemberService.kt
+++ b/src/main/kotlin/com/yourssu/scouter/hrms/business/domain/member/MemberService.kt
@@ -42,6 +42,14 @@ class MemberService(
         return writtenActiveMember.id!!
     }
 
+    fun createMemberWithActiveStateIfNotExists(newMember: Member) {
+        if (memberReader.existsByStudentId(newMember.studentId)) {
+            return
+        }
+
+        memberWriter.writeMemberWithActiveStatus(newMember)
+    }
+
     fun readAllActive(): List<ActiveMemberDto> {
         val members: List<ActiveMember> = memberReader.readAllActive().sorted()
 

--- a/src/main/kotlin/com/yourssu/scouter/hrms/business/domain/member/MemberSyncResult.kt
+++ b/src/main/kotlin/com/yourssu/scouter/hrms/business/domain/member/MemberSyncResult.kt
@@ -1,0 +1,5 @@
+package com.yourssu.scouter.hrms.business.domain.member
+
+data class MemberSyncResult(
+    val failureMessages: List<String>,
+)

--- a/src/main/kotlin/com/yourssu/scouter/hrms/business/domain/member/MemberSyncService.kt
+++ b/src/main/kotlin/com/yourssu/scouter/hrms/business/domain/member/MemberSyncService.kt
@@ -1,0 +1,153 @@
+package com.yourssu.scouter.hrms.business.domain.member
+
+import com.yourssu.scouter.ats.implement.domain.applicant.Applicant
+import com.yourssu.scouter.ats.implement.domain.applicant.ApplicantReader
+import com.yourssu.scouter.ats.implement.domain.applicant.ApplicantState
+import com.yourssu.scouter.common.business.support.utils.SemesterConverter
+import com.yourssu.scouter.common.implement.domain.authentication.OAuth2TokenInfo
+import com.yourssu.scouter.common.implement.domain.department.Department
+import com.yourssu.scouter.common.implement.domain.department.DepartmentReader
+import com.yourssu.scouter.common.implement.domain.user.User
+import com.yourssu.scouter.common.implement.domain.user.UserReader
+import com.yourssu.scouter.common.implement.domain.user.UserWriter
+import com.yourssu.scouter.common.implement.support.google.GoogleDriveFile
+import com.yourssu.scouter.common.implement.support.google.GoogleDriveMimeType
+import com.yourssu.scouter.common.implement.support.google.GoogleDriveQueryBuilder
+import com.yourssu.scouter.common.implement.support.google.GoogleDriveReader
+import com.yourssu.scouter.common.implement.support.google.GoogleFormsReader
+import com.yourssu.scouter.common.implement.support.security.oauth2.GoogleOAuth2Handler
+import com.yourssu.scouter.hrms.business.support.utils.NicknameConverter
+import com.yourssu.scouter.hrms.implement.domain.member.Member
+import com.yourssu.scouter.hrms.implement.domain.member.MemberRole
+import com.yourssu.scouter.hrms.implement.domain.member.MemberState
+import java.time.LocalDate
+import java.time.LocalDateTime
+import org.springframework.stereotype.Service
+
+@Service
+class MemberSyncService(
+    private val userReader: UserReader,
+    private val userWriter: UserWriter,
+    private val applicantReader: ApplicantReader,
+    private val departmentReader: DepartmentReader,
+    private val memberService: MemberService,
+    private val googleOAuth2Handler: GoogleOAuth2Handler,
+    private val googleDriveReader: GoogleDriveReader,
+    private val googleFormsReader: GoogleFormsReader,
+) {
+
+    fun includeMembersFromAcceptedApplicants(
+        authUserId: Long,
+        targetSemester: String? = null,
+    ): MemberSyncResult {
+        val acceptedApplicants: List<Applicant> = applicantReader.filterByState(ApplicantState.FINAL_ACCEPTED)
+        val authUser: User = getAuthUserWithValidToken(authUserId)
+        val googleAccessToken: String = authUser.getBearerAccessToken()
+        val targetSemesterString = targetSemester ?: SemesterConverter.convertToIntString(LocalDate.now())
+        val query: String = GoogleDriveQueryBuilder()
+            .nameContainsAll("면접 합격자 정보 입력 서베이", targetSemesterString)
+            .mimeType(GoogleDriveMimeType.FORM)
+            .build()
+
+        val forms: List<GoogleDriveFile> = googleDriveReader.getFiles(googleAccessToken, query)
+        val additionalInfos = processForms(googleAccessToken, forms)
+
+        val failureMessages: List<String> =
+            mergeToActiveMemberAndReturnFailMessages(acceptedApplicants, additionalInfos)
+
+        return MemberSyncResult(failureMessages)
+    }
+
+    private fun mergeToActiveMemberAndReturnFailMessages(
+        acceptedApplicants: List<Applicant>,
+        additionalInfos: List<AcceptedApplicantResponse>,
+    ): List<String> {
+        val departments: List<Department> = departmentReader.readAll()
+        val failureMessages = mutableListOf<String>()
+        val acceptedApplicantsMap = acceptedApplicants.associateBy { it.studentId }
+        val acceptedResponseMap = additionalInfos.associateBy { it.studentId }
+        for ((studentId, applicant) in acceptedApplicantsMap) {
+            val additionalInfo: AcceptedApplicantResponse? = acceptedResponseMap[studentId]
+            if (additionalInfo == null) {
+                failureMessages.add("${applicant.name}(${applicant.studentId}) - 합격자 정보 입력 서베이 응답 X")
+                continue
+            }
+            val department: Department? =
+                departments.find { normalizeString(applicant.department).contains(normalizeString(it.name)) }
+            if (department == null) {
+                failureMessages.add("${applicant.name}(${applicant.studentId}) - [${applicant.department}]에 해당하는 학과가 존재하지 않음")
+                continue
+            }
+
+            val newMember = Member(
+                name = applicant.name,
+                email = additionalInfo.yourssuEmail,
+                phoneNumber = applicant.phoneNumber,
+                birthDate = additionalInfo.birthDate,
+                department = department,
+                studentId = applicant.studentId,
+                parts = sortedSetOf(applicant.part),
+                role = MemberRole.MEMBER,
+                nicknameEnglish = NicknameConverter.extractNickname(additionalInfo.nickname),
+                nicknameKorean = NicknameConverter.extractPronunciation(additionalInfo.nickname),
+                state = MemberState.ACTIVE,
+                joinDate = LocalDate.now(),
+                note = "",
+                stateUpdatedTime = LocalDateTime.now(),
+            )
+
+            memberService.createMemberWithActiveStateIfNotExists(newMember)
+        }
+
+        return failureMessages
+    }
+
+    private fun processForms(
+        googleAccessToken: String,
+        forms: List<GoogleDriveFile>
+    ): List<AcceptedApplicantResponse> {
+        return forms.map { form ->
+            mapResponsesToAdditionalInfos(googleAccessToken, form)
+        }.flatten()
+    }
+
+    private fun mapResponsesToAdditionalInfos(
+        googleAccessToken: String,
+        form: GoogleDriveFile
+    ): List<AcceptedApplicantResponse> {
+        return googleFormsReader.getUserResponses(googleAccessToken, form.id)
+            .map { userResponse ->
+                val responseMap = userResponse.responseItems.associate { it.question to it.answer }
+                AcceptedApplicantResponse(
+                    studentId = responseMap.entries.firstOrNull { it.key.contains("학번") }?.value ?: "",
+                    nickname = responseMap.entries.firstOrNull { it.key.contains("닉네임") }?.value ?: "",
+                    yourssuEmail = responseMap.entries.firstOrNull { it.key.contains("메일") }?.value ?: "",
+                    birthDate = LocalDate.parse(
+                        responseMap.entries.firstOrNull { it.key.contains("생일") }?.value ?: ""
+                    )
+                )
+            }
+    }
+
+    private fun normalizeString(value: String): String = value.replace(" ", "").lowercase()
+
+    private fun getAuthUserWithValidToken(authUserId: Long): User {
+        val authUser: User = userReader.readById(authUserId)
+        if (authUser.isAccessTokenRemainMoreThan(10)) {
+            return authUser
+        }
+
+        val newAccessTokenInfo: OAuth2TokenInfo =
+            googleOAuth2Handler.refreshAccessToken(authUser.getBearerRefreshToken())
+        authUser.updateToken(newAccessTokenInfo)
+
+        return userWriter.write(authUser)
+    }
+}
+
+data class AcceptedApplicantResponse(
+    val studentId: String,
+    val nickname: String,
+    val yourssuEmail: String,
+    val birthDate: LocalDate,
+)

--- a/src/main/kotlin/com/yourssu/scouter/hrms/business/domain/member/MemberSyncService.kt
+++ b/src/main/kotlin/com/yourssu/scouter/hrms/business/domain/member/MemberSyncService.kt
@@ -32,7 +32,7 @@ class MemberSyncService(
     private val googleFormsReader: GoogleFormsReader,
 ) {
 
-    fun includeMembersFromAcceptedApplicants(
+    fun includeAcceptedApplicants(
         authUserId: Long,
         targetSemester: String? = null,
     ): MemberSyncResult {

--- a/src/main/kotlin/com/yourssu/scouter/hrms/implement/domain/member/MemberReader.kt
+++ b/src/main/kotlin/com/yourssu/scouter/hrms/implement/domain/member/MemberReader.kt
@@ -89,4 +89,8 @@ class MemberReader(
         return graduatedMemberRepository.findByMemberId(memberId)
             ?: throw MemberNotFoundException("해당하는 멤버를 찾을 수 없습니다.")
     }
+
+    fun existsByStudentId(studentId: String): Boolean {
+        return memberRepository.existsByStudentId(studentId)
+    }
 }

--- a/src/main/kotlin/com/yourssu/scouter/hrms/implement/domain/member/MemberRepository.kt
+++ b/src/main/kotlin/com/yourssu/scouter/hrms/implement/domain/member/MemberRepository.kt
@@ -4,4 +4,5 @@ interface MemberRepository {
 
     fun save(member: Member): Member
     fun findById(memberId: Long): Member?
+    fun existsByStudentId(studentId: String): Boolean
 }

--- a/src/main/kotlin/com/yourssu/scouter/hrms/storage/domain/member/JpaMemberRepository.kt
+++ b/src/main/kotlin/com/yourssu/scouter/hrms/storage/domain/member/JpaMemberRepository.kt
@@ -3,4 +3,6 @@ package com.yourssu.scouter.hrms.storage.domain.member
 import org.springframework.data.jpa.repository.JpaRepository
 
 interface JpaMemberRepository : JpaRepository<MemberEntity, Long> {
+
+    fun existsByStudentId(studentId: String): Boolean
 }

--- a/src/main/kotlin/com/yourssu/scouter/hrms/storage/domain/member/MemberRepositoryImpl.kt
+++ b/src/main/kotlin/com/yourssu/scouter/hrms/storage/domain/member/MemberRepositoryImpl.kt
@@ -40,4 +40,8 @@ class MemberRepositoryImpl(
 
         return memberEntity.toDomain(parts)
     }
+
+    override fun existsByStudentId(studentId: String): Boolean {
+        return jpaMemberRepository.existsByStudentId(studentId)
+    }
 }


### PR DESCRIPTION
## 📄 작업 내용 요약

- 지원자 중 상태가 `최종합격`인 지원자 정보를 멤버에 반영하는 기능
  - 지원자 도메인 엔티티에는 닉네임과 동아리 메일, 생일 등의 정보가 존재하지 않음
  - 동아리 리쿠리팅 합격 시 합격자 정보를 별도의 구글폼으로 입력받고 있음
  - 해당 구글폼 응답의 학번과 최종합격 지원자의 학번이 일치하면 동일한 학생으로 판단
  → `최종합격자 구글폼 응답`과 `최종합격 지원자 도메인 엔티티`의 정보를 활용하여 `멤버 도메인 엔티티` 생성 후 저장

## 📎 Issue 번호
- closed #36 
