### PR TITLE
fix: #68 회원가입, 재로그인 시 발생하는 오류 해결

### DIFF
--- a/src/main/kotlin/com/yourssu/scouter/common/application/support/exception/CommonExceptionHandler.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/application/support/exception/CommonExceptionHandler.kt
@@ -19,6 +19,7 @@ class CommonExceptionHandler: ResponseEntityExceptionHandler() {
 
     companion object {
         private const val METHOD_ARGUMENT_NOT_VALID_EXCEPTION_ERROR_CODE = "Request-Validation-Fail"
+        private const val LOG_MESSAGE_FORMAT = "%s : %s"
     }
 
     override fun handleExceptionInternal(
@@ -28,6 +29,8 @@ class CommonExceptionHandler: ResponseEntityExceptionHandler() {
         statusCode: HttpStatusCode,
         request: WebRequest
     ): ResponseEntity<Any>? {
+        logger.error(String.format(LOG_MESSAGE_FORMAT, ex.javaClass.simpleName, ex.message), ex)
+
         val response = ExceptionResponse(
             status = HttpStatus.valueOf(statusCode.value()),
             errorCode = "Internal-Server-Error",
@@ -43,6 +46,8 @@ class CommonExceptionHandler: ResponseEntityExceptionHandler() {
         status: HttpStatusCode,
         request: WebRequest
     ): ResponseEntity<Any>? {
+        logger.warn(String.format(LOG_MESSAGE_FORMAT, ex.javaClass.simpleName, ex.message), ex)
+
         val message = ex.fieldErrors
             .stream()
             .map { obj: FieldError -> obj.defaultMessage }
@@ -59,6 +64,8 @@ class CommonExceptionHandler: ResponseEntityExceptionHandler() {
         status: HttpStatusCode,
         request: WebRequest
     ): ResponseEntity<Any>? {
+        logger.warn(String.format(LOG_MESSAGE_FORMAT, ex.javaClass.simpleName, ex.message), ex)
+
         val response = ExceptionResponse(
             status = HttpStatus.BAD_REQUEST,
             errorCode = "Request-Validation-Fail",
@@ -70,13 +77,15 @@ class CommonExceptionHandler: ResponseEntityExceptionHandler() {
     }
 
     @ExceptionHandler(CustomException::class)
-    fun handleCustomException(e: CustomException): ResponseEntity<ExceptionResponse> {
+    fun handleCustomException(ex: CustomException): ResponseEntity<ExceptionResponse> {
+        logger.warn(String.format(LOG_MESSAGE_FORMAT, ex.javaClass.simpleName, ex.message), ex)
+
         val response = ExceptionResponse(
-            status = e.status,
-            errorCode = e.errorCode,
-            message = e.message
+            status = ex.status,
+            errorCode = ex.errorCode,
+            message = ex.message
         )
 
-        return ResponseEntity.status(e.status).body(response)
+        return ResponseEntity.status(ex.status).body(response)
     }
 }

--- a/src/main/kotlin/com/yourssu/scouter/common/application/support/exception/CommonExceptionHandler.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/application/support/exception/CommonExceptionHandler.kt
@@ -2,43 +2,71 @@ package com.yourssu.scouter.common.application.support.exception
 
 import com.yourssu.scouter.common.implement.support.exception.CustomException
 import java.util.stream.Collectors
+import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatus
+import org.springframework.http.HttpStatusCode
 import org.springframework.http.ResponseEntity
 import org.springframework.http.converter.HttpMessageNotReadableException
 import org.springframework.validation.FieldError
 import org.springframework.web.bind.MethodArgumentNotValidException
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestControllerAdvice
+import org.springframework.web.context.request.WebRequest
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler
 
 @RestControllerAdvice
-class CommonExceptionHandler {
+class CommonExceptionHandler: ResponseEntityExceptionHandler() {
 
     companion object {
         private const val METHOD_ARGUMENT_NOT_VALID_EXCEPTION_ERROR_CODE = "Request-Validation-Fail"
     }
 
-    @ExceptionHandler(MethodArgumentNotValidException::class)
-    fun handleMethodArgumentNotValidException(
-        e: MethodArgumentNotValidException,
-    ): ResponseEntity<ExceptionResponse> {
-        val message = e.fieldErrors
+    override fun handleExceptionInternal(
+        ex: Exception,
+        body: Any?,
+        headers: HttpHeaders,
+        statusCode: HttpStatusCode,
+        request: WebRequest
+    ): ResponseEntity<Any>? {
+        val response = ExceptionResponse(
+            status = HttpStatus.valueOf(statusCode.value()),
+            errorCode = "Internal-Server-Error",
+            message = ex.message ?: "Internal server error"
+        )
+
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(response)
+    }
+
+    override fun handleMethodArgumentNotValid(
+        ex: MethodArgumentNotValidException,
+        headers: HttpHeaders,
+        status: HttpStatusCode,
+        request: WebRequest
+    ): ResponseEntity<Any>? {
+        val message = ex.fieldErrors
             .stream()
             .map { obj: FieldError -> obj.defaultMessage }
             .collect(Collectors.joining("\n"))
 
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
             .body(ExceptionResponse(HttpStatus.BAD_REQUEST, METHOD_ARGUMENT_NOT_VALID_EXCEPTION_ERROR_CODE, message))
+
     }
 
-    @ExceptionHandler(HttpMessageNotReadableException::class)
-    fun handleHttpMessageNotReadableException(e: HttpMessageNotReadableException): ResponseEntity<ExceptionResponse> {
+    override fun handleHttpMessageNotReadable(
+        ex: HttpMessageNotReadableException,
+        headers: HttpHeaders,
+        status: HttpStatusCode,
+        request: WebRequest
+    ): ResponseEntity<Any>? {
         val response = ExceptionResponse(
             status = HttpStatus.BAD_REQUEST,
             errorCode = "Request-Validation-Fail",
-            message = e.message ?: "Request body is invalid"
+            message = ex.message ?: "Request body is invalid"
         )
 
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response)
+
     }
 
     @ExceptionHandler(CustomException::class)

--- a/src/main/kotlin/com/yourssu/scouter/common/business/domain/authentication/OAuth2Service.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/business/domain/authentication/OAuth2Service.kt
@@ -57,6 +57,7 @@ class OAuth2Service(
         if (findUser != null) {
             findUser.updateToken(oauth2User.token)
             userWriter.write(findUser)
+            return findUser
         }
 
         return userWriter.write(oauth2User)

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/support/security/oauth2/GoogleOAuth2Handler.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/support/security/oauth2/GoogleOAuth2Handler.kt
@@ -5,6 +5,7 @@ import com.yourssu.scouter.common.implement.domain.authentication.OAuth2TokenInf
 import com.yourssu.scouter.common.implement.domain.authentication.OAuth2Type
 import com.yourssu.scouter.common.implement.domain.authentication.OAuth2User
 import com.yourssu.scouter.common.implement.domain.authentication.OAuth2UserInfo
+import java.util.UUID
 import org.springframework.stereotype.Component
 import org.springframework.util.LinkedMultiValueMap
 import org.springframework.web.util.UriComponentsBuilder
@@ -83,12 +84,17 @@ class GoogleOAuth2Handler(
     private fun fetchUserInfo(typeSpecifiedAccessToken: String): OAuth2UserInfo {
         val userInfoResponse = googleUserApiClient.fetchUserInfo(typeSpecifiedAccessToken)
 
+        val name: String =
+            userInfoResponse.name
+                ?: userInfoResponse.givenName
+                ?: userInfoResponse.familyName
+                ?: UUID.randomUUID().toString()
         return OAuth2UserInfo(
             oauthId = userInfoResponse.id,
             oauth2Type = getSupportingOAuth2Type(),
-            name = userInfoResponse.name,
+            name = name,
             email = userInfoResponse.email,
-            profileImageUrl = userInfoResponse.picture,
+            profileImageUrl = userInfoResponse.picture ?: "",
         )
     }
 }

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/support/security/oauth2/GoogleUserApiClient.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/support/security/oauth2/GoogleUserApiClient.kt
@@ -20,10 +20,10 @@ interface GoogleUserApiClient {
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy::class)
 data class GoogleUserInfoResponse(
     val id: String,
-    val name: String,
+    val name: String? = null,
     val email: String,
-    val picture: String,
-    val familyName: String,
-    val givenName: String,
-    val verifiedEmail: Boolean,
+    val picture: String? = null,
+    val familyName: String? = null,
+    val givenName: String? = null,
+    val verifiedEmail: Boolean? = null,
 )


### PR DESCRIPTION
## 📄 작업 내용 요약
- 구글 사용자 정보 가져올 때 null 값 허용
- 로그아웃 후 재로그인 시 예외가 발생하는 문제 해결
- 전역 예외처리 핸들러 추가
- 예외처리 핸들러에 로깅 추가

## 📎 Issue 번호
- closed #68 
