### PR TITLE
fix: #74 멤버 정보 변경 시 파트를 빈 배열로 한 이후 멤버 목록 조회 시 에러가 발생하는 버그 해결

### DIFF
--- a/src/main/kotlin/com/yourssu/scouter/common/implement/domain/semester/SemesterReader.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/domain/semester/SemesterReader.kt
@@ -17,7 +17,7 @@ class SemesterReader(
 
     fun read(semester: Semester): Semester {
         return semesterRepository.find(semester)
-            ?: throw SemesterNotFoundException("${semester}에 해당하는 학기 정보를 찾을 수 없습니다.")
+            ?: throw SemesterNotFoundException("${semester.year}-${semester.term.intValue}에 해당하는 학기 정보를 찾을 수 없습니다.")
     }
 
     fun readAll(): List<Semester> = semesterRepository.findAll()

--- a/src/main/kotlin/com/yourssu/scouter/hrms/business/domain/member/MemberService.kt
+++ b/src/main/kotlin/com/yourssu/scouter/hrms/business/domain/member/MemberService.kt
@@ -220,6 +220,9 @@ class MemberService(
             return
         }
 
+        val updateParts = if (command.partIds.isNullOrEmpty()) target.parts
+                          else partReader.readAllByIds(command.partIds).toSortedSet()
+
         val updateMember = Member(
             id = target.id,
             name = command.name ?: target.name,
@@ -228,7 +231,7 @@ class MemberService(
             birthDate = command.birthDate ?: target.birthDate,
             department = command.departmentId?.let { departmentReader.readById(it) } ?: target.department,
             studentId = command.studentId ?: target.studentId,
-            parts = command.partIds?.let { partReader.readAllByIds(it).toSortedSet() } ?: target.parts,
+            parts = updateParts,
             role = target.role,
             nicknameEnglish = command.nicknameEnglish ?: target.nicknameEnglish,
             nicknameKorean = command.nicknameKorean ?: target.nicknameKorean,
@@ -263,7 +266,7 @@ class MemberService(
         var newNote = ""
         if (newRole in listOf(MemberRole.LEAD, MemberRole.VICE_LEAD)) {
             val (currentYear, currentTerm) = Semester.of(LocalDate.now()).run { year to term.intValue }
-            val partName: String = target.parts.first().name // TODO : 1멤버 2파트인 경우 어떻게 처리할지 물어보고 수정하기
+            val partName: String = target.parts.first().name
             val newRoleName: String = MemberRoleConverter.convertToString(newRole)
 
             newNote = "${currentYear}년 ${currentTerm}학기 $partName 파트 $newRoleName 역임\n"


### PR DESCRIPTION
## 📄 작업 내용 요약
[문제]
- 멤버 정보 변경 시 파트가 빈 배열인 경우 요청은 정상처리되지만, 이후에 멤버 목록 조회 시 Internal Server Error 발생

[원인]
- 멤버 목록 조회 시 정렬할 때 멤버의 첫 번째 파트를 기준으로 정렬하고 있음
- 멤버 정보 변경 시 파트를 빈 배열로 하면 파트가 없는 것으로 처리되어서 멤버 도메인은 파트 정보를 빈 리스트로 들고 있음
- 멤버 정렬 시 첫 번째 파트를 기준으로 정렬하는데 첫 번째 파트가 없기 때문에 에러 발생

[해결]
- 서비스 규칙 상 모든 멤버는 하나 이상의 파트를 맡고 있어야 함
- 프론트에서 빈 리스트를 보내는 경우는 해당 멤버가 맡고 있는 파트가 없어서가 아니라, 파트를 변경하지 않았기 때문임
- 따라서, 멤버 정보 수정 요청에서 파트가 빈 배열일 경우, 파트를 null로 보낸 경우와 동일하게 처리(파트를 변경하지 않은 것으로 처리)하도록 수정

## 📎 Issue 번호
- closed #74 
