### PR TITLE
refactor: #81 구글폼에서 지원자 정보를 불러오는 로직 리팩토링

### DIFF
--- a/src/main/kotlin/com/yourssu/scouter/ats/application/domain/applicant/ApplicantController.kt
+++ b/src/main/kotlin/com/yourssu/scouter/ats/application/domain/applicant/ApplicantController.kt
@@ -37,20 +37,22 @@ class ApplicantController(
     @PostMapping("/applicants/include-from-forms")
     fun includeFromForms(
         @AuthUser authUserInfo: AuthUserInfo,
-    ): ResponseEntity<ApplicantSyncResult> {
+    ): ResponseEntity<ApplicantSyncResponse> {
         val result: ApplicantSyncResult = applicantSyncService.includeFromForms(authUserInfo.userId)
+        val response: ApplicantSyncResponse = ApplicantSyncResponse.from(result)
 
-        return ResponseEntity.ok(result)
+        return ResponseEntity.ok(response)
     }
 
     @PostMapping("/applicants/include-from-forms/{semesterString}")
     fun includeFromForms(
         @AuthUser authUserInfo: AuthUserInfo,
         @PathVariable semesterString: String,
-    ): ResponseEntity<ApplicantSyncResult> {
+    ): ResponseEntity<ApplicantSyncResponse> {
         val result: ApplicantSyncResult = applicantSyncService.includeFromForms(authUserInfo.userId, semesterString)
+        val response: ApplicantSyncResponse = ApplicantSyncResponse.from(result)
 
-        return ResponseEntity.ok(result)
+        return ResponseEntity.ok(response)
     }
 
     @GetMapping("/applicants")

--- a/src/main/kotlin/com/yourssu/scouter/ats/application/domain/applicant/ApplicantSyncResponse.kt
+++ b/src/main/kotlin/com/yourssu/scouter/ats/application/domain/applicant/ApplicantSyncResponse.kt
@@ -1,0 +1,16 @@
+package com.yourssu.scouter.ats.application.domain.applicant
+
+import com.yourssu.scouter.ats.business.domain.applicant.ApplicantSyncResult
+
+data class ApplicantSyncResponse(
+    val successes: List<String>,
+    val failures: List<String>,
+) {
+
+    companion object {
+        fun from(result: ApplicantSyncResult) = ApplicantSyncResponse(
+            successes = result.successeMessages,
+            failures = result.failureMessages,
+        )
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/ats/business/domain/applicant/ApplicantSyncResult.kt
+++ b/src/main/kotlin/com/yourssu/scouter/ats/business/domain/applicant/ApplicantSyncResult.kt
@@ -1,23 +1,6 @@
 package com.yourssu.scouter.ats.business.domain.applicant
 
-import com.yourssu.scouter.common.implement.support.google.GoogleDriveFile
-
 data class ApplicantSyncResult(
-    val successes: List<FormDto>,
-    val failures: List<FormDto>,
+    val successeMessages: List<String>,
+    val failureMessages: List<String>,
 )
-
-data class FormDto(
-    val id: String,
-    val name: String,
-    val webViewLink: String,
-) {
-
-    companion object {
-        fun from(form: GoogleDriveFile): FormDto = FormDto(
-            id = form.id,
-            name = form.name,
-            webViewLink = form.webViewLink,
-        )
-    }
-}

--- a/src/main/kotlin/com/yourssu/scouter/ats/business/domain/applicant/ApplicantSyncService.kt
+++ b/src/main/kotlin/com/yourssu/scouter/ats/business/domain/applicant/ApplicantSyncService.kt
@@ -47,23 +47,27 @@ class ApplicantSyncService(
         val parts: List<Part> = partReader.readAll()
         val applicationSemester: Semester = semesterReader.readByString(applicationSemesterString)
 
-        val successes = mutableListOf<GoogleDriveFile>()
-        val failures = mutableListOf<GoogleDriveFile>()
+        val successMessages = mutableListOf<String>()
+        val failureMessages = mutableListOf<String>()
 
-        val applicants: List<Applicant> = forms.mapNotNull { form ->
-            extractApplicantsFromForm(form, googleAccessToken, parts, applicationSemester)?.also {
-                successes.add(form)
-            } ?: run {
-                failures.add(form)
-                null
-            }
-        }.flatten()
+        val totalApplicants: MutableList<Applicant> = mutableListOf()
+        for (form in forms) {
+            val partApplicants: List<Applicant> = extractApplicantsFromForm(
+                form = form,
+                googleAccessToken = googleAccessToken,
+                parts = parts,
+                applicationSemester = applicationSemester,
+                successMessages = successMessages,
+                failureMessages = failureMessages,
+            )
+            totalApplicants.addAll(partApplicants)
+        }
 
-        applicantWriter.writeAll(applicants)
+        applicantWriter.writeAll(totalApplicants)
 
         return ApplicantSyncResult(
-            successes = successes.map { FormDto.from(it) },
-            failures = failures.map { FormDto.from(it) },
+            successeMessages = successMessages,
+            failureMessages = failureMessages,
         )
     }
 
@@ -71,21 +75,29 @@ class ApplicantSyncService(
         form: GoogleDriveFile,
         googleAccessToken: String,
         parts: List<Part>,
-        applicationSemester: Semester
-    ): List<Applicant>? {
+        applicationSemester: Semester,
+        successMessages: MutableList<String>,
+        failureMessages: MutableList<String>,
+    ): List<Applicant> {
         val userResponses: List<UserResponse> = googleFormsReader.getUserResponses(googleAccessToken, form.id)
         if (userResponses.isEmpty()) {
-            return null
+            failureMessages.add("No responses for form: ${form.name}(${form.webViewLink})")
+            return emptyList()
         }
 
         val part: Part? = parts.find { normalizeString(form.name).contains(normalizeString(it.name)) }
         if (part == null) {
-            return null
+            failureMessages.add("No part found for form: ${form.name}(${form.webViewLink})")
+            return emptyList()
         }
 
-        return userResponses.map { userResponse ->
+        val applicants: List<Applicant> = userResponses.map { userResponse ->
             mapResponseToApplicant(userResponse, part, applicationSemester)
         }
+
+        successMessages.add("'${form.name}'의 ${userResponses.size}개의 응답 중 ${applicants.size}명의 지원자를 추출했습니다.")
+
+        return applicants
     }
 
     private fun normalizeString(value: String): String = value.replace(" ", "").lowercase()
@@ -98,7 +110,7 @@ class ApplicantSyncService(
         val responseMap = userResponse.responseItems.associate { normalizeString(it.question) to it.answer }
 
         return Applicant(
-            name = responseMap["이름"] ?: "",
+            name = responseMap["이름"] ?: responseMap["성함"] ?: "",
             email = userResponse.respondentEmail ?: "",
             phoneNumber = responseMap["연락처"] ?: "",
             age = responseMap["나이"] ?: "",

--- a/src/main/kotlin/com/yourssu/scouter/ats/business/domain/applicant/ApplicantSyncService.kt
+++ b/src/main/kotlin/com/yourssu/scouter/ats/business/domain/applicant/ApplicantSyncService.kt
@@ -38,7 +38,8 @@ class ApplicantSyncService(
         val googleAccessToken: String = authUser.getBearerAccessToken()
         val applicationSemesterString = targetSemester ?: SemesterConverter.convertToIntString(LocalDate.now())
         val query: String = GoogleDriveQueryBuilder()
-            .nameContainsAll("유어슈", "지원서", applicationSemesterString)
+            .nameContainsAll("지원서", applicationSemesterString)
+            .exceptNameContainsAll("양식")
             .mimeType(GoogleDriveMimeType.FORM)
             .build()
 

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/support/google/GoogleDriveQueryBuilder.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/support/google/GoogleDriveQueryBuilder.kt
@@ -10,6 +10,13 @@ class GoogleDriveQueryBuilder {
         return this
     }
 
+    fun exceptNameContainsAll(vararg values: String): GoogleDriveQueryBuilder {
+        values.forEach { value ->
+            conditions.add("not name contains '$value'")
+        }
+        return this
+    }
+
     fun mimeType(vararg mimeTypes: GoogleDriveMimeType): GoogleDriveQueryBuilder {
         mimeTypes.forEach { mimeType ->
             conditions.add("mimeType = '${mimeType.value}'")

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/support/google/GoogleFormsClient.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/support/google/GoogleFormsClient.kt
@@ -22,12 +22,12 @@ interface GoogleFormsClient {
 }
 
 data class GoogleFormQuestions(
-    val items: List<FormItem>?
+    val items: List<FormItem> = emptyList()
 )
 
 data class FormItem(
     val itemId: String,
-    val title: String,
+    val title: String?,
     val questionItem: QuestionItem?
 )
 
@@ -40,15 +40,15 @@ data class Question(
 )
 
 data class GoogleFormResponses(
-    val responses: List<GoogleUserResponse>?
+    val responses: List<GoogleUserResponse> = emptyList()
 )
 
 data class GoogleUserResponse(
     val responseId: String,
-    val createTime: String,
+    val createTime: String?,
     val respondentEmail: String?,
-    val lastSubmittedTime: String,
-    val answers: Map<String, Answer>
+    val lastSubmittedTime: String?,
+    val answers: Map<String, Answer> = emptyMap()
 )
 
 data class Answer(
@@ -56,9 +56,9 @@ data class Answer(
 )
 
 data class TextAnswers(
-    val answers: List<TextAnswer>
+    val answers: List<TextAnswer> = emptyList()
 )
 
 data class TextAnswer(
-    val value: String
+    val value: String?
 )

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/support/google/GoogleFormsReader.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/support/google/GoogleFormsReader.kt
@@ -9,10 +9,10 @@ class GoogleFormsReader(
 
     fun getUserResponses(authorizationHeader: String, formId: String): List<UserResponse> {
         val questionResponse = googleFormsClient.getFormQuestions(authorizationHeader, formId)
-        val questionMap: Map<String, String> = makeQuestionIdAndTitleMap(questionResponse)
+        val questionMap: Map<String, String?> = makeQuestionIdAndTitleMap(questionResponse)
         val formResponses: GoogleFormResponses = googleFormsClient.getFormResponses(authorizationHeader, formId)
 
-        return formResponses.responses?.map { googleUserResponse ->
+        return formResponses.responses.map { googleUserResponse ->
             UserResponse(
                 responseId = googleUserResponse.responseId,
                 createTime = googleUserResponse.createTime,
@@ -20,23 +20,23 @@ class GoogleFormsReader(
                 lastSubmittedTime = googleUserResponse.lastSubmittedTime,
                 responseItems = convertToResponseItems(googleUserResponse, questionMap)
             )
-        } ?: emptyList()
+        }
     }
 
     private fun makeQuestionIdAndTitleMap(questionResponse: GoogleFormQuestions) =
         questionResponse.items
-            ?.mapNotNull { item ->
+            .mapNotNull { item ->
                 val questionId = item.questionItem?.question?.questionId ?: return@mapNotNull null
                 questionId to item.title
-            }?.toMap() ?: emptyMap()
+            }.toMap()
 
     private fun convertToResponseItems(
         googleUserResponse: GoogleUserResponse,
-        questionMap: Map<String, String>
+        questionMap: Map<String, String?>
     ): List<ResponseItem> {
         val responseItems: List<ResponseItem> = googleUserResponse.answers.mapNotNull { (questionId, answer) ->
             val questionTitle = questionMap[questionId] ?: return@mapNotNull null
-            val answerText = answer.textAnswers?.answers?.joinToString(", ") { it.value } ?: ""
+            val answerText = answer.textAnswers?.answers?.joinToString(", ") { it.value.toString() } ?: ""
             ResponseItem(questionTitle, answerText)
         }
         return responseItems

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/support/google/UserResponse.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/support/google/UserResponse.kt
@@ -6,21 +6,21 @@ data class UserResponse(
     val responseId: String,
     val createTime: LocalDateTime,
     val respondentEmail: String?,
-    val lastSubmittedTime: LocalDateTime,
-    val responseItems: List<ResponseItem>
+    val lastSubmittedTime: LocalDateTime?,
+    val responseItems: List<ResponseItem> = emptyList(),
 ) {
 
     constructor(
         responseId: String,
-        createTime: String,
+        createTime: String?,
         respondentEmail: String?,
-        lastSubmittedTime: String,
+        lastSubmittedTime: String?,
         responseItems: List<ResponseItem>,
     ) : this(
         responseId = responseId,
-        createTime = LocalDateTime.parse(createTime.substringBefore("Z")),
+        createTime = LocalDateTime.parse(createTime?.substringBefore("Z")),
         respondentEmail = respondentEmail,
-        lastSubmittedTime = LocalDateTime.parse(lastSubmittedTime.substringBefore("Z")),
+        lastSubmittedTime = LocalDateTime.parse(lastSubmittedTime?.substringBefore("Z")),
         responseItems = responseItems
     )
 }

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/support/initialization/DivisionsAndPartsInitializer.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/support/initialization/DivisionsAndPartsInitializer.kt
@@ -35,7 +35,7 @@ class DivisionsAndPartsInitializer(
         parts.add(Part(division = division, name = "Head lead", sortPriority = 1))
         parts.add(Part(division = division, name = "finance", sortPriority = 2))
         parts.add(Part(division = division, name = "HR", sortPriority = 3))
-        parts.add(Part(division = division, name = "Contents Marketing", sortPriority = 34))
+        parts.add(Part(division = division, name = "Contents Marketing", sortPriority = 4))
         parts.add(Part(division = division, name = "legal", sortPriority = 5))
         parts.add(Part(division = division, name = "PM", sortPriority = 6))
 

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/support/initialization/DivisionsAndPartsInitializer.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/support/initialization/DivisionsAndPartsInitializer.kt
@@ -35,7 +35,7 @@ class DivisionsAndPartsInitializer(
         parts.add(Part(division = division, name = "Head lead", sortPriority = 1))
         parts.add(Part(division = division, name = "finance", sortPriority = 2))
         parts.add(Part(division = division, name = "HR", sortPriority = 3))
-        parts.add(Part(division = division, name = "Contents Marketing", sortPriority = 4))
+        parts.add(Part(division = division, name = "Marketing", sortPriority = 4))
         parts.add(Part(division = division, name = "legal", sortPriority = 5))
         parts.add(Part(division = division, name = "PM", sortPriority = 6))
 
@@ -48,7 +48,7 @@ class DivisionsAndPartsInitializer(
         parts.add(Part(division = division, name = "Backend", sortPriority = 1))
         parts.add(Part(division = division, name = "Android", sortPriority = 2))
         parts.add(Part(division = division, name = "iOS", sortPriority = 3))
-        parts.add(Part(division = division, name = "Web-frontend", sortPriority = 4))
+        parts.add(Part(division = division, name = "Web FE", sortPriority = 4))
 
         partRepository.saveAll(parts)
     }


### PR DESCRIPTION
## 📄 작업 내용 요약
- 구글폼 api에 사용되는 응답 dto 필드를 nullable하게 변경
- 2025년 1학기에 해당하는 지원서 제목에 맞게 구글 드라이브 api에 사용하는 쿼리 수정
- 구글폼에서 지원자 정보를 불러오는 로직 수정
- 파트 우선순위 오류 수정
- 파트명 변경된 파트에 대해 초기 파트명 변경

## 📎 Issue 번호
- closed #81 
