### PR TITLE
feat: 84 구글폼에서 지원자 정보를 불러올 때 새로운 응답만 불러오도록 하는 기능 추가

### DIFF
--- a/src/main/kotlin/com/yourssu/scouter/ats/application/domain/applicant/ApplicantController.kt
+++ b/src/main/kotlin/com/yourssu/scouter/ats/application/domain/applicant/ApplicantController.kt
@@ -2,10 +2,6 @@ package com.yourssu.scouter.ats.application.domain.applicant
 
 import com.yourssu.scouter.ats.business.domain.applicant.ApplicantDto
 import com.yourssu.scouter.ats.business.domain.applicant.ApplicantService
-import com.yourssu.scouter.ats.business.domain.applicant.ApplicantSyncResult
-import com.yourssu.scouter.ats.business.domain.applicant.ApplicantSyncService
-import com.yourssu.scouter.common.application.support.authentication.AuthUser
-import com.yourssu.scouter.common.application.support.authentication.AuthUserInfo
 import jakarta.validation.Valid
 import java.net.URI
 import org.springframework.http.ResponseEntity
@@ -21,7 +17,6 @@ import org.springframework.web.bind.annotation.RestController
 @RestController
 class ApplicantController(
     private val applicantService: ApplicantService,
-    private val applicantSyncService: ApplicantSyncService,
 ) {
 
     @PostMapping("/applicants")
@@ -34,26 +29,6 @@ class ApplicantController(
         return ResponseEntity.created(URI.create("/applicants/$applicantId")).build()
     }
 
-    @PostMapping("/applicants/include-from-forms")
-    fun includeFromForms(
-        @AuthUser authUserInfo: AuthUserInfo,
-    ): ResponseEntity<ApplicantSyncResponse> {
-        val result: ApplicantSyncResult = applicantSyncService.includeFromForms(authUserInfo.userId)
-        val response: ApplicantSyncResponse = ApplicantSyncResponse.from(result)
-
-        return ResponseEntity.ok(response)
-    }
-
-    @PostMapping("/applicants/include-from-forms/{semesterString}")
-    fun includeFromForms(
-        @AuthUser authUserInfo: AuthUserInfo,
-        @PathVariable semesterString: String,
-    ): ResponseEntity<ApplicantSyncResponse> {
-        val result: ApplicantSyncResult = applicantSyncService.includeFromForms(authUserInfo.userId, semesterString)
-        val response: ApplicantSyncResponse = ApplicantSyncResponse.from(result)
-
-        return ResponseEntity.ok(response)
-    }
 
     @GetMapping("/applicants")
     fun readAll(

--- a/src/main/kotlin/com/yourssu/scouter/ats/application/domain/applicant/ApplicantSyncController.kt
+++ b/src/main/kotlin/com/yourssu/scouter/ats/application/domain/applicant/ApplicantSyncController.kt
@@ -1,0 +1,38 @@
+package com.yourssu.scouter.ats.application.domain.applicant
+
+import com.yourssu.scouter.ats.business.domain.applicant.ApplicantSyncResult
+import com.yourssu.scouter.ats.business.domain.applicant.ApplicantSyncService
+import com.yourssu.scouter.common.application.support.authentication.AuthUser
+import com.yourssu.scouter.common.application.support.authentication.AuthUserInfo
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+class ApplicantSyncController(
+    private val applicantSyncService: ApplicantSyncService,
+) {
+
+    @PostMapping("/applicants/include-from-forms")
+    fun includeFromForms(
+        @AuthUser authUserInfo: AuthUserInfo,
+    ): ResponseEntity<ApplicantSyncResponse> {
+        val result: ApplicantSyncResult = applicantSyncService.includeFromForms(authUserInfo.userId)
+        val response: ApplicantSyncResponse = ApplicantSyncResponse.from(result)
+
+        return ResponseEntity.ok(response)
+    }
+
+    @PostMapping("/applicants/include-from-forms/{semesterString}")
+    fun includeFromForms(
+        @AuthUser authUserInfo: AuthUserInfo,
+        @PathVariable semesterString: String,
+    ): ResponseEntity<ApplicantSyncResponse> {
+        val result: ApplicantSyncResult = applicantSyncService.includeFromForms(authUserInfo.userId, semesterString)
+        val response: ApplicantSyncResponse = ApplicantSyncResponse.from(result)
+
+        return ResponseEntity.ok(response)
+    }
+}
+

--- a/src/main/kotlin/com/yourssu/scouter/ats/application/domain/applicant/ApplicantSyncResponse.kt
+++ b/src/main/kotlin/com/yourssu/scouter/ats/application/domain/applicant/ApplicantSyncResponse.kt
@@ -9,7 +9,7 @@ data class ApplicantSyncResponse(
 
     companion object {
         fun from(result: ApplicantSyncResult) = ApplicantSyncResponse(
-            successes = result.successeMessages,
+            successes = result.successMessages,
             failures = result.failureMessages,
         )
     }

--- a/src/main/kotlin/com/yourssu/scouter/ats/business/domain/applicant/ApplicantSyncResult.kt
+++ b/src/main/kotlin/com/yourssu/scouter/ats/business/domain/applicant/ApplicantSyncResult.kt
@@ -1,6 +1,6 @@
 package com.yourssu.scouter.ats.business.domain.applicant
 
 data class ApplicantSyncResult(
-    val successeMessages: List<String>,
+    val successMessages: List<String>,
     val failureMessages: List<String>,
 )

--- a/src/main/kotlin/com/yourssu/scouter/ats/business/domain/applicant/ApplicantSyncService.kt
+++ b/src/main/kotlin/com/yourssu/scouter/ats/business/domain/applicant/ApplicantSyncService.kt
@@ -74,7 +74,7 @@ class ApplicantSyncService(
                     applicantSemesterId = applicationSemester.id!!,
                     formId = form.id,
                     responseId = it.responseId,
-                    lastSyncTime = syncDateTime,
+                    syncTime = syncDateTime,
                 )
             }
             totalApplicants.addAll(partApplicants)

--- a/src/main/kotlin/com/yourssu/scouter/ats/business/domain/applicant/ApplicantSyncService.kt
+++ b/src/main/kotlin/com/yourssu/scouter/ats/business/domain/applicant/ApplicantSyncService.kt
@@ -56,9 +56,7 @@ class ApplicantSyncService(
         val successMessages = mutableListOf<String>()
         val failureMessages = mutableListOf<String>()
 
-        val totalApplicants: MutableList<Applicant> = mutableListOf()
-        val totalSyncLogs: MutableList<ApplicantSyncLog> = mutableListOf()
-        val syncDateTime: LocalDateTime = LocalDateTime.now()
+        val totalSyncResults: MutableList<SingleResponseSyncResult> = mutableListOf()
         for (form: GoogleDriveFile in forms) {
             val partSyncResults: List<SingleResponseSyncResult> = extractApplicantsFromForm(
                 form = form,
@@ -68,25 +66,51 @@ class ApplicantSyncService(
                 successMessages = successMessages,
                 failureMessages = failureMessages,
             )
-            val partApplicants: List<Applicant> = partSyncResults.map { it.applicant }
-            val syncLogs: List<ApplicantSyncLog> = partSyncResults.map {
-                ApplicantSyncLog(
-                    applicantSemesterId = applicationSemester.id!!,
-                    formId = form.id,
-                    responseId = it.responseId,
-                    syncTime = syncDateTime,
-                )
-            }
-            totalApplicants.addAll(partApplicants)
-            totalSyncLogs.addAll(syncLogs)
+            totalSyncResults.addAll(partSyncResults)
         }
 
-        applicantWriter.writeAll(totalApplicants)
+        writeNewApplicants(applicationSemester, totalSyncResults)
 
         return ApplicantSyncResult(
             successMessages = successMessages,
             failureMessages = failureMessages,
         )
+    }
+
+    private fun writeNewApplicants(
+        applicantSemester: Semester,
+        syncResults: List<SingleResponseSyncResult>,
+    ) {
+        if (syncResults.isEmpty()) {
+            return
+        }
+        val syncDateTime: LocalDateTime = LocalDateTime.now()
+        val newApplicants: MutableList<Applicant> = mutableListOf()
+        val newSyncLogs: MutableList<ApplicantSyncLog> = mutableListOf()
+        val semesterSyncLogs: List<ApplicantSyncLog> =
+            applicantSyncLogReader.readAllByApplicantSemesterId(applicantSemester.id!!)
+
+        for (syncResult: SingleResponseSyncResult in syncResults) {
+            val syncLog: ApplicantSyncLog? = semesterSyncLogs.find {log ->
+                (log.formId == syncResult.formId) && (log.responseId == syncResult.responseId)
+            }
+            if (syncLog != null) {
+                continue
+            }
+
+            newApplicants.add(syncResult.applicant)
+            newSyncLogs.add(
+                ApplicantSyncLog(
+                    applicantSemesterId = applicantSemester.id,
+                    formId = syncResult.formId,
+                    responseId = syncResult.responseId,
+                    syncTime = syncDateTime,
+                )
+            )
+        }
+
+        applicantWriter.writeAll(newApplicants)
+        applicantSyncLogWriter.writeAll(newSyncLogs)
     }
 
     private fun extractApplicantsFromForm(
@@ -109,20 +133,21 @@ class ApplicantSyncService(
             return emptyList()
         }
 
-        val singleResponseSyncResults: List<SingleResponseSyncResult> = userResponses.map { userResponse ->
-            mapResponseToApplicant(userResponse, part, applicationSemester)
+        val formSyncResult: List<SingleResponseSyncResult> = userResponses.map { userResponse ->
+            mapResponseToApplicant(form.id, userResponse, part, applicationSemester)
         }
 
         successMessages.add(
-            "'${form.name}'의 ${userResponses.size}개의 응답 중 ${singleResponseSyncResults.size}명의 지원자를 추출했습니다."
+            "'${form.name}'의 ${userResponses.size}개의 응답 중 ${formSyncResult.size}명의 지원자를 추출했습니다."
         )
 
-        return singleResponseSyncResults
+        return formSyncResult
     }
 
     private fun normalizeString(value: String): String = value.replace(" ", "").lowercase()
 
     private fun mapResponseToApplicant(
+        formId: String,
         userResponse: UserResponse,
         part: Part,
         applicationSemester: Semester
@@ -143,18 +168,12 @@ class ApplicantSyncService(
             academicSemester = responseMap.entries.firstOrNull { it.key.contains("재학중인학기") }?.value ?: ""
         )
 
-        return SingleResponseSyncResult(applicant, userResponse.responseId)
+        return SingleResponseSyncResult(applicant, formId, userResponse.responseId)
     }
 }
 
-class SingleFormSyncResult(
-    val applicants: List<Applicant>,
-    val syncLogs: List<ApplicantSyncLog>,
-    val successMessages: List<String>,
-    val failureMessages: List<String>,
-)
-
 class SingleResponseSyncResult(
     val applicant: Applicant,
+    val formId: String,
     val responseId: String,
 )

--- a/src/main/kotlin/com/yourssu/scouter/ats/business/domain/applicant/ApplicantSyncService.kt
+++ b/src/main/kotlin/com/yourssu/scouter/ats/business/domain/applicant/ApplicantSyncService.kt
@@ -66,7 +66,7 @@ class ApplicantSyncService(
         applicantWriter.writeAll(totalApplicants)
 
         return ApplicantSyncResult(
-            successeMessages = successMessages,
+            successMessages = successMessages,
             failureMessages = failureMessages,
         )
     }

--- a/src/main/kotlin/com/yourssu/scouter/ats/business/domain/applicant/ApplicantSyncService.kt
+++ b/src/main/kotlin/com/yourssu/scouter/ats/business/domain/applicant/ApplicantSyncService.kt
@@ -2,6 +2,9 @@ package com.yourssu.scouter.ats.business.domain.applicant
 
 import com.yourssu.scouter.ats.implement.domain.applicant.Applicant
 import com.yourssu.scouter.ats.implement.domain.applicant.ApplicantState
+import com.yourssu.scouter.ats.implement.domain.applicant.ApplicantSyncLog
+import com.yourssu.scouter.ats.implement.domain.applicant.ApplicantSyncLogReader
+import com.yourssu.scouter.ats.implement.domain.applicant.ApplicantSyncLogWriter
 import com.yourssu.scouter.ats.implement.domain.applicant.ApplicantWriter
 import com.yourssu.scouter.common.business.domain.authentication.OAuth2Service
 import com.yourssu.scouter.common.business.support.utils.SemesterConverter
@@ -18,6 +21,7 @@ import com.yourssu.scouter.common.implement.support.google.GoogleDriveReader
 import com.yourssu.scouter.common.implement.support.google.GoogleFormsReader
 import com.yourssu.scouter.common.implement.support.google.UserResponse
 import java.time.LocalDate
+import java.time.LocalDateTime
 import org.springframework.stereotype.Service
 
 @Service
@@ -26,6 +30,8 @@ class ApplicantSyncService(
     private val applicantWriter: ApplicantWriter,
     private val partReader: PartReader,
     private val semesterReader: SemesterReader,
+    private val applicantSyncLogReader: ApplicantSyncLogReader,
+    private val applicantSyncLogWriter: ApplicantSyncLogWriter,
     private val googleDriveReader: GoogleDriveReader,
     private val googleFormsReader: GoogleFormsReader,
 ) {
@@ -51,8 +57,10 @@ class ApplicantSyncService(
         val failureMessages = mutableListOf<String>()
 
         val totalApplicants: MutableList<Applicant> = mutableListOf()
-        for (form in forms) {
-            val partApplicants: List<Applicant> = extractApplicantsFromForm(
+        val totalSyncLogs: MutableList<ApplicantSyncLog> = mutableListOf()
+        val syncDateTime: LocalDateTime = LocalDateTime.now()
+        for (form: GoogleDriveFile in forms) {
+            val partSyncResults: List<SingleResponseSyncResult> = extractApplicantsFromForm(
                 form = form,
                 googleAccessToken = googleAccessToken,
                 parts = parts,
@@ -60,7 +68,17 @@ class ApplicantSyncService(
                 successMessages = successMessages,
                 failureMessages = failureMessages,
             )
+            val partApplicants: List<Applicant> = partSyncResults.map { it.applicant }
+            val syncLogs: List<ApplicantSyncLog> = partSyncResults.map {
+                ApplicantSyncLog(
+                    applicantSemesterId = applicationSemester.id!!,
+                    formId = form.id,
+                    responseId = it.responseId,
+                    lastSyncTime = syncDateTime,
+                )
+            }
             totalApplicants.addAll(partApplicants)
+            totalSyncLogs.addAll(syncLogs)
         }
 
         applicantWriter.writeAll(totalApplicants)
@@ -78,7 +96,7 @@ class ApplicantSyncService(
         applicationSemester: Semester,
         successMessages: MutableList<String>,
         failureMessages: MutableList<String>,
-    ): List<Applicant> {
+    ): List<SingleResponseSyncResult> {
         val userResponses: List<UserResponse> = googleFormsReader.getUserResponses(googleAccessToken, form.id)
         if (userResponses.isEmpty()) {
             failureMessages.add("No responses for form: ${form.name}(${form.webViewLink})")
@@ -91,13 +109,15 @@ class ApplicantSyncService(
             return emptyList()
         }
 
-        val applicants: List<Applicant> = userResponses.map { userResponse ->
+        val singleResponseSyncResults: List<SingleResponseSyncResult> = userResponses.map { userResponse ->
             mapResponseToApplicant(userResponse, part, applicationSemester)
         }
 
-        successMessages.add("'${form.name}'의 ${userResponses.size}개의 응답 중 ${applicants.size}명의 지원자를 추출했습니다.")
+        successMessages.add(
+            "'${form.name}'의 ${userResponses.size}개의 응답 중 ${singleResponseSyncResults.size}명의 지원자를 추출했습니다."
+        )
 
-        return applicants
+        return singleResponseSyncResults
     }
 
     private fun normalizeString(value: String): String = value.replace(" ", "").lowercase()
@@ -106,10 +126,10 @@ class ApplicantSyncService(
         userResponse: UserResponse,
         part: Part,
         applicationSemester: Semester
-    ): Applicant {
+    ): SingleResponseSyncResult {
         val responseMap = userResponse.responseItems.associate { normalizeString(it.question) to it.answer }
 
-        return Applicant(
+        val applicant = Applicant(
             name = responseMap["이름"] ?: responseMap["성함"] ?: "",
             email = userResponse.respondentEmail ?: "",
             phoneNumber = responseMap["연락처"] ?: "",
@@ -122,5 +142,19 @@ class ApplicantSyncService(
             applicationSemester = applicationSemester,
             academicSemester = responseMap.entries.firstOrNull { it.key.contains("재학중인학기") }?.value ?: ""
         )
+
+        return SingleResponseSyncResult(applicant, userResponse.responseId)
     }
 }
+
+class SingleFormSyncResult(
+    val applicants: List<Applicant>,
+    val syncLogs: List<ApplicantSyncLog>,
+    val successMessages: List<String>,
+    val failureMessages: List<String>,
+)
+
+class SingleResponseSyncResult(
+    val applicant: Applicant,
+    val responseId: String,
+)

--- a/src/main/kotlin/com/yourssu/scouter/ats/implement/domain/applicant/ApplicantSyncLog.kt
+++ b/src/main/kotlin/com/yourssu/scouter/ats/implement/domain/applicant/ApplicantSyncLog.kt
@@ -1,0 +1,25 @@
+package com.yourssu.scouter.ats.implement.domain.applicant
+
+import java.time.LocalDateTime
+
+class ApplicantSyncLog(
+    val id: Long? = null,
+    val applicantSemesterId: Long,
+    val formId: String,
+    val responseId: String,
+    val lastSyncTime: LocalDateTime,
+) {
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as ApplicantSyncLog
+
+        return id == other.id
+    }
+
+    override fun hashCode(): Int {
+        return id.hashCode()
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/ats/implement/domain/applicant/ApplicantSyncLog.kt
+++ b/src/main/kotlin/com/yourssu/scouter/ats/implement/domain/applicant/ApplicantSyncLog.kt
@@ -7,7 +7,7 @@ class ApplicantSyncLog(
     val applicantSemesterId: Long,
     val formId: String,
     val responseId: String,
-    val lastSyncTime: LocalDateTime,
+    val syncTime: LocalDateTime,
 ) {
 
     override fun equals(other: Any?): Boolean {

--- a/src/main/kotlin/com/yourssu/scouter/ats/implement/domain/applicant/ApplicantSyncLogReader.kt
+++ b/src/main/kotlin/com/yourssu/scouter/ats/implement/domain/applicant/ApplicantSyncLogReader.kt
@@ -9,7 +9,7 @@ class ApplicantSyncLogReader(
     private val applicantSyncLogRepository: ApplicantSyncLogRepository,
 ) {
 
-    fun findByApplicantSemesterId(applicantSemesterId: Long): List<ApplicantSyncLog> {
+    fun readAllByApplicantSemesterId(applicantSemesterId: Long): List<ApplicantSyncLog> {
         return applicantSyncLogRepository.findAllByApplicantSemesterId(applicantSemesterId)
     }
 }

--- a/src/main/kotlin/com/yourssu/scouter/ats/implement/domain/applicant/ApplicantSyncLogReader.kt
+++ b/src/main/kotlin/com/yourssu/scouter/ats/implement/domain/applicant/ApplicantSyncLogReader.kt
@@ -1,0 +1,15 @@
+package com.yourssu.scouter.ats.implement.domain.applicant
+
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+
+@Component
+@Transactional(readOnly = true)
+class ApplicantSyncLogReader(
+    private val applicantSyncLogRepository: ApplicantSyncLogRepository,
+) {
+
+    fun findByApplicantSemesterId(applicantSemesterId: Long): List<ApplicantSyncLog> {
+        return applicantSyncLogRepository.findAllByApplicantSemesterId(applicantSemesterId)
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/ats/implement/domain/applicant/ApplicantSyncLogRepository.kt
+++ b/src/main/kotlin/com/yourssu/scouter/ats/implement/domain/applicant/ApplicantSyncLogRepository.kt
@@ -2,7 +2,7 @@ package com.yourssu.scouter.ats.implement.domain.applicant
 
 interface ApplicantSyncLogRepository {
 
-    fun save(applicantSyncLog: ApplicantSyncLog): ApplicantSyncLog
+    fun saveAll(applicantSyncLogs: List<ApplicantSyncLog>)
 
     fun findAllByApplicantSemesterId(applicantSemesterId: Long): List<ApplicantSyncLog>
 }

--- a/src/main/kotlin/com/yourssu/scouter/ats/implement/domain/applicant/ApplicantSyncLogRepository.kt
+++ b/src/main/kotlin/com/yourssu/scouter/ats/implement/domain/applicant/ApplicantSyncLogRepository.kt
@@ -1,0 +1,8 @@
+package com.yourssu.scouter.ats.implement.domain.applicant
+
+interface ApplicantSyncLogRepository {
+
+    fun save(applicantSyncLog: ApplicantSyncLog): ApplicantSyncLog
+
+    fun findAllByApplicantSemesterId(applicantSemesterId: Long): List<ApplicantSyncLog>
+}

--- a/src/main/kotlin/com/yourssu/scouter/ats/implement/domain/applicant/ApplicantSyncLogWriter.kt
+++ b/src/main/kotlin/com/yourssu/scouter/ats/implement/domain/applicant/ApplicantSyncLogWriter.kt
@@ -9,7 +9,7 @@ class ApplicantSyncLogWriter(
     private val applicantSyncLogRepository: ApplicantSyncLogRepository,
 ) {
 
-    fun save(applicantSyncLog: ApplicantSyncLog): ApplicantSyncLog {
-        return applicantSyncLogRepository.save(applicantSyncLog)
+    fun writeAll(newSyncLogs: List<ApplicantSyncLog>) {
+        applicantSyncLogRepository.saveAll(newSyncLogs)
     }
 }

--- a/src/main/kotlin/com/yourssu/scouter/ats/implement/domain/applicant/ApplicantSyncLogWriter.kt
+++ b/src/main/kotlin/com/yourssu/scouter/ats/implement/domain/applicant/ApplicantSyncLogWriter.kt
@@ -1,0 +1,15 @@
+package com.yourssu.scouter.ats.implement.domain.applicant
+
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+
+@Component
+@Transactional
+class ApplicantSyncLogWriter(
+    private val applicantSyncLogRepository: ApplicantSyncLogRepository,
+) {
+
+    fun save(applicantSyncLog: ApplicantSyncLog): ApplicantSyncLog {
+        return applicantSyncLogRepository.save(applicantSyncLog)
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/ats/storage/domain/applicant/ApplicantSyncLogEntity.kt
+++ b/src/main/kotlin/com/yourssu/scouter/ats/storage/domain/applicant/ApplicantSyncLogEntity.kt
@@ -1,0 +1,65 @@
+package com.yourssu.scouter.ats.storage.domain.applicant
+
+import com.yourssu.scouter.ats.implement.domain.applicant.ApplicantSyncLog
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import java.time.LocalDateTime
+
+@Entity
+@Table(name = "applicant_sync_log")
+class ApplicantSyncLogEntity(
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long? = null,
+
+    @Column(nullable = false)
+    val applicantSemesterId: Long,
+
+    @Column(nullable = false)
+    val formId: String,
+
+    @Column(nullable = false)
+    val responseId: String,
+
+    @Column(nullable = false)
+    val lastSyncTime: LocalDateTime,
+) {
+
+    companion object {
+        fun from(applicantSyncLog: ApplicantSyncLog) = ApplicantSyncLogEntity(
+            id = applicantSyncLog.id,
+            applicantSemesterId = applicantSyncLog.applicantSemesterId,
+            formId = applicantSyncLog.formId,
+            responseId = applicantSyncLog.responseId,
+            lastSyncTime = applicantSyncLog.lastSyncTime,
+        )
+    }
+
+    fun toDomain(): ApplicantSyncLog {
+        return ApplicantSyncLog(
+            id = id,
+            applicantSemesterId = applicantSemesterId,
+            formId = formId,
+            responseId = responseId,
+            lastSyncTime = lastSyncTime,
+        )
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as ApplicantSyncLogEntity
+
+        return id == other.id
+    }
+
+    override fun hashCode(): Int {
+        return id?.hashCode() ?: 0
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/ats/storage/domain/applicant/ApplicantSyncLogEntity.kt
+++ b/src/main/kotlin/com/yourssu/scouter/ats/storage/domain/applicant/ApplicantSyncLogEntity.kt
@@ -27,7 +27,7 @@ class ApplicantSyncLogEntity(
     val responseId: String,
 
     @Column(nullable = false)
-    val lastSyncTime: LocalDateTime,
+    val syncTime: LocalDateTime,
 ) {
 
     companion object {
@@ -36,7 +36,7 @@ class ApplicantSyncLogEntity(
             applicantSemesterId = applicantSyncLog.applicantSemesterId,
             formId = applicantSyncLog.formId,
             responseId = applicantSyncLog.responseId,
-            lastSyncTime = applicantSyncLog.lastSyncTime,
+            syncTime = applicantSyncLog.syncTime,
         )
     }
 
@@ -46,7 +46,7 @@ class ApplicantSyncLogEntity(
             applicantSemesterId = applicantSemesterId,
             formId = formId,
             responseId = responseId,
-            lastSyncTime = lastSyncTime,
+            syncTime = syncTime,
         )
     }
 

--- a/src/main/kotlin/com/yourssu/scouter/ats/storage/domain/applicant/ApplicantSyncLogRepositoryImpl.kt
+++ b/src/main/kotlin/com/yourssu/scouter/ats/storage/domain/applicant/ApplicantSyncLogRepositoryImpl.kt
@@ -1,0 +1,19 @@
+package com.yourssu.scouter.ats.storage.domain.applicant
+
+import com.yourssu.scouter.ats.implement.domain.applicant.ApplicantSyncLog
+import com.yourssu.scouter.ats.implement.domain.applicant.ApplicantSyncLogRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+class ApplicantSyncLogRepositoryImpl(
+    private val jpaApplicantSyncLogRepository: JpaApplicantSyncLogRepository,
+): ApplicantSyncLogRepository {
+
+    override fun save(applicantSyncLog: ApplicantSyncLog): ApplicantSyncLog {
+        return jpaApplicantSyncLogRepository.save(ApplicantSyncLogEntity.from(applicantSyncLog)).toDomain()
+    }
+
+    override fun findAllByApplicantSemesterId(applicantSemesterId: Long): List<ApplicantSyncLog> {
+        return jpaApplicantSyncLogRepository.findAllByApplicantSemesterId(applicantSemesterId).map { it.toDomain() }
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/ats/storage/domain/applicant/ApplicantSyncLogRepositoryImpl.kt
+++ b/src/main/kotlin/com/yourssu/scouter/ats/storage/domain/applicant/ApplicantSyncLogRepositoryImpl.kt
@@ -9,8 +9,8 @@ class ApplicantSyncLogRepositoryImpl(
     private val jpaApplicantSyncLogRepository: JpaApplicantSyncLogRepository,
 ): ApplicantSyncLogRepository {
 
-    override fun save(applicantSyncLog: ApplicantSyncLog): ApplicantSyncLog {
-        return jpaApplicantSyncLogRepository.save(ApplicantSyncLogEntity.from(applicantSyncLog)).toDomain()
+    override fun saveAll(applicantSyncLogs: List<ApplicantSyncLog>) {
+        jpaApplicantSyncLogRepository.saveAll(applicantSyncLogs.map { ApplicantSyncLogEntity.from(it) })
     }
 
     override fun findAllByApplicantSemesterId(applicantSemesterId: Long): List<ApplicantSyncLog> {

--- a/src/main/kotlin/com/yourssu/scouter/ats/storage/domain/applicant/JpaApplicantSyncLogRepository.kt
+++ b/src/main/kotlin/com/yourssu/scouter/ats/storage/domain/applicant/JpaApplicantSyncLogRepository.kt
@@ -1,0 +1,8 @@
+package com.yourssu.scouter.ats.storage.domain.applicant
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface JpaApplicantSyncLogRepository : JpaRepository<ApplicantSyncLogEntity, Long> {
+
+    fun findAllByApplicantSemesterId(applicantSemesterId: Long): List<ApplicantSyncLogEntity>
+}


### PR DESCRIPTION
## 📄 작업 내용 요약
- 구글폼에서 지원자 응답을 불러와서 지원자 목록에 저장할 때 폼 id와 응답 id를 기록하도록 함
- 지원자 저장 시 저장된 기록이 없는 지원자만 저장

## 📎 Issue 번호
- closed #84 
