### PR TITLE
feat: #91 oauth2 로그인 redirect uri를 프론트 출처에 따라 유동적으로 반환하는 기능 추가

### DIFF
--- a/src/main/kotlin/com/yourssu/scouter/common/application/domain/authentication/AuthenticationController.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/application/domain/authentication/AuthenticationController.kt
@@ -6,6 +6,7 @@ import com.yourssu.scouter.common.business.domain.authentication.OAuth2Service
 import com.yourssu.scouter.common.business.domain.authentication.TokenDto
 import com.yourssu.scouter.common.implement.domain.authentication.OAuth2Type
 import com.yourssu.scouter.common.implement.domain.authentication.TokenType
+import jakarta.servlet.http.HttpServletRequest
 import jakarta.validation.Valid
 import java.time.LocalDateTime
 import org.springframework.http.HttpHeaders
@@ -27,8 +28,13 @@ class AuthenticationController(
     fun login(
         @PathVariable oauth2Type: OAuth2Type,
         @RequestBody @Valid request: OAuth2LoginRequest,
+        httpServletRequest: HttpServletRequest,
     ): ResponseEntity<LoginResponse> {
-        val loginResult: LoginResult = oauth2Service.login(oauth2Type, request.authorizationCode)
+        val loginResult: LoginResult = oauth2Service.login(
+            oauth2Type = oauth2Type,
+            oauth2AuthorizationCode = request.authorizationCode,
+            referer = httpServletRequest.getHeader(HttpHeaders.REFERER),
+        )
         val response: LoginResponse = LoginResponse.from(loginResult)
 
         return ResponseEntity.ok(response)

--- a/src/main/kotlin/com/yourssu/scouter/common/application/domain/authentication/OAuth2Controller.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/application/domain/authentication/OAuth2Controller.kt
@@ -2,7 +2,9 @@ package com.yourssu.scouter.common.application.domain.authentication
 
 import com.yourssu.scouter.common.business.domain.authentication.OAuth2Service
 import com.yourssu.scouter.common.implement.domain.authentication.OAuth2Type
+import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
+import org.springframework.http.HttpHeaders
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
@@ -17,8 +19,13 @@ class OAuth2Controller(
     fun redirectAuthCodeRequestUrl(
         @PathVariable oauth2Type: OAuth2Type,
         response: HttpServletResponse,
+        httpServletRequest: HttpServletRequest,
     ): ResponseEntity<Unit> {
-        val redirectUrl: String = oauth2Service.getAuthCodeRequestUrl(oauth2Type)
+        val redirectUrl: String = oauth2Service.getAuthCodeRequestUrl(
+            oauth2Type = oauth2Type,
+            referer = httpServletRequest.getHeader(HttpHeaders.REFERER),
+        )
+
         response.sendRedirect(redirectUrl)
 
         return ResponseEntity.ok().build()

--- a/src/main/kotlin/com/yourssu/scouter/common/business/domain/authentication/OAuth2Service.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/business/domain/authentication/OAuth2Service.kt
@@ -22,14 +22,22 @@ class OAuth2Service(
     private val tokenProcessor: TokenProcessor,
 ) {
 
-    fun getAuthCodeRequestUrl(oauth2Type: OAuth2Type): String {
+    fun getAuthCodeRequestUrl(oauth2Type: OAuth2Type, referer: String): String {
         val oauth2Handler: OAuth2Handler = oauth2HandlerComposite.findHandler(oauth2Type)
 
-        return oauth2Handler.provideAuthCodeRequestUrl()
+        return oauth2Handler.provideAuthCodeRequestUrl(referer)
     }
 
-    fun login(oauth2Type: OAuth2Type, oauth2AuthorizationCode: String): LoginResult {
-        val oauth2User: OAuth2User = fetchOAuth2User(oauth2Type, oauth2AuthorizationCode)
+    fun login(
+        oauth2Type: OAuth2Type,
+        oauth2AuthorizationCode: String,
+        referer: String
+    ): LoginResult {
+        val oauth2User: OAuth2User = fetchOAuth2User(
+            oauth2Type = oauth2Type,
+            authorizationCode = oauth2AuthorizationCode,
+            referer = referer
+        )
         val loginUser: User = createOrUpdate(oauth2User)
 
         val tokenIssueTime = LocalDateTime.now()
@@ -46,10 +54,14 @@ class OAuth2Service(
         )
     }
 
-    private fun fetchOAuth2User(oauth2Type: OAuth2Type, authorizationCode: String): OAuth2User {
+    private fun fetchOAuth2User(
+        oauth2Type: OAuth2Type,
+        authorizationCode: String,
+        referer: String,
+    ): OAuth2User {
         val oauth2Handler: OAuth2Handler = oauth2HandlerComposite.findHandler(oauth2Type)
 
-        return oauth2Handler.fetchOAuth2User(authorizationCode)
+        return oauth2Handler.fetchOAuth2User(authorizationCode, referer)
     }
 
     private fun createOrUpdate(oauth2User: OAuth2User): User {

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/domain/authentication/OAuth2Handler.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/domain/authentication/OAuth2Handler.kt
@@ -3,7 +3,7 @@ package com.yourssu.scouter.common.implement.domain.authentication
 interface OAuth2Handler {
 
     fun getSupportingOAuth2Type(): OAuth2Type
-    fun provideAuthCodeRequestUrl(): String
-    fun fetchOAuth2User(authorizationCode: String): OAuth2User
+    fun provideAuthCodeRequestUrl(referer: String): String
+    fun fetchOAuth2User(authorizationCode: String, referer: String): OAuth2User
     fun refreshAccessToken(refreshToken: String): OAuth2TokenInfo
 }

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/support/security/oauth2/GoogleOAuth2Handler.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/support/security/oauth2/GoogleOAuth2Handler.kt
@@ -19,10 +19,10 @@ class GoogleOAuth2Handler(
 
     override fun getSupportingOAuth2Type() = OAuth2Type.GOOGLE
 
-    override fun provideAuthCodeRequestUrl(): String {
+    override fun provideAuthCodeRequestUrl(referer: String): String {
         return UriComponentsBuilder.fromUriString("https://accounts.google.com/o/oauth2/auth")
             .queryParam("client_id", googleOAuth2Properties.clientId)
-            .queryParam("redirect_uri", googleOAuth2Properties.redirectUri)
+            .queryParam("redirect_uri", googleOAuth2Properties.calculateRedirectUri(referer))
             .queryParam("response_type", "code")
             .queryParam("scope", googleOAuth2Properties.scope.joinToString(" "))
             .queryParam("access_type", "offline")
@@ -31,8 +31,8 @@ class GoogleOAuth2Handler(
             .toUriString()
     }
 
-    override fun fetchOAuth2User(authorizationCode: String): OAuth2User {
-        val tokenInfo: OAuth2TokenInfo = fetchTokenInfo(authorizationCode)
+    override fun fetchOAuth2User(authorizationCode: String, referer: String): OAuth2User {
+        val tokenInfo: OAuth2TokenInfo = fetchTokenInfo(authorizationCode, referer)
 
         val authorizationHeaderValue = StringBuilder()
             .append(tokenInfo.tokenPrefix)
@@ -45,13 +45,13 @@ class GoogleOAuth2Handler(
         return OAuth2User(userInfo, tokenInfo)
     }
 
-    private fun fetchTokenInfo(authorizationCode: String): OAuth2TokenInfo {
+    private fun fetchTokenInfo(authorizationCode: String, referer: String): OAuth2TokenInfo {
         val tokenRequest = LinkedMultiValueMap<String, String>().apply {
             add("client_id", googleOAuth2Properties.clientId)
             add("client_secret", googleOAuth2Properties.clientSecret)
             add("code", authorizationCode)
             add("grant_type", "authorization_code")
-            add("redirect_uri", googleOAuth2Properties.redirectUri)
+            add("redirect_uri", googleOAuth2Properties.calculateRedirectUri(referer))
         }
 
         val tokenResponse: GoogleTokenResponse = googleOAuth2TokenClient.fetchToken(tokenRequest)

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/support/security/oauth2/GoogleOAuth2Properties.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/support/security/oauth2/GoogleOAuth2Properties.kt
@@ -7,7 +7,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties
 data class GoogleOAuth2Properties(
     val clientId: String,
     val clientSecret: String,
-    val redirectPath: String,
+    private val redirectPath: String,
     val scope: List<String>
 ) {
 

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/support/security/oauth2/GoogleOAuth2Properties.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/support/security/oauth2/GoogleOAuth2Properties.kt
@@ -1,11 +1,17 @@
 package com.yourssu.scouter.common.implement.support.security.oauth2
 
+import java.net.URI
 import org.springframework.boot.context.properties.ConfigurationProperties
 
 @ConfigurationProperties(prefix = "oauth2.google")
 data class GoogleOAuth2Properties(
     val clientId: String,
     val clientSecret: String,
-    val redirectUri: String,
+    val redirectPath: String,
     val scope: List<String>
-)
+) {
+
+    fun calculateRedirectUri(referer: String): String {
+        return URI(referer).resolve(redirectPath).toString()
+    }
+}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -34,7 +34,7 @@ oauth2:
   google:
     client_id: scouter-google-client-id # REST API 키
     client_secret: scouter-google-secret-key # Client Secret 키
-    redirect_uri: redirect-uri
+    redirect_path: redirect-path # 리다이렉트 경로
     scope:
       - openid
       - https://www.googleapis.com/auth/userinfo.email


### PR DESCRIPTION
## 📄 작업 내용 요약
프론트 실배포 서버, qa용 서버, 개발환경(localhost 서버) 등 다양한 요청 주소에 동적으로 대응할 수 있도록 redirect url을 http request의 referer 헤더 값과 조합해서 반환

## 📎 Issue 번호
- closed #89 
