### PR TITLE
feat: #76 메일 전송 기능 추가

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -34,6 +34,14 @@ dependencies {
 	implementation("org.springframework.cloud:spring-cloud-starter-openfeign")
 	implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
 	implementation("org.jetbrains.kotlin:kotlin-reflect")
+
+	// mail
+	implementation("com.sun.mail:jakarta.mail:2.0.1")
+//	implementation("javax.activation:activation:1.1.1")
+	implementation("jakarta.activation:jakarta.activation-api:2.1.3")
+	implementation("com.sun.activation:jakarta.activation:2.0.1")
+
+	// jwt
 	implementation ("io.jsonwebtoken:jjwt-api:$jwtVersion")
 	runtimeOnly ("io.jsonwebtoken:jjwt-impl:$jwtVersion")
 	runtimeOnly ("io.jsonwebtoken:jjwt-jackson:$jwtVersion")

--- a/src/main/kotlin/com/yourssu/scouter/common/business/domain/mail/MailBodyFormat.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/business/domain/mail/MailBodyFormat.kt
@@ -1,0 +1,6 @@
+package com.yourssu.scouter.common.business.domain.mail
+
+enum class MailBodyFormat {
+    PLAIN_TEXT,
+    HTML,
+}

--- a/src/main/kotlin/com/yourssu/scouter/common/business/domain/mail/MailData.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/business/domain/mail/MailData.kt
@@ -1,0 +1,15 @@
+package com.yourssu.scouter.common.business.domain.mail
+
+import jakarta.mail.util.ByteArrayDataSource
+
+data class MailData(
+    val senderEmailAddress: String,
+    val receiverEmailAddresses: List<String> = emptyList(),
+    val ccEmailAddresses: List<String> = emptyList(),
+    val bccEmailAddresses: List<String> = emptyList(),
+    val mailSubject: String,
+    val mailBody: String,
+    val bodyFormat: MailBodyFormat,
+    val inlineImages: Map<String, ByteArrayDataSource> = emptyMap(),
+    val attachments: Map<String, ByteArrayDataSource> = emptyMap(),
+)

--- a/src/main/kotlin/com/yourssu/scouter/common/business/domain/mail/MailSender.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/business/domain/mail/MailSender.kt
@@ -1,0 +1,9 @@
+package com.yourssu.scouter.common.business.domain.mail
+
+interface MailSender {
+
+    fun send(
+        mailData: MailData,
+        accessToken: String,
+    )
+}

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/domain/mail/MimeMessageBuilder.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/domain/mail/MimeMessageBuilder.kt
@@ -1,0 +1,9 @@
+package com.yourssu.scouter.common.implement.domain.mail
+
+import com.yourssu.scouter.common.business.domain.mail.MailData
+import jakarta.mail.Session
+import jakarta.mail.internet.MimeMessage
+
+interface MimeMessageBuilder {
+    fun build(mailData: MailData, session: Session): MimeMessage
+}

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/domain/mail/MimeMessageBuilderResolver.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/domain/mail/MimeMessageBuilderResolver.kt
@@ -1,0 +1,28 @@
+package com.yourssu.scouter.common.implement.domain.mail
+
+import com.yourssu.scouter.common.business.domain.mail.MailBodyFormat
+import com.yourssu.scouter.common.business.domain.mail.MailData
+import com.yourssu.scouter.common.implement.domain.mail.builder.MultipartHtmlMimeMessageBuilder
+import com.yourssu.scouter.common.implement.domain.mail.builder.PlainTextOnlyMimeMessageBuilder
+import com.yourssu.scouter.common.implement.domain.mail.builder.SimpleHtmlMimeMessageBuilder
+import org.springframework.stereotype.Component
+
+@Component
+class MimeMessageBuilderResolver(
+    private val plainTextBuilder: PlainTextOnlyMimeMessageBuilder,
+    private val simpleHtmlBuilder: SimpleHtmlMimeMessageBuilder,
+    private val multipartHtmlBuilder: MultipartHtmlMimeMessageBuilder,
+) {
+
+    fun resolve(mailData: MailData): MimeMessageBuilder {
+        if (mailData.bodyFormat == MailBodyFormat.PLAIN_TEXT) {
+            return plainTextBuilder
+        }
+
+        if (mailData.inlineImages.isEmpty() && mailData.attachments.isEmpty()) {
+            return simpleHtmlBuilder
+        }
+
+        return multipartHtmlBuilder
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/domain/mail/builder/MimeMessageCommonHeaderApplier.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/domain/mail/builder/MimeMessageCommonHeaderApplier.kt
@@ -1,0 +1,24 @@
+package com.yourssu.scouter.common.implement.domain.mail.builder
+
+import com.yourssu.scouter.common.business.domain.mail.MailData
+import jakarta.mail.Address
+import jakarta.mail.Message
+import jakarta.mail.internet.InternetAddress
+import jakarta.mail.internet.MimeMessage
+import org.springframework.stereotype.Component
+
+@Component
+class MimeMessageCommonHeaderApplier {
+
+    fun applyHeader(message: MimeMessage, mailData: MailData) {
+        message.setFrom(InternetAddress(mailData.senderEmailAddress))
+        message.setRecipients(Message.RecipientType.TO, mailData.receiverEmailAddresses.toInternetAddresses())
+        message.setRecipients(Message.RecipientType.CC, mailData.ccEmailAddresses.toInternetAddresses())
+        message.setRecipients(Message.RecipientType.BCC, mailData.bccEmailAddresses.toInternetAddresses())
+        message.setSubject(mailData.mailSubject, "UTF-8")
+    }
+
+    private fun List<String>.toInternetAddresses(): Array<Address> {
+        return this.map { InternetAddress(it) }.toTypedArray()
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/domain/mail/builder/MultipartHtmlMimeMessageBuilder.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/domain/mail/builder/MultipartHtmlMimeMessageBuilder.kt
@@ -1,0 +1,55 @@
+package com.yourssu.scouter.common.implement.domain.mail.builder
+
+import com.yourssu.scouter.common.business.domain.mail.MailData
+import com.yourssu.scouter.common.implement.domain.mail.MimeMessageBuilder
+import jakarta.activation.DataHandler
+import jakarta.mail.Multipart
+import jakarta.mail.Session
+import jakarta.mail.internet.MimeBodyPart
+import jakarta.mail.internet.MimeMessage
+
+import jakarta.mail.internet.MimeMultipart
+import jakarta.mail.util.ByteArrayDataSource
+import org.springframework.stereotype.Component
+
+@Component
+class MultipartHtmlMimeMessageBuilder(
+    private val helper: MimeMessageCommonHeaderApplier,
+) : MimeMessageBuilder {
+
+    override fun build(mailData: MailData, session: Session): MimeMessage {
+        val mimeMessage = MimeMessage(session)
+        helper.applyHeader(mimeMessage, mailData)
+        mimeMessage.setContent(buildMultipart(mailData))
+
+        return mimeMessage
+    }
+    private fun buildMultipart(mailData: MailData): Multipart {
+        return MimeMultipart("related").apply {
+            addBodyPart(buildHtmlPart(mailData.mailBody))
+            mailData.inlineImages.forEach { addBodyPart(buildInlineImagePart(it.key, it.value)) }
+            mailData.attachments.forEach { addBodyPart(buildAttachmentPart(it.key, it.value)) }
+        }
+    }
+
+    private fun buildHtmlPart(body: String): MimeBodyPart {
+        return MimeBodyPart().apply {
+            setContent(body, "text/html; charset=utf-8")
+        }
+    }
+
+    private fun buildInlineImagePart(contentId: String, dataSource: ByteArrayDataSource): MimeBodyPart {
+        return MimeBodyPart().apply {
+            setHeader("Content-ID", "<$contentId>")
+            disposition = MimeBodyPart.INLINE
+            dataHandler = DataHandler(dataSource)
+        }
+    }
+
+    private fun buildAttachmentPart(name: String, dataSource: ByteArrayDataSource): MimeBodyPart {
+        return MimeBodyPart().apply {
+            fileName = name
+            dataHandler = DataHandler(dataSource)
+        }
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/domain/mail/builder/PlainTextOnlyMimeMessageBuilder.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/domain/mail/builder/PlainTextOnlyMimeMessageBuilder.kt
@@ -1,0 +1,21 @@
+package com.yourssu.scouter.common.implement.domain.mail.builder
+
+import com.yourssu.scouter.common.business.domain.mail.MailData
+import com.yourssu.scouter.common.implement.domain.mail.MimeMessageBuilder
+import jakarta.mail.Session
+import jakarta.mail.internet.MimeMessage
+import org.springframework.stereotype.Component
+
+@Component
+class PlainTextOnlyMimeMessageBuilder(
+    private val helper: MimeMessageCommonHeaderApplier
+) : MimeMessageBuilder {
+
+    override fun build(mailData: MailData, session: Session): MimeMessage {
+        val mimeMessage = MimeMessage(session)
+        helper.applyHeader(mimeMessage, mailData)
+        mimeMessage.setText(mailData.mailBody, "UTF-8")
+
+        return mimeMessage
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/domain/mail/builder/SimpleHtmlMimeMessageBuilder.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/domain/mail/builder/SimpleHtmlMimeMessageBuilder.kt
@@ -1,0 +1,20 @@
+package com.yourssu.scouter.common.implement.domain.mail.builder
+
+import com.yourssu.scouter.common.business.domain.mail.MailData
+import com.yourssu.scouter.common.implement.domain.mail.MimeMessageBuilder
+import jakarta.mail.Session
+import jakarta.mail.internet.MimeMessage
+import org.springframework.stereotype.Component
+
+@Component
+class SimpleHtmlMimeMessageBuilder(
+    private val helper: MimeMessageCommonHeaderApplier,
+) : MimeMessageBuilder {
+
+    override fun build(mailData: MailData, session: Session): MimeMessage {
+        return MimeMessage(session).apply {
+            helper.applyHeader(this, mailData)
+            setContent(mailData.mailBody, "text/html; charset=utf-8")
+        }
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/support/exception/MailFailedException.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/support/exception/MailFailedException.kt
@@ -1,0 +1,7 @@
+package com.yourssu.scouter.common.implement.support.exception
+
+import org.springframework.http.HttpStatus
+
+class MailFailedException(
+    message: String,
+): CustomException(message, "Mail-002", HttpStatus.BAD_GATEWAY)

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/support/google/GoogleMailClient.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/support/google/GoogleMailClient.kt
@@ -1,0 +1,28 @@
+package com.yourssu.scouter.common.implement.support.google
+
+import com.yourssu.scouter.common.implement.support.exception.MailFailedException
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
+import org.springframework.http.HttpStatus
+import org.springframework.stereotype.Component
+
+@Component
+class GoogleMailClient {
+
+    fun sendEmail(encodedEmail: String, bearerAccessToken: String) {
+        val requestBody = HttpRequest.BodyPublishers.ofString("""{"raw": "$encodedEmail"}""".trimIndent())
+        val request = HttpRequest.newBuilder()
+            .uri(java.net.URI.create("https://gmail.googleapis.com/gmail/v1/users/me/messages/send"))
+            .header("Authorization", bearerAccessToken)
+            .header("Content-Type", "application/json")
+            .POST(requestBody).build()
+
+        val client = HttpClient.newHttpClient()
+        val response: HttpResponse<String> = client.send(request, HttpResponse.BodyHandlers.ofString())
+
+        if (response.statusCode() >= HttpStatus.BAD_REQUEST.value()) {
+            throw MailFailedException("Failed to send email via Gmail API: ${response.statusCode()} ${response.body()}")
+        }
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/support/mail/GoogleMailSender.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/support/mail/GoogleMailSender.kt
@@ -1,0 +1,44 @@
+package com.yourssu.scouter.common.implement.support.mail
+
+import com.yourssu.scouter.common.business.domain.mail.MailSender
+import com.yourssu.scouter.common.business.domain.mail.MailData
+import com.yourssu.scouter.common.implement.domain.mail.MimeMessageBuilder
+import com.yourssu.scouter.common.implement.domain.mail.MimeMessageBuilderResolver
+import com.yourssu.scouter.common.implement.support.google.GoogleMailClient
+import jakarta.mail.Session
+import jakarta.mail.internet.MimeMessage
+import java.io.ByteArrayOutputStream
+import java.util.*
+import org.springframework.stereotype.Component
+
+@Component
+class GoogleMailSender(
+    private val googleMailClient: GoogleMailClient,
+    private val messageBuilderResolver: MimeMessageBuilderResolver,
+) : MailSender {
+
+    override fun send(mailData: MailData, accessToken: String) {
+        val messageBuilder: MimeMessageBuilder = messageBuilderResolver.resolve(mailData)
+
+        val properties = Properties().apply {
+            put("mail.smtp.auth", "true")
+            put("mail.smtp.starttls.enable", "true")
+            put("mail.smtp.host", "smtp.gmail.com")
+            put("mail.smtp.port", "587")
+        }
+        val session = Session.getInstance(properties, null)
+        val message: MimeMessage = messageBuilder.build(mailData, session)
+        val encodedEmail: String = encodeMessage(message)
+
+        googleMailClient.sendEmail(encodedEmail, accessToken)
+    }
+
+    private fun encodeMessage(message: MimeMessage): String {
+        val outputStream = ByteArrayOutputStream()
+        message.writeTo(outputStream)
+
+        val encoder: Base64.Encoder = Base64.getUrlEncoder()
+
+        return encoder.encodeToString(outputStream.toByteArray())
+    }
+}

--- a/src/test/kotlin/com/yourssu/scouter/common/implement/support/mail/GoogleMailSenderTest.kt
+++ b/src/test/kotlin/com/yourssu/scouter/common/implement/support/mail/GoogleMailSenderTest.kt
@@ -1,0 +1,60 @@
+package com.yourssu.scouter.common.implement.support.mail
+
+import com.yourssu.scouter.common.business.domain.mail.MailBodyFormat
+import com.yourssu.scouter.common.business.domain.mail.MailData
+import jakarta.mail.util.ByteArrayDataSource
+import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+
+@SpringBootTest
+@Suppress("NonAsciiCharacters")
+class GoogleMailSenderTest(
+
+    @Autowired
+    private val googleMailSender: GoogleMailSender,
+) {
+
+    @Test
+    @Disabled
+    fun HTML본문_인라인이미지_첨부파일_메일_전송_테스트() {
+        val body = """
+            <p>안녕하세요,</p>
+            <p>이메일 전송 기능 테스트입니다.</p>
+            <img src="cid:logo" alt="유어슈 로고">
+            <p>감사합니다.<br>- 권예진</p>
+        """.trimIndent()
+
+        val mailData = MailData(
+            senderEmailAddress = "encho.urssu@gmail.com",
+            receiverEmailAddresses = listOf("email1@gmail.com", "email2@naver.com"),
+            ccEmailAddresses = listOf("cc1@gmail.com", "cc2@naver.com"),
+            bccEmailAddresses = listOf("bcc1@gmail.com", "bcc2@naver.com"),
+            mailSubject = "메일 전송 테스트",
+            mailBody = body,
+            bodyFormat = MailBodyFormat.HTML,
+            inlineImages = mapOf(
+                "logo" to ByteArrayDataSource(
+                    this::class.java.getResourceAsStream("/static/logo.jpg")!!.readAllBytes(),
+                    "image/png",
+                ),
+            ),
+            attachments = mapOf(
+                "테스트1.pdf" to ByteArrayDataSource(
+                    this::class.java.getResourceAsStream("/static/테스트1.pdf")!!.readAllBytes(),
+                    "application/pdf",
+                ),
+                "테스트2.zip" to ByteArrayDataSource(
+                    this::class.java.getResourceAsStream("/static/테스트2.zip")!!.readAllBytes(),
+                    "application/zip",
+                ),
+            ),
+        )
+
+        googleMailSender.send(
+            mailData,
+            "Bearer access-token"
+        )
+    }
+}


### PR DESCRIPTION
## 📄 작업 내용 요약
- 구글로그인한 사용자의 access token과 구글 api 호출로 gmail 전송 가능
- 수신자, cc, bcc, 메일 제목, 메일 본문, 인라인 이미지(메일 본문에 삽입한 이미지), 첨부파일 설정해서 전송 가능
  - plain text, 단순 html, 인라인 이미지와 첨부파일이 포함된 multipart html 모두 사용 가능하도록 확장성있게 설계

## 📎 Issue 번호
- closed #76 
