### PR TITLE
fix:#110 Google Oauth 리다이렉트 경로 mismatch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,11 @@ src/main/resources/application-dev.yml
 src/main/resources/application-prod.yml
 src/main/resources/applicant-sync-mapping-data.yml
 
+### Local Environment Variables ###
+.env
+.env.local
+env.local
+
 ### STS ###
 .apt_generated
 .classpath

--- a/env.example
+++ b/env.example
@@ -1,0 +1,7 @@
+GOOGLE_OAUTH_CLIENT_ID=your-google-client-id
+GOOGLE_OAUTH_CLIENT_SECRET=your-google-client-secret
+
+GOOGLE_OAUTH_REDIRECT_PATH=redirect-path
+
+JWT_ACCESS_KEY=LocalAccessKeyForDevelopment
+JWT_REFRESH_KEY=LocalRefreshKeyForDevelopment

--- a/src/main/kotlin/com/yourssu/scouter/common/application/domain/authentication/AuthenticationController.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/application/domain/authentication/AuthenticationController.kt
@@ -17,12 +17,15 @@ import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestHeader
 import org.springframework.web.bind.annotation.RestController
+import org.slf4j.LoggerFactory
 
 @RestController
 class AuthenticationController(
     private val authenticationService: AuthenticationService,
     private val oauth2Service: OAuth2Service,
 ) {
+
+    private val logger = LoggerFactory.getLogger(AuthenticationController::class.java)
 
     @PostMapping("oauth2/login/{oauth2Type}")
     fun login(
@@ -32,6 +35,7 @@ class AuthenticationController(
     ): ResponseEntity<LoginResponse> {
         val referer = httpServletRequest.getHeader(HttpHeaders.REFERER)
             ?: "http://localhost:8080"
+        logger.info("[Auth] POST /oauth2/login/{} | referer={}", oauth2Type, referer)
 
         val loginResult: LoginResult = oauth2Service.login(
             oauth2Type = oauth2Type,
@@ -66,10 +70,13 @@ class AuthenticationController(
     @PostMapping("/refresh-token")
     fun refreshToken(
         @RequestBody @Valid request: TokenRefreshRequest,
+        @RequestHeader(HttpHeaders.AUTHORIZATION, required = false) bearerRefreshHeader: String?,
     ): ResponseEntity<TokenRefreshResponse> {
+        logger.info("[Auth] POST /refresh-token | hasAuthHeader={} | bodyPresent={}", !bearerRefreshHeader.isNullOrBlank(), !request.refreshToken.isNullOrBlank())
         val requestTime = LocalDateTime.now()
-        val tokenDto: TokenDto = authenticationService.refreshToken(requestTime, request.refreshToken)
-        val response = TokenRefreshResponse.from(tokenDto)
+        val providedRefreshToken = if (!bearerRefreshHeader.isNullOrBlank()) bearerRefreshHeader else request.refreshToken
+        val tokenDto: TokenDto = authenticationService.refreshToken(requestTime, providedRefreshToken)
+        val response: TokenRefreshResponse = TokenRefreshResponse.from(tokenDto)
 
         return ResponseEntity.ok(response)
     }

--- a/src/main/kotlin/com/yourssu/scouter/common/application/domain/authentication/AuthenticationController.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/application/domain/authentication/AuthenticationController.kt
@@ -35,12 +35,14 @@ class AuthenticationController(
     ): ResponseEntity<LoginResponse> {
         val referer = httpServletRequest.getHeader(HttpHeaders.REFERER)
             ?: "http://localhost:8080"
-        logger.info("[Auth] POST /oauth2/login/{} | referer={}", oauth2Type, referer)
+        val redirectUriFromClient = request.redirectUri
+        logger.info("[Auth] POST /oauth2/login/{} | referer={} | redirectUri={}", oauth2Type, referer, redirectUriFromClient)
 
         val loginResult: LoginResult = oauth2Service.login(
             oauth2Type = oauth2Type,
             oauth2AuthorizationCode = request.authorizationCode,
             referer = referer,
+            redirectUriOverride = redirectUriFromClient,
         )
         val response: LoginResponse = LoginResponse.from(loginResult)
 

--- a/src/main/kotlin/com/yourssu/scouter/common/application/domain/authentication/OAuth2Controller.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/application/domain/authentication/OAuth2Controller.kt
@@ -8,7 +8,9 @@ import org.springframework.http.HttpHeaders
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.util.UriComponentsBuilder
 
 @RestController
 class OAuth2Controller(
@@ -20,6 +22,7 @@ class OAuth2Controller(
         @PathVariable oauth2Type: OAuth2Type,
         response: HttpServletResponse,
         httpServletRequest: HttpServletRequest,
+        @RequestParam(required = false) returnTo: String?,
     ): ResponseEntity<Unit> {
         val referer = httpServletRequest.getHeader(HttpHeaders.REFERER)
             ?: "http://localhost:8080"
@@ -29,7 +32,16 @@ class OAuth2Controller(
             referer = referer,
         )
 
-        response.sendRedirect(redirectUrl)
+        val finalRedirectUrl = if (!returnTo.isNullOrBlank()) {
+            UriComponentsBuilder.fromUriString(redirectUrl)
+                .queryParam("state", "returnTo=$returnTo")
+                .build()
+                .toUriString()
+        } else {
+            redirectUrl
+        }
+
+        response.sendRedirect(finalRedirectUrl)
 
         return ResponseEntity.ok().build()
     }

--- a/src/main/kotlin/com/yourssu/scouter/common/application/domain/authentication/OAuth2Controller.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/application/domain/authentication/OAuth2Controller.kt
@@ -22,7 +22,6 @@ class OAuth2Controller(
         @PathVariable oauth2Type: OAuth2Type,
         response: HttpServletResponse,
         httpServletRequest: HttpServletRequest,
-        @RequestParam(required = false) returnTo: String?,
     ): ResponseEntity<Unit> {
         val referer = httpServletRequest.getHeader(HttpHeaders.REFERER)
             ?: "http://localhost:8080"
@@ -32,16 +31,7 @@ class OAuth2Controller(
             referer = referer,
         )
 
-        val finalRedirectUrl = if (!returnTo.isNullOrBlank()) {
-            UriComponentsBuilder.fromUriString(redirectUrl)
-                .queryParam("state", "returnTo=$returnTo")
-                .build()
-                .toUriString()
-        } else {
-            redirectUrl
-        }
-
-        response.sendRedirect(finalRedirectUrl)
+        response.sendRedirect(redirectUrl)
 
         return ResponseEntity.ok().build()
     }

--- a/src/main/kotlin/com/yourssu/scouter/common/application/domain/authentication/OAuth2LoginRequest.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/application/domain/authentication/OAuth2LoginRequest.kt
@@ -6,4 +6,6 @@ data class OAuth2LoginRequest(
 
     @field:NotBlank(message = "authorization code가 입력되지 않았습니다.")
     val authorizationCode: String,
+    // 프론트가 넘긴 redirect_uri를 신뢰(allowlist 검증 전제)
+    val redirectUri: String? = null,
 )

--- a/src/main/kotlin/com/yourssu/scouter/common/application/support/authentication/LoginInterceptor.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/application/support/authentication/LoginInterceptor.kt
@@ -9,11 +9,14 @@ import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpMethod
 import org.springframework.stereotype.Component
 import org.springframework.web.servlet.HandlerInterceptor
+import org.slf4j.LoggerFactory
 
 @Component
 class LoginInterceptor(
     private val authenticationService: AuthenticationService,
 ) : HandlerInterceptor {
+
+    private val logger = LoggerFactory.getLogger(LoginInterceptor::class.java)
 
     override fun preHandle(request: HttpServletRequest, response: HttpServletResponse, handler: Any): Boolean {
         if (isPreflightRequest(request)) {
@@ -21,6 +24,11 @@ class LoginInterceptor(
         }
 
         val accessToken: String? = request.getHeader(HttpHeaders.AUTHORIZATION)
+        if (accessToken.isNullOrEmpty()) {
+            logger.warn("[LoginInterceptor] Missing Authorization | {} {}", request.method, request.requestURI)
+        } else if (!accessToken.startsWith("Bearer ")) {
+            logger.warn("[LoginInterceptor] Invalid Authorization prefix | {} {} | preview={}", request.method, request.requestURI, accessToken.take(12) + "...")
+        }
         if (accessToken.isNullOrEmpty()) {
             throw LoginRequiredException("로그인이 필요한 기능입니다.")
         }

--- a/src/main/kotlin/com/yourssu/scouter/common/application/support/configuration/RequestLoggingFilter.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/application/support/configuration/RequestLoggingFilter.kt
@@ -1,0 +1,32 @@
+package com.yourssu.scouter.common.application.support.configuration
+
+import jakarta.servlet.FilterChain
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
+import org.springframework.web.filter.OncePerRequestFilter
+
+@Component
+class RequestLoggingFilter : OncePerRequestFilter() {
+
+    private val log = LoggerFactory.getLogger(RequestLoggingFilter::class.java)
+
+    override fun doFilterInternal(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        filterChain: FilterChain,
+    ) {
+        val method = request.method
+        val uri = request.requestURI
+        if (!method.equals("OPTIONS", ignoreCase = true)) {
+            val referer = request.getHeader("Referer")
+            val origin = request.getHeader("Origin")
+            val auth = request.getHeader("Authorization")
+            val authPreview = auth?.let { if (it.length > 12) it.substring(0, 12) + "..." else it } ?: "<none>"
+            log.info("[ACCESS] {} {} | origin={} | referer={} | auth={}", method, uri, origin, referer, authPreview)
+        }
+
+        filterChain.doFilter(request, response)
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/common/application/support/exception/CommonExceptionHandler.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/application/support/exception/CommonExceptionHandler.kt
@@ -2,6 +2,7 @@ package com.yourssu.scouter.common.application.support.exception
 
 import com.yourssu.scouter.common.implement.support.exception.CustomException
 import java.util.stream.Collectors
+import jakarta.servlet.http.HttpServletRequest
 import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatus
 import org.springframework.http.HttpStatusCode
@@ -77,8 +78,23 @@ class CommonExceptionHandler: ResponseEntityExceptionHandler() {
     }
 
     @ExceptionHandler(CustomException::class)
-    fun handleCustomException(ex: CustomException): ResponseEntity<ExceptionResponse> {
-        logger.warn(String.format(LOG_MESSAGE_FORMAT, ex.javaClass.simpleName, ex.message), ex)
+    fun handleCustomException(ex: CustomException, request: HttpServletRequest): ResponseEntity<ExceptionResponse> {
+        val method = request.method
+        val uri = request.requestURI
+        val authHeader: String? = request.getHeader(HttpHeaders.AUTHORIZATION)
+        val authPreview = authHeader?.let { if (it.length > 12) it.substring(0, 12) + "..." else it }
+
+        logger.warn(
+            String.format(
+                "$LOG_MESSAGE_FORMAT | %s %s | Authorization=%s",
+                ex.javaClass.simpleName,
+                ex.message,
+                method,
+                uri,
+                authPreview ?: "<none>"
+            ),
+            ex
+        )
 
         val response = ExceptionResponse(
             status = ex.status,

--- a/src/main/kotlin/com/yourssu/scouter/common/business/domain/authentication/AuthenticationService.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/business/domain/authentication/AuthenticationService.kt
@@ -56,7 +56,8 @@ class AuthenticationService(
     }
 
     fun refreshToken(requestTime: LocalDateTime, refreshToken: String): TokenDto {
-        val privateClaims: PrivateClaims = getValidPrivateClaims(TokenType.REFRESH, refreshToken)
+        val normalizedRefreshToken = if (refreshToken.startsWith("Bearer ")) refreshToken else "Bearer $refreshToken"
+        val privateClaims: PrivateClaims = getValidPrivateClaims(TokenType.REFRESH, normalizedRefreshToken)
         val token: Token = tokenProcessor.generateToken(requestTime, privateClaims.toMap())
 
         return TokenDto(token.accessToken, token.refreshToken)

--- a/src/main/kotlin/com/yourssu/scouter/common/business/domain/authentication/OAuth2Service.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/business/domain/authentication/OAuth2Service.kt
@@ -31,12 +31,14 @@ class OAuth2Service(
     fun login(
         oauth2Type: OAuth2Type,
         oauth2AuthorizationCode: String,
-        referer: String
+        referer: String,
+        redirectUriOverride: String?
     ): LoginResult {
         val oauth2User: OAuth2User = fetchOAuth2User(
             oauth2Type = oauth2Type,
             authorizationCode = oauth2AuthorizationCode,
-            referer = referer
+            referer = referer,
+            redirectUriOverride = redirectUriOverride,
         )
         val loginUser: User = createOrUpdate(oauth2User)
 
@@ -58,10 +60,11 @@ class OAuth2Service(
         oauth2Type: OAuth2Type,
         authorizationCode: String,
         referer: String,
+        redirectUriOverride: String?,
     ): OAuth2User {
         val oauth2Handler: OAuth2Handler = oauth2HandlerComposite.findHandler(oauth2Type)
 
-        return oauth2Handler.fetchOAuth2User(authorizationCode, referer)
+        return oauth2Handler.fetchOAuth2User(authorizationCode, referer, redirectUriOverride)
     }
 
     private fun createOrUpdate(oauth2User: OAuth2User): User {

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/domain/authentication/OAuth2Handler.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/domain/authentication/OAuth2Handler.kt
@@ -4,6 +4,6 @@ interface OAuth2Handler {
 
     fun getSupportingOAuth2Type(): OAuth2Type
     fun provideAuthCodeRequestUrl(referer: String): String
-    fun fetchOAuth2User(authorizationCode: String, referer: String): OAuth2User
+    fun fetchOAuth2User(authorizationCode: String, referer: String, redirectUriOverride: String? = null): OAuth2User
     fun refreshAccessToken(refreshToken: String): OAuth2TokenInfo
 }

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/support/configuration/OpenFeignConfiguration.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/support/configuration/OpenFeignConfiguration.kt
@@ -1,9 +1,16 @@
 package com.yourssu.scouter.common.implement.support.configuration
 
+import feign.Logger
 import org.springframework.cloud.openfeign.EnableFeignClients
+import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Profile
 
 @Configuration
 @EnableFeignClients(basePackages = ["com.yourssu.scouter"])
 class OpenFeignConfiguration {
+
+    @Bean
+    @Profile("local", "dev")
+    fun feignLoggerLevel(): Logger.Level = Logger.Level.FULL
 }

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/support/security/oauth2/GoogleOAuth2Handler.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/support/security/oauth2/GoogleOAuth2Handler.kt
@@ -33,8 +33,8 @@ class GoogleOAuth2Handler(
             .toUriString()
     }
 
-    override fun fetchOAuth2User(authorizationCode: String, referer: String): OAuth2User {
-        val tokenInfo: OAuth2TokenInfo = fetchTokenInfo(authorizationCode, referer)
+    override fun fetchOAuth2User(authorizationCode: String, referer: String, redirectUriOverride: String?): OAuth2User {
+        val tokenInfo: OAuth2TokenInfo = fetchTokenInfo(authorizationCode, referer, redirectUriOverride)
 
         val authorizationHeaderValue = StringBuilder()
             .append(tokenInfo.tokenPrefix)
@@ -47,9 +47,10 @@ class GoogleOAuth2Handler(
         return OAuth2User(userInfo, tokenInfo)
     }
 
-    private fun fetchTokenInfo(authorizationCode: String, referer: String): OAuth2TokenInfo {
-        val redirectUri = googleOAuth2Properties.redirectUri
-            ?: googleOAuth2Properties.calculateRedirectUri(referer)
+    private fun fetchTokenInfo(authorizationCode: String, referer: String, redirectUriOverride: String?): OAuth2TokenInfo {
+        val redirectUri =
+            selectAllowedRedirectUri(redirectUriOverride)
+                ?: (googleOAuth2Properties.redirectUri ?: googleOAuth2Properties.calculateRedirectUri(referer))
         logger.info(">>> [GoogleOAuth2Handler] using redirect_uri={}", redirectUri)
 
         val tokenRequest = LinkedMultiValueMap<String, String>().apply {
@@ -83,6 +84,14 @@ class GoogleOAuth2Handler(
             tokenPrefix = tokenResponse.tokenType,
             expiresIn = tokenResponse.expiresIn,
         )
+    }
+
+    private fun selectAllowedRedirectUri(candidate: String?): String? {
+        if (candidate.isNullOrBlank()) return null
+        val trimmed = candidate.trim()
+        val allowList = googleOAuth2Properties.allowedRedirectUris ?: emptyList()
+        val ok = allowList.any { allowed -> trimmed.equals(allowed, ignoreCase = true) }
+        return if (ok) trimmed else null
     }
 
     override fun refreshAccessToken(refreshToken: String): OAuth2TokenInfo {

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/support/security/oauth2/GoogleOAuth2Handler.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/support/security/oauth2/GoogleOAuth2Handler.kt
@@ -1,7 +1,10 @@
 package com.yourssu.scouter.common.implement.support.security.oauth2
 
 import com.yourssu.scouter.common.implement.domain.authentication.*
-import org.hibernate.query.sqm.tree.SqmNode.log
+import com.yourssu.scouter.common.implement.support.exception.CustomException
+import feign.FeignException
+import org.springframework.http.HttpStatus
+import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
 import org.springframework.util.LinkedMultiValueMap
 import org.springframework.web.util.UriComponentsBuilder
@@ -13,6 +16,8 @@ class GoogleOAuth2Handler(
     val googleOAuth2TokenClient: GoogleOAuth2TokenClient,
     val googleUserApiClient: GoogleUserApiClient,
 ) : OAuth2Handler {
+
+    private val logger = LoggerFactory.getLogger(GoogleOAuth2Handler::class.java)
 
     override fun getSupportingOAuth2Type() = OAuth2Type.GOOGLE
 
@@ -44,8 +49,8 @@ class GoogleOAuth2Handler(
 
     private fun fetchTokenInfo(authorizationCode: String, referer: String): OAuth2TokenInfo {
         val redirectUri = googleOAuth2Properties.redirectUri
-            ?: googleOAuth2Properties.calculateRedirectUri()
-        log.info(">>> [GoogleOAuth2Handler] using redirect_uri=$redirectUri")
+            ?: googleOAuth2Properties.calculateRedirectUri(referer)
+        logger.info(">>> [GoogleOAuth2Handler] using redirect_uri={}", redirectUri)
 
         val tokenRequest = LinkedMultiValueMap<String, String>().apply {
             add("client_id", googleOAuth2Properties.clientId)
@@ -55,7 +60,22 @@ class GoogleOAuth2Handler(
             add("redirect_uri", redirectUri)
         }
 
-        val tokenResponse: GoogleTokenResponse = googleOAuth2TokenClient.fetchToken(tokenRequest)
+        val tokenResponse: GoogleTokenResponse = try {
+            googleOAuth2TokenClient.fetchToken(tokenRequest)
+        } catch (e: FeignException) {
+            val status = e.status()
+            val body = try { e.contentUTF8() } catch (_: Throwable) { null }
+            logger.error(
+                ">>> [GoogleOAuth2Handler] token exchange failed: status={}, redirect_uri={}, body={}",
+                status, redirectUri, body
+            )
+            val mappedStatus = if (status == 401) HttpStatus.UNAUTHORIZED else HttpStatus.BAD_REQUEST
+            throw CustomException(
+                message = "OAuth2 토큰 교환 실패(${status})",
+                errorCode = "OAuth-Token-Exchange-Fail",
+                status = mappedStatus
+            )
+        }
 
         return OAuth2TokenInfo(
             accessToken = tokenResponse.accessToken,
@@ -73,7 +93,22 @@ class GoogleOAuth2Handler(
             add("grant_type", "refresh_token")
         }
 
-        val tokenResponse: GoogleTokenResponse = googleOAuth2TokenClient.fetchToken(refreshRequest)
+        val tokenResponse: GoogleTokenResponse = try {
+            googleOAuth2TokenClient.fetchToken(refreshRequest)
+        } catch (e: FeignException) {
+            val status = e.status()
+            val body = try { e.contentUTF8() } catch (_: Throwable) { null }
+            logger.error(
+                ">>> [GoogleOAuth2Handler] refresh token failed: status={}, body={}",
+                status, body
+            )
+            val mappedStatus = if (status == 401) HttpStatus.UNAUTHORIZED else HttpStatus.BAD_REQUEST
+            throw CustomException(
+                message = "OAuth2 토큰 갱신 실패(${status})",
+                errorCode = "OAuth-Token-Refresh-Fail",
+                status = mappedStatus
+            )
+        }
 
         return OAuth2TokenInfo(
             accessToken = tokenResponse.accessToken,

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/support/security/oauth2/GoogleOAuth2Handler.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/support/security/oauth2/GoogleOAuth2Handler.kt
@@ -22,9 +22,10 @@ class GoogleOAuth2Handler(
     override fun getSupportingOAuth2Type() = OAuth2Type.GOOGLE
 
     override fun provideAuthCodeRequestUrl(referer: String): String {
+        val redirectUri = resolveRedirectUri(referer, null)
         return UriComponentsBuilder.fromUriString("https://accounts.google.com/o/oauth2/auth")
             .queryParam("client_id", googleOAuth2Properties.clientId)
-            .queryParam("redirect_uri", googleOAuth2Properties.calculateRedirectUri(referer))
+            .queryParam("redirect_uri", redirectUri)
             .queryParam("response_type", "code")
             .queryParam("scope", googleOAuth2Properties.scope.joinToString(" "))
             .queryParam("access_type", "offline")
@@ -48,9 +49,7 @@ class GoogleOAuth2Handler(
     }
 
     private fun fetchTokenInfo(authorizationCode: String, referer: String, redirectUriOverride: String?): OAuth2TokenInfo {
-        val redirectUri =
-            selectAllowedRedirectUri(redirectUriOverride)
-                ?: (googleOAuth2Properties.redirectUri ?: googleOAuth2Properties.calculateRedirectUri(referer))
+        val redirectUri = resolveRedirectUri(referer, redirectUriOverride)
         logger.info(">>> [GoogleOAuth2Handler] using redirect_uri={}", redirectUri)
 
         val tokenRequest = LinkedMultiValueMap<String, String>().apply {
@@ -141,5 +140,11 @@ class GoogleOAuth2Handler(
             email = userInfoResponse.email,
             profileImageUrl = userInfoResponse.picture ?: "",
         )
+    }
+
+    private fun resolveRedirectUri(referer: String, redirectUriOverride: String?): String {
+        val fromOverride = selectAllowedRedirectUri(redirectUriOverride)
+        return fromOverride ?: (googleOAuth2Properties.redirectUri
+            ?: googleOAuth2Properties.calculateRedirectUri(referer))
     }
 }

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/support/security/oauth2/GoogleOAuth2Properties.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/support/security/oauth2/GoogleOAuth2Properties.kt
@@ -11,6 +11,7 @@ data class GoogleOAuth2Properties(
 
     // 새 절대 URL도 널 허용 (없으면 path로 계산)
     var redirectUri: String? = null,
+    var allowedRedirectUris: List<String>? = null,
     val scope: List<String>
 ) {
 

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -26,15 +26,15 @@ spring:
       - http://localhost:5173
 token:
   jwt:
-    access-key: ThisIsLocalAccessKeyThisIsLocalAccessKey
-    refresh-key: ThisIsLocalRefreshKeyThisIsLocalRefreshKey
+    access-key: ${JWT_ACCESS_KEY}
+    refresh-key: ${JWT_REFRESH_KEY}
     access-expired-hours: 1 # 1시간
     refresh-expired-hours: 336  # 14일
 oauth2:
   google:
-    client_id: scouter-google-client-id # REST API 키
-    client_secret: scouter-google-secret-key # Client Secret 키
-    redirect_path: redirect-path # 리다이렉트 경로
+    client_id: ${GOOGLE_OAUTH_CLIENT_ID} # 환경변수에서 주입
+    client_secret: ${GOOGLE_OAUTH_CLIENT_SECRET} # 환경변수에서 주입
+    redirect_uri: ${GOOGLE_OAUTH_REDIRECT_URI} # 환경변수에서 주입 (전체 URL)
     scope:
       - openid
       - https://www.googleapis.com/auth/userinfo.email

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -35,6 +35,9 @@ oauth2:
     client_id: ${GOOGLE_OAUTH_CLIENT_ID} # 환경변수에서 주입
     client_secret: ${GOOGLE_OAUTH_CLIENT_SECRET} # 환경변수에서 주입
     redirect_uri: ${GOOGLE_OAUTH_REDIRECT_URI} # 환경변수에서 주입 (전체 URL)
+    allowed_redirect_uris:
+      - ${ALLOWED_REDIRECT_URI_LOCAL}
+      - ${ALLOWED_REDIRECT_URI_DEV}
     scope:
       - openid
       - https://www.googleapis.com/auth/userinfo.email


### PR DESCRIPTION
## 📄 작업 내용 요약
### 배경
Google OAuth에서 redirect_uri_mismatch 발생. 
인가 단계와 토큰 교환 단계의 redirect_uri가 일치하지 않았음.
토큰 교환 시 referer 기반 calculateRedirectUri(referer) 사용으로 referer에 의존하여 값이 들쭉날쭉 달라졌음.

### 변경사항
oauth2.google.redirect_uri(절대 URL) 설정 도입 및 우선 사용.
GoogleOAuth2Handler: 토큰 교환 요청의 redirect_uri를 절대값으로 고정. allowlist 검증 지원
application-*.yml: 환경별 redirect_uri와 allowed_redirect_uris 구성.

+) 로깅 강화: 실제 전송한 redirect_uri를 INFO로 기록
+) 부가: 요청/예외 로깅, refresh-token 처리 정비, env 변수화

### 설계의도
- Google 정책상 인가와 토큰 교환의 redirect_uri는 완전 동일해야 하며, 절대 URL을 고정하는 것이 가장 안전
- referer 의존 계산은 프록시/호스트 전개(Nginx, 디버그 엔드포인트, localhost 등) 상황에서 변동성이 큼
- allowlist로 FE가 넘겨준 redirect_uri를 검증·허용하면 로컬/스테이징 전환도 통제 가능

## 📎 Issue 번호
closed #110 

## 특이사항
...잘 고쳤는지 모르겠어요..ㅠㅡㅠ 아직 완전히 이해한건 아닌데 그냥 yml 에 redirect_uri을 고정시켜서 들쭉날쭉하는 걸 막았다는 느낌만 들어요...
