### PR TITLE
feat: #111 메일 템플릿 CRUD API 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@ src/main/resources/application-dev.yml
 src/main/resources/application-prod.yml
 src/main/resources/applicant-sync-mapping-data.yml
 
+.env
+.env.local
+
 ### STS ###
 .apt_generated
 .classpath

--- a/src/main/kotlin/com/yourssu/scouter/common/application/domain/mail/template/CreateMailTemplateRequest.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/application/domain/mail/template/CreateMailTemplateRequest.kt
@@ -16,12 +16,26 @@ data class CreateMailTemplateRequest(
 ) {
     data class TemplateVariableRequest(
         val key: String,
-        val type: VariableType,
+        val type: VariableType?,
         val displayName: String,
         val perRecipient: Boolean,
     )
 
     fun toDomain(createdBy: Long): MailTemplate {
+        // validation rules:
+        // - fixed keys: "applicant", "partName" -> type must be null
+        // - variable keys: start with "var-" -> type must not be null
+        variables.forEach { v ->
+            val isFixed = v.key == "applicant" || v.key == "partName"
+            val isVar = v.key.startsWith("var-")
+            if (isFixed && v.type != null) {
+                throw IllegalArgumentException("Fixed key '${v.key}' must not have a type")
+            }
+            if (isVar && v.type == null) {
+                throw IllegalArgumentException("Variable key '${v.key}' must have a type")
+            }
+        }
+
         return MailTemplate(
             title = title,
             bodyHtml = bodyHtml,

--- a/src/main/kotlin/com/yourssu/scouter/common/application/domain/mail/template/CreateMailTemplateRequest.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/application/domain/mail/template/CreateMailTemplateRequest.kt
@@ -22,20 +22,6 @@ data class CreateMailTemplateRequest(
     )
 
     fun toDomain(createdBy: Long): MailTemplate {
-        // validation rules:
-        // - fixed keys: "applicant", "partName" -> type must be null
-        // - variable keys: start with "var-" -> type must not be null
-        variables.forEach { v ->
-            val isFixed = v.key == "applicant" || v.key == "partName"
-            val isVar = v.key.startsWith("var-")
-            if (isFixed && v.type != null) {
-                throw IllegalArgumentException("Fixed key '${v.key}' must not have a type")
-            }
-            if (isVar && v.type == null) {
-                throw IllegalArgumentException("Variable key '${v.key}' must have a type")
-            }
-        }
-
         return MailTemplate(
             title = title,
             bodyHtml = bodyHtml,

--- a/src/main/kotlin/com/yourssu/scouter/common/application/domain/mail/template/CreateMailTemplateRequest.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/application/domain/mail/template/CreateMailTemplateRequest.kt
@@ -1,0 +1,32 @@
+package com.yourssu.scouter.common.application.domain.mail.template
+
+import com.yourssu.scouter.common.implement.domain.mail.template.MailTemplate
+import com.yourssu.scouter.common.implement.domain.mail.template.TemplateVariable
+import com.yourssu.scouter.common.implement.domain.mail.template.VariableType
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotNull
+
+data class CreateMailTemplateRequest(
+    @field:NotBlank
+    val title: String,
+    @field:NotBlank
+    val bodyHtml: String,
+    @field:NotNull
+    val variables: List<TemplateVariableRequest> = emptyList(),
+) {
+    data class TemplateVariableRequest(
+        val key: String,
+        val type: VariableType,
+        val displayName: String,
+        val perRecipient: Boolean,
+    )
+
+    fun toDomain(createdBy: Long): MailTemplate {
+        return MailTemplate(
+            title = title,
+            bodyHtml = bodyHtml,
+            variables = variables.map { TemplateVariable(it.key, it.type, it.displayName, it.perRecipient) },
+            createdBy = createdBy,
+        )
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/common/application/domain/mail/template/CreateMailTemplateResponse.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/application/domain/mail/template/CreateMailTemplateResponse.kt
@@ -1,0 +1,19 @@
+package com.yourssu.scouter.common.application.domain.mail.template
+
+import com.yourssu.scouter.common.implement.domain.mail.template.MailTemplate
+
+data class CreateMailTemplateResponse(
+    val id: Long,
+    val title: String,
+    val updatedAt: java.time.LocalDateTime,
+) {
+    companion object {
+        fun from(template: MailTemplate): CreateMailTemplateResponse {
+            return CreateMailTemplateResponse(
+                id = template.id!!,
+                title = template.title,
+                updatedAt = template.updatedAt!!,
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/common/application/domain/mail/template/MailTemplateController.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/application/domain/mail/template/MailTemplateController.kt
@@ -12,6 +12,8 @@ import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
 
 @RestController
 @RequestMapping("/api/mails/templates")
@@ -50,5 +52,15 @@ class MailTemplateController(
             totalPages = pageResult.totalPages,
         )
         return ResponseEntity.ok(response)
+    }
+
+    @GetMapping("/{templateId}")
+    fun readDetail(
+        @PathVariable templateId: Long,
+    ): ResponseEntity<ReadMailTemplateDetailResponse> {
+        val template = mailTemplateService.readTemplate(templateId)
+            ?: return ResponseEntity.notFound().build()
+
+        return ResponseEntity.ok(ReadMailTemplateDetailResponse.from(template))
     }
 }

--- a/src/main/kotlin/com/yourssu/scouter/common/application/domain/mail/template/MailTemplateController.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/application/domain/mail/template/MailTemplateController.kt
@@ -15,6 +15,7 @@ import org.springframework.web.bind.annotation.RestController
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.DeleteMapping
 
 @RestController
 @RequestMapping("/api/mails/templates")
@@ -74,5 +75,13 @@ class MailTemplateController(
         val domain: MailTemplate = request.toDomain(createdBy = authUserInfo.userId)
         val updated = mailTemplateService.updateTemplate(templateId, domain) ?: return ResponseEntity.notFound().build()
         return ResponseEntity.ok(CreateMailTemplateResponse.from(updated))
+    }
+
+    @DeleteMapping("/{templateId}")
+    fun delete(
+        @PathVariable templateId: Long,
+    ): ResponseEntity<Unit> {
+        val deleted = mailTemplateService.deleteTemplate(templateId)
+        return if (deleted) ResponseEntity.noContent().build() else ResponseEntity.notFound().build()
     }
 }

--- a/src/main/kotlin/com/yourssu/scouter/common/application/domain/mail/template/MailTemplateController.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/application/domain/mail/template/MailTemplateController.kt
@@ -14,6 +14,7 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PutMapping
 
 @RestController
 @RequestMapping("/api/mails/templates")
@@ -62,5 +63,16 @@ class MailTemplateController(
             ?: return ResponseEntity.notFound().build()
 
         return ResponseEntity.ok(ReadMailTemplateDetailResponse.from(template))
+    }
+
+    @PutMapping("/{templateId}")
+    fun update(
+        @AuthUser authUserInfo: AuthUserInfo,
+        @PathVariable templateId: Long,
+        @RequestBody request: CreateMailTemplateRequest,
+    ): ResponseEntity<CreateMailTemplateResponse> {
+        val domain: MailTemplate = request.toDomain(createdBy = authUserInfo.userId)
+        val updated = mailTemplateService.updateTemplate(templateId, domain) ?: return ResponseEntity.notFound().build()
+        return ResponseEntity.ok(CreateMailTemplateResponse.from(updated))
     }
 }

--- a/src/main/kotlin/com/yourssu/scouter/common/application/domain/mail/template/MailTemplateController.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/application/domain/mail/template/MailTemplateController.kt
@@ -5,6 +5,9 @@ import com.yourssu.scouter.common.application.support.authentication.AuthUserInf
 import com.yourssu.scouter.common.business.domain.mail.template.MailTemplateService
 import com.yourssu.scouter.common.implement.domain.mail.template.MailTemplate
 import org.springframework.http.ResponseEntity
+import org.springframework.data.domain.PageRequest
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
@@ -24,5 +27,28 @@ class MailTemplateController(
         val domain: MailTemplate = request.toDomain(createdBy = authUserInfo.userId)
         val saved: MailTemplate = mailTemplateService.createTemplate(domain)
         return ResponseEntity.status(201).body(CreateMailTemplateResponse.from(saved))
+    }
+
+    @GetMapping
+    fun readAll(
+        @RequestParam(required = false, defaultValue = "0") page: Int,
+        @RequestParam(required = false, defaultValue = "20") size: Int,
+        @RequestParam(required = false, defaultValue = "updatedAt,desc") sort: String,
+    ): ResponseEntity<PageResponse<ReadMailTemplateSummaryResponse>> {
+        val sortParts = sort.split(",")
+        val pageable = PageRequest.of(page, size, org.springframework.data.domain.Sort.by(
+            if (sortParts.size >= 2 && sortParts[1].equals("desc", true)) org.springframework.data.domain.Sort.Order.desc(sortParts[0])
+            else org.springframework.data.domain.Sort.Order.asc(sortParts[0])
+        ))
+
+        val pageResult = mailTemplateService.readTemplates(pageable)
+        val response = PageResponse(
+            content = pageResult.content.map { ReadMailTemplateSummaryResponse.from(it) },
+            page = pageResult.number,
+            size = pageResult.size,
+            totalElements = pageResult.totalElements,
+            totalPages = pageResult.totalPages,
+        )
+        return ResponseEntity.ok(response)
     }
 }

--- a/src/main/kotlin/com/yourssu/scouter/common/application/domain/mail/template/MailTemplateController.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/application/domain/mail/template/MailTemplateController.kt
@@ -1,0 +1,28 @@
+package com.yourssu.scouter.common.application.domain.mail.template
+
+import com.yourssu.scouter.common.application.support.authentication.AuthUser
+import com.yourssu.scouter.common.application.support.authentication.AuthUserInfo
+import com.yourssu.scouter.common.business.domain.mail.template.MailTemplateService
+import com.yourssu.scouter.common.implement.domain.mail.template.MailTemplate
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/mails/templates")
+class MailTemplateController(
+    private val mailTemplateService: MailTemplateService
+) {
+
+    @PostMapping
+    fun create(
+        @AuthUser authUserInfo: AuthUserInfo,
+        @RequestBody request: CreateMailTemplateRequest,
+    ): ResponseEntity<CreateMailTemplateResponse> {
+        val domain: MailTemplate = request.toDomain(createdBy = authUserInfo.userId)
+        val saved: MailTemplate = mailTemplateService.createTemplate(domain)
+        return ResponseEntity.status(201).body(CreateMailTemplateResponse.from(saved))
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/common/application/domain/mail/template/MailTemplateController.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/application/domain/mail/template/MailTemplateController.kt
@@ -4,18 +4,9 @@ import com.yourssu.scouter.common.application.support.authentication.AuthUser
 import com.yourssu.scouter.common.application.support.authentication.AuthUserInfo
 import com.yourssu.scouter.common.business.domain.mail.template.MailTemplateService
 import com.yourssu.scouter.common.implement.domain.mail.template.MailTemplate
-import org.springframework.http.ResponseEntity
 import org.springframework.data.domain.PageRequest
-import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.RequestParam
-import org.springframework.web.bind.annotation.PostMapping
-import org.springframework.web.bind.annotation.RequestBody
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RestController
-import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.PathVariable
-import org.springframework.web.bind.annotation.PutMapping
-import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.*
 
 @RestController
 @RequestMapping("/api/mails/templates")
@@ -40,10 +31,16 @@ class MailTemplateController(
         @RequestParam(required = false, defaultValue = "updatedAt,desc") sort: String,
     ): ResponseEntity<PageResponse<ReadMailTemplateSummaryResponse>> {
         val sortParts = sort.split(",")
-        val pageable = PageRequest.of(page, size, org.springframework.data.domain.Sort.by(
-            if (sortParts.size >= 2 && sortParts[1].equals("desc", true)) org.springframework.data.domain.Sort.Order.desc(sortParts[0])
-            else org.springframework.data.domain.Sort.Order.asc(sortParts[0])
-        ))
+        val pageable = PageRequest.of(
+            page, size, org.springframework.data.domain.Sort.by(
+                if (sortParts.size >= 2 && sortParts[1].equals(
+                        "desc",
+                        true
+                    )
+                ) org.springframework.data.domain.Sort.Order.desc(sortParts[0])
+                else org.springframework.data.domain.Sort.Order.asc(sortParts[0])
+            )
+        )
 
         val pageResult = mailTemplateService.readTemplates(pageable)
         val response = PageResponse(

--- a/src/main/kotlin/com/yourssu/scouter/common/application/domain/mail/template/ReadMailTemplateDetailResponse.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/application/domain/mail/template/ReadMailTemplateDetailResponse.kt
@@ -1,0 +1,39 @@
+package com.yourssu.scouter.common.application.domain.mail.template
+
+import com.yourssu.scouter.common.implement.domain.mail.template.MailTemplate
+import com.yourssu.scouter.common.implement.domain.mail.template.TemplateVariable
+import com.yourssu.scouter.common.implement.domain.mail.template.VariableType
+
+data class ReadMailTemplateDetailResponse(
+    val id: Long,
+    val title: String,
+    val bodyHtml: String,
+    val variables: List<DetailVariable>,
+    val updatedAt: java.time.LocalDateTime,
+) {
+    data class DetailVariable(
+        val key: String,
+        val type: VariableType,
+        val displayName: String,
+        val perRecipient: Boolean,
+    ) {
+        companion object {
+            fun from(variable: TemplateVariable): DetailVariable = DetailVariable(
+                key = variable.key,
+                type = variable.type,
+                displayName = variable.displayName,
+                perRecipient = variable.perRecipient,
+            )
+        }
+    }
+
+    companion object {
+        fun from(template: MailTemplate): ReadMailTemplateDetailResponse = ReadMailTemplateDetailResponse(
+            id = template.id!!,
+            title = template.title,
+            bodyHtml = template.bodyHtml,
+            variables = template.variables.map { DetailVariable.from(it) },
+            updatedAt = template.updatedAt!!,
+        )
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/common/application/domain/mail/template/ReadMailTemplateDetailResponse.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/application/domain/mail/template/ReadMailTemplateDetailResponse.kt
@@ -13,7 +13,7 @@ data class ReadMailTemplateDetailResponse(
 ) {
     data class DetailVariable(
         val key: String,
-        val type: VariableType,
+        val type: VariableType?,
         val displayName: String,
         val perRecipient: Boolean,
     ) {

--- a/src/main/kotlin/com/yourssu/scouter/common/application/domain/mail/template/ReadMailTemplatesResponse.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/application/domain/mail/template/ReadMailTemplatesResponse.kt
@@ -1,0 +1,25 @@
+package com.yourssu.scouter.common.application.domain.mail.template
+
+import com.yourssu.scouter.common.implement.domain.mail.template.MailTemplate
+
+data class ReadMailTemplateSummaryResponse(
+    val id: Long,
+    val title: String,
+    val updatedAt: java.time.LocalDateTime,
+) {
+    companion object {
+        fun from(template: MailTemplate): ReadMailTemplateSummaryResponse = ReadMailTemplateSummaryResponse(
+            id = template.id!!,
+            title = template.title,
+            updatedAt = template.updatedAt!!,
+        )
+    }
+}
+
+data class PageResponse<T>(
+    val content: List<T>,
+    val page: Int,
+    val size: Int,
+    val totalElements: Long,
+    val totalPages: Int,
+)

--- a/src/main/kotlin/com/yourssu/scouter/common/business/domain/mail/template/MailTemplateService.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/business/domain/mail/template/MailTemplateService.kt
@@ -2,10 +2,9 @@ package com.yourssu.scouter.common.business.domain.mail.template
 
 import com.yourssu.scouter.common.implement.domain.mail.template.MailTemplate
 import com.yourssu.scouter.common.implement.domain.mail.template.MailTemplateRepository
-import com.yourssu.scouter.common.implement.domain.mail.template.TemplateVariable
-import org.springframework.stereotype.Service
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
+import org.springframework.stereotype.Service
 
 @Service
 class MailTemplateService(

--- a/src/main/kotlin/com/yourssu/scouter/common/business/domain/mail/template/MailTemplateService.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/business/domain/mail/template/MailTemplateService.kt
@@ -2,6 +2,7 @@ package com.yourssu.scouter.common.business.domain.mail.template
 
 import com.yourssu.scouter.common.implement.domain.mail.template.MailTemplate
 import com.yourssu.scouter.common.implement.domain.mail.template.MailTemplateRepository
+import com.yourssu.scouter.common.implement.domain.mail.template.MailTemplateValidator
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Service
@@ -11,6 +12,7 @@ class MailTemplateService(
     private val mailTemplateRepository: MailTemplateRepository,
 ) {
     fun createTemplate(template: MailTemplate): MailTemplate {
+        MailTemplateValidator.validate(template)
         return mailTemplateRepository.save(template)
     }
 
@@ -23,6 +25,7 @@ class MailTemplateService(
     }
 
     fun updateTemplate(templateId: Long, template: MailTemplate): MailTemplate? {
+        MailTemplateValidator.validate(template)
         return mailTemplateRepository.update(templateId, template)
     }
 

--- a/src/main/kotlin/com/yourssu/scouter/common/business/domain/mail/template/MailTemplateService.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/business/domain/mail/template/MailTemplateService.kt
@@ -1,0 +1,15 @@
+package com.yourssu.scouter.common.business.domain.mail.template
+
+import com.yourssu.scouter.common.implement.domain.mail.template.MailTemplate
+import com.yourssu.scouter.common.implement.domain.mail.template.MailTemplateRepository
+import com.yourssu.scouter.common.implement.domain.mail.template.TemplateVariable
+import org.springframework.stereotype.Service
+
+@Service
+class MailTemplateService(
+    private val mailTemplateRepository: MailTemplateRepository,
+) {
+    fun createTemplate(template: MailTemplate): MailTemplate {
+        return mailTemplateRepository.save(template)
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/common/business/domain/mail/template/MailTemplateService.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/business/domain/mail/template/MailTemplateService.kt
@@ -22,4 +22,8 @@ class MailTemplateService(
     fun readTemplate(templateId: Long): MailTemplate? {
         return mailTemplateRepository.findById(templateId)
     }
+
+    fun updateTemplate(templateId: Long, template: MailTemplate): MailTemplate? {
+        return mailTemplateRepository.update(templateId, template)
+    }
 }

--- a/src/main/kotlin/com/yourssu/scouter/common/business/domain/mail/template/MailTemplateService.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/business/domain/mail/template/MailTemplateService.kt
@@ -26,4 +26,8 @@ class MailTemplateService(
     fun updateTemplate(templateId: Long, template: MailTemplate): MailTemplate? {
         return mailTemplateRepository.update(templateId, template)
     }
+
+    fun deleteTemplate(templateId: Long): Boolean {
+        return mailTemplateRepository.deleteById(templateId)
+    }
 }

--- a/src/main/kotlin/com/yourssu/scouter/common/business/domain/mail/template/MailTemplateService.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/business/domain/mail/template/MailTemplateService.kt
@@ -18,4 +18,8 @@ class MailTemplateService(
     fun readTemplates(pageable: Pageable): Page<MailTemplate> {
         return mailTemplateRepository.findAll(pageable)
     }
+
+    fun readTemplate(templateId: Long): MailTemplate? {
+        return mailTemplateRepository.findById(templateId)
+    }
 }

--- a/src/main/kotlin/com/yourssu/scouter/common/business/domain/mail/template/MailTemplateService.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/business/domain/mail/template/MailTemplateService.kt
@@ -4,6 +4,8 @@ import com.yourssu.scouter.common.implement.domain.mail.template.MailTemplate
 import com.yourssu.scouter.common.implement.domain.mail.template.MailTemplateRepository
 import com.yourssu.scouter.common.implement.domain.mail.template.TemplateVariable
 import org.springframework.stereotype.Service
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
 
 @Service
 class MailTemplateService(
@@ -11,5 +13,9 @@ class MailTemplateService(
 ) {
     fun createTemplate(template: MailTemplate): MailTemplate {
         return mailTemplateRepository.save(template)
+    }
+
+    fun readTemplates(pageable: Pageable): Page<MailTemplate> {
+        return mailTemplateRepository.findAll(pageable)
     }
 }

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/domain/mail/template/MailTemplate.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/domain/mail/template/MailTemplate.kt
@@ -1,0 +1,13 @@
+package com.yourssu.scouter.common.implement.domain.mail.template
+
+import java.time.LocalDateTime
+
+class MailTemplate(
+    val id: Long? = null,
+    val title: String,
+    val bodyHtml: String,
+    val variables: List<TemplateVariable> = emptyList(),
+    val createdBy: Long,
+    val createdAt: LocalDateTime? = null,
+    val updatedAt: LocalDateTime? = null,
+)

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/domain/mail/template/MailTemplateFactory.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/domain/mail/template/MailTemplateFactory.kt
@@ -1,0 +1,9 @@
+package com.yourssu.scouter.common.implement.domain.mail.template
+
+object MailTemplateFactory {
+
+    fun createValidated(template: MailTemplate): MailTemplate {
+        MailTemplateValidator.validate(template)
+        return template
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/domain/mail/template/MailTemplateRepository.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/domain/mail/template/MailTemplateRepository.kt
@@ -1,5 +1,9 @@
 package com.yourssu.scouter.common.implement.domain.mail.template
 
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+
 interface MailTemplateRepository {
     fun save(template: MailTemplate): MailTemplate
+    fun findAll(pageable: Pageable): Page<MailTemplate>
 }

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/domain/mail/template/MailTemplateRepository.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/domain/mail/template/MailTemplateRepository.kt
@@ -1,0 +1,5 @@
+package com.yourssu.scouter.common.implement.domain.mail.template
+
+interface MailTemplateRepository {
+    fun save(template: MailTemplate): MailTemplate
+}

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/domain/mail/template/MailTemplateRepository.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/domain/mail/template/MailTemplateRepository.kt
@@ -8,4 +8,5 @@ interface MailTemplateRepository {
     fun findAll(pageable: Pageable): Page<MailTemplate>
     fun findById(templateId: Long): MailTemplate?
     fun update(templateId: Long, template: MailTemplate): MailTemplate?
+    fun deleteById(templateId: Long): Boolean
 }

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/domain/mail/template/MailTemplateRepository.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/domain/mail/template/MailTemplateRepository.kt
@@ -7,4 +7,5 @@ interface MailTemplateRepository {
     fun save(template: MailTemplate): MailTemplate
     fun findAll(pageable: Pageable): Page<MailTemplate>
     fun findById(templateId: Long): MailTemplate?
+    fun update(templateId: Long, template: MailTemplate): MailTemplate?
 }

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/domain/mail/template/MailTemplateRepository.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/domain/mail/template/MailTemplateRepository.kt
@@ -6,4 +6,5 @@ import org.springframework.data.domain.Pageable
 interface MailTemplateRepository {
     fun save(template: MailTemplate): MailTemplate
     fun findAll(pageable: Pageable): Page<MailTemplate>
+    fun findById(templateId: Long): MailTemplate?
 }

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/domain/mail/template/MailTemplateUpdater.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/domain/mail/template/MailTemplateUpdater.kt
@@ -1,0 +1,18 @@
+package com.yourssu.scouter.common.implement.domain.mail.template
+
+object MailTemplateUpdater {
+    fun updateValidated(existingId: Long, createdBy: Long, current: MailTemplate, replacement: MailTemplate): MailTemplate {
+        val merged = MailTemplate(
+            id = existingId,
+            title = replacement.title,
+            bodyHtml = replacement.bodyHtml,
+            variables = replacement.variables,
+            createdBy = createdBy,
+            createdAt = current.createdAt,
+            updatedAt = java.time.LocalDateTime.now(),
+        )
+
+        MailTemplateValidator.validate(merged)
+        return merged
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/domain/mail/template/MailTemplateValidator.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/domain/mail/template/MailTemplateValidator.kt
@@ -1,0 +1,56 @@
+package com.yourssu.scouter.common.implement.domain.mail.template
+
+import com.yourssu.scouter.common.implement.support.exception.InvalidTemplateException
+
+object MailTemplateValidator {
+
+    private val fixedKeys: Set<String> = setOf("applicant", "partName")
+
+    fun validate(template: MailTemplate) {
+        validateVariables(template.variables)
+        validateNoDuplicateKeys(template.variables)
+        validateBodyConsistency(template.bodyHtml, template.variables)
+    }
+
+    private fun validateVariables(variables: List<TemplateVariable>) {
+        variables.forEach { v ->
+            val isFixed = fixedKeys.contains(v.key)
+            val isVar = v.key.startsWith("var-")
+            if (isFixed && v.type != null) {
+                throw InvalidTemplateException("Fixed key '${'$'}{v.key}' must not have a type")
+            }
+            if (isVar && v.type == null) {
+                throw InvalidTemplateException("Variable key '${'$'}{v.key}' must have a type")
+            }
+            if (!isFixed && !isVar) {
+                throw InvalidTemplateException("Key '${'$'}{v.key}' must be one of fixed keys ${'$'}fixedKeys or start with 'var-'")
+            }
+        }
+    }
+
+    private fun validateNoDuplicateKeys(variables: List<TemplateVariable>) {
+        val dup = variables.groupBy { it.key }.filter { it.value.size > 1 }.keys
+        if (dup.isNotEmpty()) {
+            throw InvalidTemplateException("Duplicate variable keys: ${'$'}dup")
+        }
+    }
+
+    private fun extractKeysFromBody(bodyHtml: String): Set<String> {
+        val regex = "\\{\\{(.*?)\\}}".toRegex()
+        return regex.findAll(bodyHtml).map { it.groupValues[1].trim() }.toSet()
+    }
+
+    private fun validateBodyConsistency(bodyHtml: String, variables: List<TemplateVariable>) {
+        val bodyKeys = extractKeysFromBody(bodyHtml)
+        val variableKeys = variables.map { it.key }.toSet()
+
+        val missingInVars = bodyKeys - variableKeys
+        val unusedInBody = variableKeys - bodyKeys
+        if (missingInVars.isNotEmpty()) {
+            throw InvalidTemplateException("Variables missing for placeholders: ${'$'}missingInVars")
+        }
+        if (unusedInBody.isNotEmpty()) {
+            throw InvalidTemplateException("Variables not used in body: ${'$'}unusedInBody")
+        }
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/domain/mail/template/TemplateVariable.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/domain/mail/template/TemplateVariable.kt
@@ -1,0 +1,8 @@
+package com.yourssu.scouter.common.implement.domain.mail.template
+
+data class TemplateVariable(
+    val key: String,
+    val type: VariableType,
+    val displayName: String,
+    val perRecipient: Boolean,
+)

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/domain/mail/template/TemplateVariable.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/domain/mail/template/TemplateVariable.kt
@@ -2,7 +2,7 @@ package com.yourssu.scouter.common.implement.domain.mail.template
 
 data class TemplateVariable(
     val key: String,
-    val type: VariableType,
+    val type: VariableType?,
     val displayName: String,
     val perRecipient: Boolean,
 )

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/domain/mail/template/VariableType.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/domain/mail/template/VariableType.kt
@@ -1,0 +1,8 @@
+package com.yourssu.scouter.common.implement.domain.mail.template
+
+enum class VariableType {
+    PERSON,
+    DATE,
+    LINK,
+    TEXT,
+}

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/support/exception/InvalidTemplateException.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/support/exception/InvalidTemplateException.kt
@@ -1,0 +1,7 @@
+package com.yourssu.scouter.common.implement.support.exception
+
+import org.springframework.http.HttpStatus
+
+class InvalidTemplateException(
+    message: String,
+) : CustomException(message, "Template-Validation-Fail", HttpStatus.BAD_REQUEST)

--- a/src/main/kotlin/com/yourssu/scouter/common/storage/domain/mail/template/JpaMailTemplateRepository.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/storage/domain/mail/template/JpaMailTemplateRepository.kt
@@ -1,5 +1,9 @@
 package com.yourssu.scouter.common.storage.domain.mail.template
 
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
 
-interface JpaMailTemplateRepository : JpaRepository<MailTemplateEntity, Long>
+interface JpaMailTemplateRepository : JpaRepository<MailTemplateEntity, Long> {
+    fun findAllBy(pageable: Pageable): Page<MailTemplateEntity>
+}

--- a/src/main/kotlin/com/yourssu/scouter/common/storage/domain/mail/template/JpaMailTemplateRepository.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/storage/domain/mail/template/JpaMailTemplateRepository.kt
@@ -1,0 +1,5 @@
+package com.yourssu.scouter.common.storage.domain.mail.template
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface JpaMailTemplateRepository : JpaRepository<MailTemplateEntity, Long>

--- a/src/main/kotlin/com/yourssu/scouter/common/storage/domain/mail/template/MailTemplateEntity.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/storage/domain/mail/template/MailTemplateEntity.kt
@@ -1,16 +1,6 @@
 package com.yourssu.scouter.common.storage.domain.mail.template
 
-import com.yourssu.scouter.common.implement.domain.mail.template.MailTemplate
-import jakarta.persistence.CascadeType
-import jakarta.persistence.Column
-import jakarta.persistence.Entity
-import jakarta.persistence.FetchType
-import jakarta.persistence.GeneratedValue
-import jakarta.persistence.GenerationType
-import jakarta.persistence.Id
-import jakarta.persistence.Lob
-import jakarta.persistence.OneToMany
-import jakarta.persistence.Table
+import jakarta.persistence.*
 import java.time.LocalDateTime
 
 @Entity

--- a/src/main/kotlin/com/yourssu/scouter/common/storage/domain/mail/template/MailTemplateEntity.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/storage/domain/mail/template/MailTemplateEntity.kt
@@ -2,6 +2,7 @@ package com.yourssu.scouter.common.storage.domain.mail.template
 
 import jakarta.persistence.*
 import java.time.LocalDateTime
+import com.yourssu.scouter.common.implement.domain.mail.template.MailTemplate
 
 @Entity
 @Table(name = "mail_template")
@@ -30,3 +31,18 @@ class MailTemplateEntity(
     @OneToMany(mappedBy = "template", fetch = FetchType.EAGER, cascade = [CascadeType.ALL], orphanRemoval = true)
     val variables: MutableList<TemplateVariableEntity> = mutableListOf(),
 )
+
+object MailTemplateEntityFactory {
+    fun from(template: MailTemplate): MailTemplateEntity {
+        val entity = MailTemplateEntity(
+            id = template.id,
+            title = template.title,
+            bodyHtml = template.bodyHtml,
+            createdBy = template.createdBy,
+            createdAt = template.createdAt ?: LocalDateTime.now(),
+            updatedAt = template.updatedAt ?: LocalDateTime.now(),
+        )
+        entity.variables.addAll(TemplateVariableEntityFactory.fromList(template.variables, entity))
+        return entity
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/common/storage/domain/mail/template/MailTemplateEntity.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/storage/domain/mail/template/MailTemplateEntity.kt
@@ -1,0 +1,42 @@
+package com.yourssu.scouter.common.storage.domain.mail.template
+
+import com.yourssu.scouter.common.implement.domain.mail.template.MailTemplate
+import jakarta.persistence.CascadeType
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Lob
+import jakarta.persistence.OneToMany
+import jakarta.persistence.Table
+import java.time.LocalDateTime
+
+@Entity
+@Table(name = "mail_template")
+class MailTemplateEntity(
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long? = null,
+
+    @Column(nullable = false)
+    val title: String,
+
+    @Lob
+    @Column(nullable = false)
+    val bodyHtml: String,
+
+    @Column(nullable = false)
+    val createdBy: Long,
+
+    @Column(nullable = false)
+    val createdAt: LocalDateTime,
+
+    @Column(nullable = false)
+    val updatedAt: LocalDateTime,
+
+    @OneToMany(mappedBy = "template", fetch = FetchType.EAGER, cascade = [CascadeType.ALL], orphanRemoval = true)
+    val variables: MutableList<TemplateVariableEntity> = mutableListOf(),
+)

--- a/src/main/kotlin/com/yourssu/scouter/common/storage/domain/mail/template/MailTemplateRepositoryImpl.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/storage/domain/mail/template/MailTemplateRepositoryImpl.kt
@@ -75,6 +75,13 @@ class MailTemplateRepositoryImpl(
         val saved = jpaMailTemplateRepository.save(updated)
         return saved.toDomain()
     }
+
+    override fun deleteById(templateId: Long): Boolean {
+        val exists = jpaMailTemplateRepository.existsById(templateId)
+        if (!exists) return false
+        jpaMailTemplateRepository.deleteById(templateId)
+        return true
+    }
 }
 
 private fun MailTemplateEntity.toDomain(): MailTemplate = MailTemplate(

--- a/src/main/kotlin/com/yourssu/scouter/common/storage/domain/mail/template/MailTemplateRepositoryImpl.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/storage/domain/mail/template/MailTemplateRepositoryImpl.kt
@@ -1,0 +1,47 @@
+package com.yourssu.scouter.common.storage.domain.mail.template
+
+import com.yourssu.scouter.common.implement.domain.mail.template.MailTemplate
+import com.yourssu.scouter.common.implement.domain.mail.template.MailTemplateRepository
+import com.yourssu.scouter.common.implement.domain.mail.template.TemplateVariable
+import org.springframework.stereotype.Repository
+
+@Repository
+class MailTemplateRepositoryImpl(
+    private val jpaMailTemplateRepository: JpaMailTemplateRepository,
+) : MailTemplateRepository {
+
+    override fun save(template: MailTemplate): MailTemplate {
+        val entity = MailTemplateEntity(
+            id = template.id,
+            title = template.title,
+            bodyHtml = template.bodyHtml,
+            createdBy = template.createdBy,
+            createdAt = template.createdAt ?: java.time.LocalDateTime.now(),
+            updatedAt = template.updatedAt ?: java.time.LocalDateTime.now(),
+        )
+
+        val variables = template.variables.map {
+            TemplateVariableEntity(
+                template = entity,
+                variableKey = it.key,
+                variableType = it.type,
+                displayName = it.displayName,
+                perRecipient = it.perRecipient,
+            )
+        }
+        entity.variables.addAll(variables)
+
+        val saved = jpaMailTemplateRepository.save(entity)
+        return saved.toDomain()
+    }
+}
+
+private fun MailTemplateEntity.toDomain(): MailTemplate = MailTemplate(
+    id = id,
+    title = title,
+    bodyHtml = bodyHtml,
+    variables = variables.map { it.toDomain() },
+    createdBy = createdBy,
+    createdAt = createdAt,
+    updatedAt = updatedAt,
+)

--- a/src/main/kotlin/com/yourssu/scouter/common/storage/domain/mail/template/MailTemplateRepositoryImpl.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/storage/domain/mail/template/MailTemplateRepositoryImpl.kt
@@ -2,7 +2,6 @@ package com.yourssu.scouter.common.storage.domain.mail.template
 
 import com.yourssu.scouter.common.implement.domain.mail.template.MailTemplate
 import com.yourssu.scouter.common.implement.domain.mail.template.MailTemplateRepository
-import com.yourssu.scouter.common.implement.domain.mail.template.TemplateVariable
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Repository

--- a/src/main/kotlin/com/yourssu/scouter/common/storage/domain/mail/template/MailTemplateRepositoryImpl.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/storage/domain/mail/template/MailTemplateRepositoryImpl.kt
@@ -44,6 +44,37 @@ class MailTemplateRepositoryImpl(
     override fun findById(templateId: Long): MailTemplate? {
         return jpaMailTemplateRepository.findById(templateId).orElse(null)?.toDomain()
     }
+
+    override fun update(templateId: Long, template: MailTemplate): MailTemplate? {
+        val existing = jpaMailTemplateRepository.findById(templateId).orElse(null) ?: return null
+
+        // 전체 교체: 제목/본문/변수/updatedAt
+        existing.variables.clear()
+        existing.variables.addAll(
+            template.variables.map {
+                TemplateVariableEntity(
+                    template = existing,
+                    variableKey = it.key,
+                    variableType = it.type,
+                    displayName = it.displayName,
+                    perRecipient = it.perRecipient,
+                )
+            }
+        )
+
+        val updated = MailTemplateEntity(
+            id = existing.id,
+            title = template.title,
+            bodyHtml = template.bodyHtml,
+            createdBy = existing.createdBy,
+            createdAt = existing.createdAt,
+            updatedAt = java.time.LocalDateTime.now(),
+            variables = existing.variables,
+        )
+
+        val saved = jpaMailTemplateRepository.save(updated)
+        return saved.toDomain()
+    }
 }
 
 private fun MailTemplateEntity.toDomain(): MailTemplate = MailTemplate(

--- a/src/main/kotlin/com/yourssu/scouter/common/storage/domain/mail/template/MailTemplateRepositoryImpl.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/storage/domain/mail/template/MailTemplateRepositoryImpl.kt
@@ -12,26 +12,7 @@ class MailTemplateRepositoryImpl(
 ) : MailTemplateRepository {
 
     override fun save(template: MailTemplate): MailTemplate {
-        val entity = MailTemplateEntity(
-            id = template.id,
-            title = template.title,
-            bodyHtml = template.bodyHtml,
-            createdBy = template.createdBy,
-            createdAt = template.createdAt ?: java.time.LocalDateTime.now(),
-            updatedAt = template.updatedAt ?: java.time.LocalDateTime.now(),
-        )
-
-        val variables = template.variables.map {
-            TemplateVariableEntity(
-                template = entity,
-                variableKey = it.key,
-                variableType = it.type,
-                displayName = it.displayName,
-                perRecipient = it.perRecipient,
-            )
-        }
-        entity.variables.addAll(variables)
-
+        val entity = MailTemplateEntityFactory.from(template)
         val saved = jpaMailTemplateRepository.save(entity)
         return saved.toDomain()
     }
@@ -49,17 +30,7 @@ class MailTemplateRepositoryImpl(
 
         // 전체 교체: 제목/본문/변수/updatedAt
         existing.variables.clear()
-        existing.variables.addAll(
-            template.variables.map {
-                TemplateVariableEntity(
-                    template = existing,
-                    variableKey = it.key,
-                    variableType = it.type,
-                    displayName = it.displayName,
-                    perRecipient = it.perRecipient,
-                )
-            }
-        )
+        existing.variables.addAll(TemplateVariableEntityFactory.fromList(template.variables, existing))
 
         val updated = MailTemplateEntity(
             id = existing.id,

--- a/src/main/kotlin/com/yourssu/scouter/common/storage/domain/mail/template/MailTemplateRepositoryImpl.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/storage/domain/mail/template/MailTemplateRepositoryImpl.kt
@@ -40,6 +40,10 @@ class MailTemplateRepositoryImpl(
     override fun findAll(pageable: Pageable): Page<MailTemplate> {
         return jpaMailTemplateRepository.findAllBy(pageable).map { it.toDomain() }
     }
+
+    override fun findById(templateId: Long): MailTemplate? {
+        return jpaMailTemplateRepository.findById(templateId).orElse(null)?.toDomain()
+    }
 }
 
 private fun MailTemplateEntity.toDomain(): MailTemplate = MailTemplate(

--- a/src/main/kotlin/com/yourssu/scouter/common/storage/domain/mail/template/MailTemplateRepositoryImpl.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/storage/domain/mail/template/MailTemplateRepositoryImpl.kt
@@ -3,6 +3,8 @@ package com.yourssu.scouter.common.storage.domain.mail.template
 import com.yourssu.scouter.common.implement.domain.mail.template.MailTemplate
 import com.yourssu.scouter.common.implement.domain.mail.template.MailTemplateRepository
 import com.yourssu.scouter.common.implement.domain.mail.template.TemplateVariable
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Repository
 
 @Repository
@@ -33,6 +35,10 @@ class MailTemplateRepositoryImpl(
 
         val saved = jpaMailTemplateRepository.save(entity)
         return saved.toDomain()
+    }
+
+    override fun findAll(pageable: Pageable): Page<MailTemplate> {
+        return jpaMailTemplateRepository.findAllBy(pageable).map { it.toDomain() }
     }
 }
 

--- a/src/main/kotlin/com/yourssu/scouter/common/storage/domain/mail/template/TemplateVariableEntity.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/storage/domain/mail/template/TemplateVariableEntity.kt
@@ -36,3 +36,17 @@ fun TemplateVariableEntity.toDomain(): TemplateVariable = TemplateVariable(
     displayName = displayName,
     perRecipient = perRecipient,
 )
+
+object TemplateVariableEntityFactory {
+    fun fromList(variables: List<TemplateVariable>, template: MailTemplateEntity): List<TemplateVariableEntity> {
+        return variables.map {
+            TemplateVariableEntity(
+                template = template,
+                variableKey = it.key,
+                variableType = it.type,
+                displayName = it.displayName,
+                perRecipient = it.perRecipient,
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/common/storage/domain/mail/template/TemplateVariableEntity.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/storage/domain/mail/template/TemplateVariableEntity.kt
@@ -1,0 +1,38 @@
+package com.yourssu.scouter.common.storage.domain.mail.template
+
+import com.yourssu.scouter.common.implement.domain.mail.template.TemplateVariable
+import com.yourssu.scouter.common.implement.domain.mail.template.VariableType
+import jakarta.persistence.*
+
+@Entity
+@Table(name = "mail_template_variable")
+class TemplateVariableEntity(
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long? = null,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "template_id")
+    val template: MailTemplateEntity,
+
+    @Column(nullable = false)
+    val variableKey: String,
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    val variableType: VariableType,
+
+    @Column(nullable = false)
+    val displayName: String,
+
+    @Column(nullable = false)
+    val perRecipient: Boolean,
+)
+
+fun TemplateVariableEntity.toDomain(): TemplateVariable = TemplateVariable(
+    key = variableKey,
+    type = variableType,
+    displayName = displayName,
+    perRecipient = perRecipient,
+)

--- a/src/main/kotlin/com/yourssu/scouter/common/storage/domain/mail/template/TemplateVariableEntity.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/storage/domain/mail/template/TemplateVariableEntity.kt
@@ -20,8 +20,8 @@ class TemplateVariableEntity(
     val variableKey: String,
 
     @Enumerated(EnumType.STRING)
-    @Column(nullable = false)
-    val variableType: VariableType,
+    @Column(nullable = true)
+    val variableType: VariableType?,
 
     @Column(nullable = false)
     val displayName: String,


### PR DESCRIPTION
## 📄 작업 내용 요약
메일 템플릿을 생성/조회/세부내용조회/수정/삭제 하는 API 를 구현한다.

## 📎 Issue 번호
closed #111 
