### PR TITLE
[#73]; docs: swagger api 문서화 추가

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -53,6 +53,9 @@ dependencies {
 	testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
 	testImplementation("org.assertj:assertj-core")
 	testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+
+    // swagger
+    implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.13")
 }
 
 kotlin {

--- a/src/main/kotlin/com/yourssu/scouter/ats/application/domain/applicant/ApplicantController.kt
+++ b/src/main/kotlin/com/yourssu/scouter/ats/application/domain/applicant/ApplicantController.kt
@@ -2,23 +2,31 @@ package com.yourssu.scouter.ats.application.domain.applicant
 
 import com.yourssu.scouter.ats.business.domain.applicant.ApplicantDto
 import com.yourssu.scouter.ats.business.domain.applicant.ApplicantService
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.headers.Header
+import io.swagger.v3.oas.annotations.media.ArraySchema
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.ExampleObject
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.Valid
-import java.net.URI
 import org.springframework.http.ResponseEntity
-import org.springframework.web.bind.annotation.DeleteMapping
-import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.PatchMapping
-import org.springframework.web.bind.annotation.PathVariable
-import org.springframework.web.bind.annotation.PostMapping
-import org.springframework.web.bind.annotation.RequestBody
-import org.springframework.web.bind.annotation.RequestParam
-import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.bind.annotation.*
+import java.net.URI
 
+@Tag(name = "리크루팅 지원자")
 @RestController
 class ApplicantController(
     private val applicantService: ApplicantService,
 ) {
 
+    @Operation(summary = "지원자 추가 API")
+    @ApiResponse(
+        description = "CREATED", responseCode = "201", headers = [
+            Header(name = "Location", description = "/applicants/{applicantId}")
+        ]
+    )
     @PostMapping("/applicants")
     fun create(
         @RequestBody @Valid request: CreateApplicantRequest,
@@ -30,6 +38,10 @@ class ApplicantController(
     }
 
 
+    @Operation(
+        summary = "지원자 목록 조회",
+        description = "지원자 목록을 검색, 필터링을 통해 얻습니다. 필터링에 필요한 정보는 각 api에서 얻어야 합니다."
+    )
     @GetMapping("/applicants")
     fun readAll(
         @RequestParam(required = false) name: String?,
@@ -47,6 +59,7 @@ class ApplicantController(
         return ResponseEntity.ok(responses)
     }
 
+    @Operation(summary = "지원자 정보 수정", description = "변경할 지원자 정보의 값을 보냅니다. 변경되지 않은 값은 보내면 안 됩니다.")
     @PatchMapping("/applicants/{applicantId}")
     fun updateById(
         @PathVariable applicantId: Long,
@@ -58,6 +71,7 @@ class ApplicantController(
         return ResponseEntity.ok().build()
     }
 
+    @Operation(summary = "지원자 단일 조회", description = "지원자 목록 조회에서 얻은 applicantId를 이용해 지원자의 세부정보를 확인합니다.")
     @GetMapping("/applicants/{applicantId}")
     fun readById(
         @PathVariable applicantId: Long,
@@ -68,6 +82,8 @@ class ApplicantController(
         return ResponseEntity.ok(response)
     }
 
+    @Operation(summary = "지원자 삭제", description = "지원자 목록 조회에서 얻은 applicantId를 이용해 지원자를 삭제합니다.")
+    @ApiResponse(description = "NO_CONTENT", responseCode = "204")
     @DeleteMapping("/applicants/{applicantId}")
     fun deleteById(
         @PathVariable applicantId: Long,
@@ -77,6 +93,15 @@ class ApplicantController(
         return ResponseEntity.noContent().build()
     }
 
+    @Operation(summary = "지원자 상태 목록 조회", description = "전체 지원자의 가능한 상태 목록을 확인합니다. 현재 지원자와는 관련이 없습니다.")
+    @ApiResponse(
+        description = "OK", responseCode = "200", content = [Content(
+            mediaType = "application/json",
+            array = ArraySchema(schema = Schema(implementation = String::class)),
+            examples =
+                [ExampleObject(value = "[ \"심사 진행 중\", \"서류 불합\", \"면접 불합\", \"인큐베이팅 불합\", \"최종 합격\" ]")]
+        )]
+    )
     @GetMapping("/applicants/states")
     fun readAllMemberStates(): ResponseEntity<List<String>> {
         val states: List<String> = applicantService.readAllStates()

--- a/src/main/kotlin/com/yourssu/scouter/ats/application/domain/applicant/ApplicantSyncController.kt
+++ b/src/main/kotlin/com/yourssu/scouter/ats/application/domain/applicant/ApplicantSyncController.kt
@@ -4,6 +4,10 @@ import com.yourssu.scouter.ats.business.domain.applicant.ApplicantSyncResult
 import com.yourssu.scouter.ats.business.domain.applicant.ApplicantSyncService
 import com.yourssu.scouter.common.application.support.authentication.AuthUser
 import com.yourssu.scouter.common.application.support.authentication.AuthUserInfo
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.headers.Header
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.tags.Tag
 import java.time.LocalDateTime
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
@@ -11,11 +15,20 @@ import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RestController
 
+@Tag(name = "리크루팅 지원자")
+@Tag(name = "지원자 동기화 API")
 @RestController
 class ApplicantSyncController(
     private val applicantSyncService: ApplicantSyncService,
 ) {
 
+    @Operation(
+        summary = "구글폼 응답을 지원자 목록에 업데이트",
+        description = "현재 로그인 되어있는 사용자의 계정을 이용해 지원자의 구글폼 응답을 동기화 합니다."
+    )
+    @ApiResponse(description = "OK", responseCode = "200", headers = [
+        Header(name = "Location", description = "/applicants")
+    ]) // 노션 api 명세랑 안맞는 부분 api 명세 상 201 <-> 실제는 200
     @PostMapping("/applicants/include-from-forms")
     fun includeFromForms(
         @AuthUser authUserInfo: AuthUserInfo,
@@ -37,6 +50,7 @@ class ApplicantSyncController(
         return ResponseEntity.ok(response)
     }
 
+    @Operation(summary = "마지막 동기화 시간 조회")
     @GetMapping("/applicants/lastUpdatedTime")
     fun lastSyncTime(): ResponseEntity<LastApplicantSyncTimeResponse> {
         val lastSyncTime: LocalDateTime? = applicantSyncService.readLastUpdatedTime()

--- a/src/main/kotlin/com/yourssu/scouter/common/application/domain/authentication/AuthenticationController.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/application/domain/authentication/AuthenticationController.kt
@@ -9,6 +9,7 @@ import com.yourssu.scouter.common.implement.domain.authentication.TokenType
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
 import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.security.SecurityRequirements
 import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.validation.Valid
@@ -34,6 +35,7 @@ class AuthenticationController(
 
     @Tag(name = "OAUTH2")
     @Operation(summary = "회원가입/로그인", description = "/oauth2/{oauth2Type}에서 얻은 code를 이용해 회원가입/로그인을 진행합니다.")
+    @SecurityRequirements // 로그인을 필요로 하지 않는 곳은 전역 인증을 사용하지않도록 초기화
     @PostMapping("oauth2/login/{oauth2Type}")
     fun login(
         @PathVariable oauth2Type: OAuth2Type,
@@ -60,6 +62,7 @@ class AuthenticationController(
     @ApiResponse(description = "NO_CONTENT", responseCode = "204")
     @PostMapping("/logout")
     fun logout(
+        @Parameter(hidden = true)
         @RequestHeader(HttpHeaders.AUTHORIZATION) accessToken: String,
         @RequestBody @Valid request: LogoutRequest,
     ): ResponseEntity<Unit> {
@@ -68,9 +71,11 @@ class AuthenticationController(
         return ResponseEntity.noContent().build()
     }
 
+    @SecurityRequirements // 로그인을 필요로 하지 않는 곳은 전역 인증을 사용하지않도록 초기화
     @Operation(summary = "AccessToken 유효성 검사")
     @GetMapping("/validate-token")
     fun validateToken(
+        @Parameter(hidden = true)
         @RequestHeader(HttpHeaders.AUTHORIZATION) accessToken: String,
     ): ResponseEntity<ValidateTokenResponse> {
         val validated: Boolean = authenticationService.isValidToken(TokenType.ACCESS, accessToken)
@@ -79,10 +84,12 @@ class AuthenticationController(
         return ResponseEntity.ok(response)
     }
 
+    @SecurityRequirements // 로그인을 필요로 하지 않는 곳은 전역 인증을 사용하지않도록 초기화
     @Operation(summary = "토큰 재발급")
     @PostMapping("/refresh-token")
     fun refreshToken(
         @RequestBody @Valid request: TokenRefreshRequest,
+        @Parameter(hidden = true)
         @RequestHeader(HttpHeaders.AUTHORIZATION, required = false) bearerRefreshHeader: String?,
     ): ResponseEntity<TokenRefreshResponse> {
         logger.info("[Auth] POST /refresh-token | hasAuthHeader={} | bodyPresent={}", !bearerRefreshHeader.isNullOrBlank(), !request.refreshToken.isNullOrBlank())
@@ -98,6 +105,7 @@ class AuthenticationController(
     @ApiResponse(description = "NO_CONTENT", responseCode = "204")
     @PostMapping("/withdrawal")
     fun withdraw(
+        @Parameter(hidden = true)
         @RequestHeader(HttpHeaders.AUTHORIZATION) accessToken: String,
         @RequestBody @Valid request: WithdrawalRequest,
     ): ResponseEntity<Unit> {

--- a/src/main/kotlin/com/yourssu/scouter/common/application/domain/authentication/AuthenticationController.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/application/domain/authentication/AuthenticationController.kt
@@ -6,6 +6,10 @@ import com.yourssu.scouter.common.business.domain.authentication.OAuth2Service
 import com.yourssu.scouter.common.business.domain.authentication.TokenDto
 import com.yourssu.scouter.common.implement.domain.authentication.OAuth2Type
 import com.yourssu.scouter.common.implement.domain.authentication.TokenType
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.validation.Valid
 import java.time.LocalDateTime
@@ -19,6 +23,7 @@ import org.springframework.web.bind.annotation.RequestHeader
 import org.springframework.web.bind.annotation.RestController
 import org.slf4j.LoggerFactory
 
+@Tag(name = "인증/인가")
 @RestController
 class AuthenticationController(
     private val authenticationService: AuthenticationService,
@@ -27,6 +32,8 @@ class AuthenticationController(
 
     private val logger = LoggerFactory.getLogger(AuthenticationController::class.java)
 
+    @Tag(name = "OAUTH2")
+    @Operation(summary = "회원가입/로그인", description = "/oauth2/{oauth2Type}에서 얻은 code를 이용해 회원가입/로그인을 진행합니다.")
     @PostMapping("oauth2/login/{oauth2Type}")
     fun login(
         @PathVariable oauth2Type: OAuth2Type,
@@ -49,6 +56,8 @@ class AuthenticationController(
         return ResponseEntity.ok(response)
     }
 
+    @Operation(summary = "로그아웃")
+    @ApiResponse(description = "NO_CONTENT", responseCode = "204")
     @PostMapping("/logout")
     fun logout(
         @RequestHeader(HttpHeaders.AUTHORIZATION) accessToken: String,
@@ -59,6 +68,7 @@ class AuthenticationController(
         return ResponseEntity.noContent().build()
     }
 
+    @Operation(summary = "AccessToken 유효성 검사")
     @GetMapping("/validate-token")
     fun validateToken(
         @RequestHeader(HttpHeaders.AUTHORIZATION) accessToken: String,
@@ -69,6 +79,7 @@ class AuthenticationController(
         return ResponseEntity.ok(response)
     }
 
+    @Operation(summary = "토큰 재발급")
     @PostMapping("/refresh-token")
     fun refreshToken(
         @RequestBody @Valid request: TokenRefreshRequest,
@@ -83,6 +94,8 @@ class AuthenticationController(
         return ResponseEntity.ok(response)
     }
 
+    @Operation(summary = "회원 탈퇴")
+    @ApiResponse(description = "NO_CONTENT", responseCode = "204")
     @PostMapping("/withdrawal")
     fun withdraw(
         @RequestHeader(HttpHeaders.AUTHORIZATION) accessToken: String,

--- a/src/main/kotlin/com/yourssu/scouter/common/application/domain/authentication/OAuth2Controller.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/application/domain/authentication/OAuth2Controller.kt
@@ -2,6 +2,9 @@ package com.yourssu.scouter.common.application.domain.authentication
 
 import com.yourssu.scouter.common.business.domain.authentication.OAuth2Service
 import com.yourssu.scouter.common.implement.domain.authentication.OAuth2Type
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.security.SecurityRequirements
+import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
 import org.springframework.http.HttpHeaders
@@ -12,11 +15,15 @@ import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 import org.springframework.web.util.UriComponentsBuilder
 
+@Tag(name = "인증/인가")
+@Tag(name = "OAUTH2")
 @RestController
 class OAuth2Controller(
     private val oauth2Service: OAuth2Service
 ) {
 
+    @Operation(summary = "OAuth2 로그인 페이지 리다이렉트", description = "여기에서는 리다이렉트가 되지 않습니다. Authorize 이용.")
+    @SecurityRequirements // 로그인을 필요로 하지 않는 곳은 전역 인증을 사용하지않도록 초기화
     @GetMapping("/oauth2/{oauth2Type}")
     fun redirectAuthCodeRequestUrl(
         @PathVariable oauth2Type: OAuth2Type,

--- a/src/main/kotlin/com/yourssu/scouter/common/application/domain/authentication/SwaggerOAuth2Controller.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/application/domain/authentication/SwaggerOAuth2Controller.kt
@@ -1,0 +1,46 @@
+package com.yourssu.scouter.common.application.domain.authentication
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy
+import com.fasterxml.jackson.databind.annotation.JsonNaming
+import com.yourssu.scouter.common.business.domain.authentication.LoginResult
+import com.yourssu.scouter.common.business.domain.authentication.OAuth2Service
+import com.yourssu.scouter.common.implement.domain.authentication.OAuth2Type
+import io.swagger.v3.oas.annotations.Hidden
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+@Hidden
+@RestController
+class SwaggerOAuth2Controller(private val oauth2Service: OAuth2Service) {
+
+    @Value("\${springdoc.swagger-ui.oauth2-redirect-url}")
+    private lateinit var redirectUri: String
+
+    @PostMapping("/oauth2/swagger/callback")
+    fun callback(
+        @RequestParam code: String,
+        @RequestParam(required = false) error: String?
+    ): ResponseEntity<AuthResponse> {
+        if (error != null) throw RuntimeException(
+            "OAuth2 authorization code flow failed: $error"
+        )
+
+        val referer = redirectUri.substringBefore("/")
+        val loginResult: LoginResult = oauth2Service.login(
+            oauth2Type = OAuth2Type.GOOGLE, // 인증, 인가 로직을 시험하기 위함이 아니기 때문에 google로 고정해뒀습니다.
+            oauth2AuthorizationCode = code,
+            referer = referer,
+            redirectUriOverride = redirectUri,
+        )
+        val accessToken = loginResult.accessToken.substringAfter(" ")
+        return ResponseEntity.ok(AuthResponse(accessToken))
+    }
+}
+
+@JsonNaming(SnakeCaseStrategy::class)
+data class AuthResponse(val accessToken: String)
+
+

--- a/src/main/kotlin/com/yourssu/scouter/common/application/domain/college/CollegeController.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/application/domain/college/CollegeController.kt
@@ -2,15 +2,19 @@ package com.yourssu.scouter.common.application.domain.college
 
 import com.yourssu.scouter.common.business.domain.college.CollegeService
 import com.yourssu.scouter.common.business.domain.college.ReadCollegesResult
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RestController
 
+@Tag(name = "학과/학기/단과대")
 @RestController
 class CollegeController(
     private val collegeService: CollegeService,
 ) {
 
+    @Operation(summary = "전체 단과대 조회", description = "전체 단과대의 정보를 조회합니다.")
     @GetMapping("/colleges")
     fun readAll(): ResponseEntity<List<ReadCollegeResponse>> {
         val result: ReadCollegesResult = collegeService.readAll()

--- a/src/main/kotlin/com/yourssu/scouter/common/application/domain/department/DepartmentController.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/application/domain/department/DepartmentController.kt
@@ -2,16 +2,20 @@ package com.yourssu.scouter.common.application.domain.department
 
 import com.yourssu.scouter.common.business.domain.department.DepartmentService
 import com.yourssu.scouter.common.business.domain.department.ReadDepartmentsResult
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RestController
 
+@Tag(name = "학과/학기/단과대")
 @RestController
 class DepartmentController(
     private val departmentService: DepartmentService,
 ) {
 
+    @Operation(summary = "전체 학과 조회", description = "전체 학과 정보를 조회합니다.")
     @GetMapping("/departments")
     fun readAll(): ResponseEntity<List<ReadDepartmentsResponse>> {
         val result: ReadDepartmentsResult = departmentService.readAll()
@@ -20,6 +24,7 @@ class DepartmentController(
         return ResponseEntity.ok(response)
     }
 
+    @Operation(summary = "단과대 소속 학과 조회", description = "특정 단과대에 소속된 전체 학과 정보를 조회합니다.")
     @GetMapping("/colleges/{collegeId}/departments")
     fun readAllByCollegeId(
         @PathVariable collegeId: Long,

--- a/src/main/kotlin/com/yourssu/scouter/common/application/domain/division/DivisionController.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/application/domain/division/DivisionController.kt
@@ -2,15 +2,21 @@ package com.yourssu.scouter.common.application.domain.division
 
 import com.yourssu.scouter.common.business.domain.division.DivisionService
 import com.yourssu.scouter.common.business.domain.division.ReadDivisionsResult
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RestController
 
+@Tag(name = "구분/파트")
 @RestController
 class DivisionController(
     private val divisionService: DivisionService,
 ) {
 
+    @Operation(summary = "멤버 구분 목록 조회", description = "운영, 개발, 디자인 등 각 구분의 목록을 조회합니다.")
     @GetMapping("/divisions")
     fun readAll(): ResponseEntity<List<ReadDivisionResponse>> {
         val result: ReadDivisionsResult = divisionService.readAll()

--- a/src/main/kotlin/com/yourssu/scouter/common/application/domain/mail/MailReservationController.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/application/domain/mail/MailReservationController.kt
@@ -4,6 +4,8 @@ import com.yourssu.scouter.common.application.support.authentication.AuthUser
 import com.yourssu.scouter.common.application.support.authentication.AuthUserInfo
 import com.yourssu.scouter.common.business.domain.mail.MailService
 import com.yourssu.scouter.common.implement.domain.mail.MailReserveCommand
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestMapping
@@ -11,12 +13,14 @@ import org.springframework.web.bind.annotation.RequestPart
 import org.springframework.web.bind.annotation.RestController
 import org.springframework.web.multipart.MultipartFile
 
+@Tag(name = "메일")
 @RestController
 @RequestMapping("/api/mails/reservation")
 class MailReservationController(
     private val mailService: MailService
 ) {
 
+    @Operation(summary = "메일 전송 예약")
     @PostMapping
     fun reserveMail(
         @AuthUser authUserInfo: AuthUserInfo,

--- a/src/main/kotlin/com/yourssu/scouter/common/application/domain/mail/template/MailTemplateController.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/application/domain/mail/template/MailTemplateController.kt
@@ -4,16 +4,25 @@ import com.yourssu.scouter.common.application.support.authentication.AuthUser
 import com.yourssu.scouter.common.application.support.authentication.AuthUserInfo
 import com.yourssu.scouter.common.business.domain.mail.template.MailTemplateService
 import com.yourssu.scouter.common.implement.domain.mail.template.MailTemplate
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.data.domain.PageRequest
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
 
+@Tag(name = "메일")
 @RestController
 @RequestMapping("/api/mails/templates")
 class MailTemplateController(
     private val mailTemplateService: MailTemplateService
 ) {
 
+    @Operation(
+        summary = "메일 템플릿 생성",
+        description = "제목과 양식을 지정해 새로운 메일 템플릿을 생성합니다. 메일 템플릿에 들어가는 변수는 {{}}로 감싸져 있어야 합니다.")
     @PostMapping
     fun create(
         @AuthUser authUserInfo: AuthUserInfo,
@@ -24,6 +33,7 @@ class MailTemplateController(
         return ResponseEntity.status(201).body(CreateMailTemplateResponse.from(saved))
     }
 
+    @Operation(summary = "메일 템플릿 목록 조회", description = "현재 등록된 전체 메일 템플릿을 조회합니다.")
     @GetMapping
     fun readAll(
         @RequestParam(required = false, defaultValue = "0") page: Int,
@@ -53,8 +63,10 @@ class MailTemplateController(
         return ResponseEntity.ok(response)
     }
 
+    @Operation(summary = "메일 템플릿 상세 조회", description = "특정 메일 템플릿의 상세 내용을 조회합니다. (편집용)")
     @GetMapping("/{templateId}")
     fun readDetail(
+        @Parameter(description = "템플릿 ID")
         @PathVariable templateId: Long,
     ): ResponseEntity<ReadMailTemplateDetailResponse> {
         val template = mailTemplateService.readTemplate(templateId)
@@ -63,6 +75,7 @@ class MailTemplateController(
         return ResponseEntity.ok(ReadMailTemplateDetailResponse.from(template))
     }
 
+    @Operation(summary = "메일 템플릿 수정", description = "특정 메일 템플릿을 수정합니다. 전체 메일 템플릿의 내용을 보내야 합니다.")
     @PutMapping("/{templateId}")
     fun update(
         @AuthUser authUserInfo: AuthUserInfo,
@@ -74,6 +87,11 @@ class MailTemplateController(
         return ResponseEntity.ok(CreateMailTemplateResponse.from(updated))
     }
 
+    @Operation(summary = "메일 템플릿 삭제", description = "특정 메일 템플릿을 삭제합니다. 해당 메일 템플릿이 없을 시 404를 반환합니다.")
+    @ApiResponses(
+        ApiResponse(description = "No Content", responseCode = "204"),
+        ApiResponse(description = "Not Found - 템플릿을 찾을 수 없음", responseCode = "404")
+    )
     @DeleteMapping("/{templateId}")
     fun delete(
         @PathVariable templateId: Long,

--- a/src/main/kotlin/com/yourssu/scouter/common/application/domain/part/PartController.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/application/domain/part/PartController.kt
@@ -2,15 +2,19 @@ package com.yourssu.scouter.common.application.domain.part
 
 import com.yourssu.scouter.common.business.domain.part.PartService
 import com.yourssu.scouter.common.business.domain.part.ReadPartsResult
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RestController
 
+@Tag(name = "구분/파트")
 @RestController
 class PartController(
     private val partService: PartService,
 ) {
 
+    @Operation(summary = "파트(팀) 목록 조회", description = "Head lead, finance 등 파트 목록을 조회합니다.")
     @GetMapping("/parts")
     fun readAll(): ResponseEntity<List<ReadPartsResponse>> {
         val result: ReadPartsResult = partService.readAll()

--- a/src/main/kotlin/com/yourssu/scouter/common/application/domain/semester/SemesterController.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/application/domain/semester/SemesterController.kt
@@ -2,6 +2,8 @@ package com.yourssu.scouter.common.application.domain.semester
 
 import com.yourssu.scouter.common.business.domain.semester.SemesterDto
 import com.yourssu.scouter.common.business.domain.semester.SemesterService
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.Valid
 import java.net.URI
 import java.time.LocalDate
@@ -13,11 +15,13 @@ import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RestController
 
+@Tag(name = "학과/학기/단과대")
 @RestController
 class SemesterController(
     private val semesterService: SemesterService,
 ) {
 
+    @Operation(summary= "학기 생성", description = "연도, 학기 조합으로 학기를 생성합니다.")
     @PostMapping("/semesters")
     fun create(
         @RequestBody @Valid request: CreateSemesterRequest,
@@ -27,6 +31,7 @@ class SemesterController(
         return ResponseEntity.created(URI.create("/semesters/$semesterId")).build()
     }
 
+    @Operation(summary = "학기 전체 조회", description = "생성된 전체 학기 정보를 조회합니다.")
     @GetMapping("/semesters")
     fun readAll(): ResponseEntity<List<ReadSemesterResponse>> {
         val semesterDtos: List<SemesterDto> = semesterService.readAllByReverseOrder()
@@ -35,6 +40,7 @@ class SemesterController(
         return ResponseEntity.ok(response)
     }
 
+    @Operation(summary = "현재 학기 조회", description = "현재 학기에 해당하는 정보를 조회합니다.")
     @GetMapping("/semesters/now")
     fun readByDate(): ResponseEntity<ReadSemesterResponse> {
         val now: LocalDate = LocalDate.now()
@@ -44,6 +50,7 @@ class SemesterController(
         return ResponseEntity.ok(response)
     }
 
+    @Operation(summary = "학기 삭제", description = "특정 학기 정보를 삭제합니다.")
     @DeleteMapping("/semesters/{semesterId}")
     fun deleteById(
         @PathVariable semesterId: Long,

--- a/src/main/kotlin/com/yourssu/scouter/common/application/support/authentication/AuthUserInfo.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/application/support/authentication/AuthUserInfo.kt
@@ -1,5 +1,8 @@
 package com.yourssu.scouter.common.application.support.authentication
 
+import io.swagger.v3.oas.annotations.Hidden
+
+@Hidden // AuthUserInfoArgumentResolver 에서 처리함
 data class AuthUserInfo(
     val userId: Long,
 )

--- a/src/main/kotlin/com/yourssu/scouter/common/application/support/configuration/SwaggerConfiguration.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/application/support/configuration/SwaggerConfiguration.kt
@@ -1,0 +1,42 @@
+package com.yourssu.scouter.common.application.support.configuration
+
+import io.swagger.v3.oas.models.Components
+import io.swagger.v3.oas.models.OpenAPI
+import io.swagger.v3.oas.models.info.Info
+import io.swagger.v3.oas.models.security.SecurityRequirement
+import io.swagger.v3.oas.models.security.SecurityScheme
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class SwaggerConfiguration {
+
+    companion object {
+        const val JWT = "JWT"
+        const val BEARER = "Bearer"
+    }
+
+    @Bean
+    fun customOpenAPI() : OpenAPI {
+        val securityRequirement = SecurityRequirement().addList(JWT)
+        val components = Components().addSecuritySchemes(
+            JWT, SecurityScheme()
+                .name(JWT)
+                .type(SecurityScheme.Type.HTTP)
+                .scheme(BEARER)
+                .bearerFormat(JWT)
+        )
+        return OpenAPI()
+            .components(Components())
+            .info(info())
+            .addSecurityItem(securityRequirement)
+            .components(components)
+    }
+
+    private fun info() : Info {
+        return Info()
+            .title("Scouter API")
+            .description("Scouter API")
+            .version("v1.0.0")
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/common/application/support/configuration/SwaggerConfiguration.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/application/support/configuration/SwaggerConfiguration.kt
@@ -3,6 +3,9 @@ package com.yourssu.scouter.common.application.support.configuration
 import io.swagger.v3.oas.models.Components
 import io.swagger.v3.oas.models.OpenAPI
 import io.swagger.v3.oas.models.info.Info
+import io.swagger.v3.oas.models.security.OAuthFlow
+import io.swagger.v3.oas.models.security.OAuthFlows
+import io.swagger.v3.oas.models.security.Scopes
 import io.swagger.v3.oas.models.security.SecurityRequirement
 import io.swagger.v3.oas.models.security.SecurityScheme
 import org.springframework.context.annotation.Bean
@@ -12,25 +15,44 @@ import org.springframework.context.annotation.Configuration
 class SwaggerConfiguration {
 
     companion object {
-        const val JWT = "JWT"
-        const val BEARER = "Bearer"
+        const val OAUTH2 = "oauth2"
     }
 
     @Bean
     fun customOpenAPI() : OpenAPI {
-        val securityRequirement = SecurityRequirement().addList(JWT)
-        val components = Components().addSecuritySchemes(
-            JWT, SecurityScheme()
-                .name(JWT)
-                .type(SecurityScheme.Type.HTTP)
-                .scheme(BEARER)
-                .bearerFormat(JWT)
-        )
+        val securityRequirement = SecurityRequirement().addList(OAUTH2)
+        val components = Components()
+            .addSecuritySchemes(OAUTH2, createGoogleOAuth2Scheme())
         return OpenAPI()
             .components(Components())
             .info(info())
             .addSecurityItem(securityRequirement)
             .components(components)
+    }
+
+    private fun createGoogleOAuth2Scheme() : SecurityScheme {
+        return SecurityScheme()
+            .type(SecurityScheme.Type.OAUTH2)
+            .flows(
+                OAuthFlows()
+                    .authorizationCode(
+                        OAuthFlow()
+                            .authorizationUrl("https://accounts.google.com/o/oauth2/auth")
+                            .tokenUrl("http://localhost:8080/oauth2/swagger/callback")
+                            .refreshUrl("http://localhost:8080/oauth2/swagger/callback")
+                            .scopes(createGoogleScopes())
+                    )
+            )
+    }
+
+    private fun createGoogleScopes() : Scopes {
+        return Scopes()
+            .addString("openid", "OpenId Connect")
+            .addString("profile", "기본 프로필 정보")
+            .addString("email", "이메일 주소")
+            .addString("https://www.googleapis.com/auth/drive.readonly", "드라이브 읽기 권한")
+            .addString("https://www.googleapis.com/auth/forms.responses.readonly", "구글 폼 응답 읽기 권한")
+            .addString("https://www.googleapis.com/auth/gmail.send", "메일 전송 권한")
     }
 
     private fun info() : Info {

--- a/src/main/kotlin/com/yourssu/scouter/common/application/support/configuration/WebConfiguration.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/application/support/configuration/WebConfiguration.kt
@@ -33,6 +33,7 @@ class WebConfiguration(
             .excludePathPatterns("/members/member-upload.html")
             .excludePathPatterns("/members/include-from-excel")
             .excludePathPatterns("/members/download-to-excel")
+            .excludePathPatterns("/swagger-ui/**", "/v3/api-docs/**", "/webjars/**", "/swagger-resources/**")
     }
 
     override fun addArgumentResolvers(resolvers: MutableList<HandlerMethodArgumentResolver>) {

--- a/src/main/kotlin/com/yourssu/scouter/hrms/application/domain/member/MemberController.kt
+++ b/src/main/kotlin/com/yourssu/scouter/hrms/application/domain/member/MemberController.kt
@@ -9,6 +9,9 @@ import com.yourssu.scouter.hrms.business.domain.member.UpdateGraduatedMemberComm
 import com.yourssu.scouter.hrms.business.domain.member.UpdateInactiveMemberCommand
 import com.yourssu.scouter.hrms.business.domain.member.UpdateWithdrawnMemberCommand
 import com.yourssu.scouter.hrms.business.domain.member.WithdrawnMemberDto
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.Valid
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
@@ -18,11 +21,13 @@ import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 
+@Tag(name = "유어슈 멤버")
 @RestController
 class MemberController(
     private val memberService: MemberService,
 ) {
 
+    @Operation(summary = "액티브 멤버 목록 조회/검색")
     @GetMapping("/members/active")
     fun readAllActive(
         @RequestParam(required = false) search: String?,
@@ -37,6 +42,7 @@ class MemberController(
         return ResponseEntity.ok(responses)
     }
 
+    @Operation(summary = "비액티브 멤버 목록 조회/검색")
     @GetMapping("/members/inactive")
     fun readAllInActive(
         @RequestParam(required = false) search: String?,
@@ -51,6 +57,7 @@ class MemberController(
         return ResponseEntity.ok(responses)
     }
 
+    @Operation(summary = "졸업 멤버 목록 조회/검색")
     @GetMapping("/members/graduated")
     fun readAllGraduated(
         @RequestParam(required = false) search: String?,
@@ -66,6 +73,7 @@ class MemberController(
         return ResponseEntity.ok(responses)
     }
 
+    @Operation(summary = "탈퇴 멤버 목록 조회/검색")
     @GetMapping("members/withdrawn")
     fun readAllWithdrawn(
         @RequestParam(required = false) search: String?,
@@ -81,6 +89,7 @@ class MemberController(
         return ResponseEntity.ok(responses)
     }
 
+    @Operation(summary = "액티브 멤버 정보 수정", description = "변경되지 않은 정보는 보내면 안됩니다.")
     @PatchMapping("/members/active/{memberId}")
     fun updateActiveById(
         @PathVariable memberId: Long,
@@ -92,6 +101,7 @@ class MemberController(
         return ResponseEntity.ok().build()
     }
 
+    @Operation(summary = "비액티브 멤버 정보 수정", description = "변경되지 않은 정보는 보내면 안됩니다.")
     @PatchMapping("/members/inactive/{memberId}")
     fun updateInactiveById(
         @PathVariable memberId: Long,
@@ -103,6 +113,7 @@ class MemberController(
         return ResponseEntity.ok().build()
     }
 
+    @Operation(summary = "졸업 멤버 정보 수정", description = "변경되지 않은 정보는 보내면 안됩니다.")
     @PatchMapping("/members/graduated/{memberId}")
     fun updateGraduatedById(
         @PathVariable memberId: Long,
@@ -114,6 +125,7 @@ class MemberController(
         return ResponseEntity.ok().build()
     }
 
+    @Operation(summary = "탈퇴 멤버 정보 수정", description = "변경되지 않은 정보는 보내면 안됩니다.")
     @PatchMapping("/members/withdrawn/{memberId}")
     fun updateWithdrawnById(
         @PathVariable memberId: Long,
@@ -125,6 +137,7 @@ class MemberController(
         return ResponseEntity.ok().build()
     }
 
+    @Operation(summary = "멤버 역할 목록 조회", description = "Lead, Vice Lead, Member 등 역할을 조회합니다.")
     @GetMapping("/members/roles")
     fun readAllMemberRoles(): ResponseEntity<List<String>> {
         val roles: List<String> = memberService.readAllRoles()
@@ -132,6 +145,7 @@ class MemberController(
         return ResponseEntity.ok(roles)
     }
 
+    @Operation(summary = "멤버 상태 목록 조회", description = "액티브, 비액티브, 졸업, 탈퇴 등 상태를 조회합니다.")
     @GetMapping("/members/states")
     fun readAllMemberStates(): ResponseEntity<List<String>> {
         val states: List<String> = memberService.readAllStates()

--- a/src/main/kotlin/com/yourssu/scouter/hrms/application/domain/member/MemberSyncController.kt
+++ b/src/main/kotlin/com/yourssu/scouter/hrms/application/domain/member/MemberSyncController.kt
@@ -4,6 +4,8 @@ import com.yourssu.scouter.common.application.support.authentication.AuthUser
 import com.yourssu.scouter.common.application.support.authentication.AuthUserInfo
 import com.yourssu.scouter.hrms.business.domain.member.MemberSyncResult
 import com.yourssu.scouter.hrms.business.domain.member.MemberSyncService
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
 import java.time.LocalDateTime
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
@@ -11,11 +13,14 @@ import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RestController
 
+@Tag(name = "유어슈 멤버")
+@Tag(name = "합격자 동기화 API")
 @RestController
 class MemberSyncController(
     private val memberSyncService: MemberSyncService,
 ) {
 
+    @Operation(summary = "지원자 중 합격자 멤버 동기화", description = "리크루팅 지원자 중 합격자를 멤버에 동기화 합니다.")
     @PostMapping("/members/include-from-applicants")
     fun includeFromApplicants(
         @AuthUser authUserInfo: AuthUserInfo,
@@ -38,6 +43,7 @@ class MemberSyncController(
         return ResponseEntity.ok(response)
     }
 
+    @Operation(summary = "마지막 동기화 시간 조회", description = "유어슈 멤버의 마지막 동기화 시간을 조회합니다.")
     @GetMapping("/members/lastUpdatedTime")
     fun lastSyncTime(): ResponseEntity<LastMemberSyncTimeResponse> {
         val lastSyncTime: LocalDateTime? = memberSyncService.readLastUpdatedTime()

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -38,6 +38,7 @@ oauth2:
     allowed_redirect_uris:
       - ${ALLOWED_REDIRECT_URI_LOCAL}
       - ${ALLOWED_REDIRECT_URI_DEV}
+      - ${SWAGGER_OAUTH2_REDIRECT_URL}
     scope:
       - openid
       - https://www.googleapis.com/auth/userinfo.email
@@ -53,3 +54,7 @@ springdoc:
     doc-expansion: none # 기본으로 접기
     operations-sorter: method # 정렬 방식
     tags-sorter: alpha
+    oauth:
+      client-id: ${GOOGLE_OAUTH_CLIENT_ID}
+      client-secret: ${GOOGLE_OAUTH_CLIENT_SECRET}
+    oauth2-redirect-url: ${SWAGGER_OAUTH2_REDIRECT_URL}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -45,3 +45,11 @@ oauth2:
       - https://www.googleapis.com/auth/drive.readonly
       - https://www.googleapis.com/auth/forms.responses.readonly
       - https://www.googleapis.com/auth/gmail.send
+
+springdoc:
+  swagger-ui:
+    syntax-highlight:
+      theme: arta # syntax highlight theme
+    doc-expansion: none # 기본으로 접기
+    operations-sorter: method # 정렬 방식
+    tags-sorter: alpha


### PR DESCRIPTION
## 📄 작업 내용 요약
### Swagger 자동 문서화를 추가합니다.
- OAuth2 인증을 추가했습니다. OAuth2 인증 로직 테스트를 위한 것이 아니라 다른 API를 테스트하기 위한 인증이므로 GOOGLE로 고정되게 했습니다.
- SWAGGER_OAUTH_REDIRECTION_URL에는 환경에 맞는 swagger 리다이렉션 Url을 입력하면 됩니다. ex) http://localhost:8080/swagger-ui/oauth2-redirect.html
- 기본적인 설명은 전부 달아뒀습니다. 그런데 특정 학기로 멤버/지원자를 동기화시키는건 목적이 무엇인지 잘 모르겠어서 설명을 달지 않았습니다.
- 문서화 작업을 하다가 /applicants/include-from-forms 엔드포인트의 응답 코드가 노션에 나와있는 코드와 다른 것을 확인했습니다. 우선 코드대로 200으로 달아두었지만 201 응답으로 변경하는게 맞을 것 같습니다.

## 📎 Issue 번호
<!-- closed #번호 -->
closed #73 