### PR TITLE
[#125]; bug: referer 오리진 기반 redirect 통일

### DIFF
--- a/src/main/kotlin/com/yourssu/scouter/common/implement/support/configuration/OpenFeignConfiguration.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/support/configuration/OpenFeignConfiguration.kt
@@ -12,5 +12,5 @@ class OpenFeignConfiguration {
 
     @Bean
     @Profile("local", "dev")
-    fun feignLoggerLevel(): Logger.Level = Logger.Level.FULL
+    fun feignLoggerLevel(): Logger.Level = Logger.Level.BASIC
 }

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/support/security/oauth2/GoogleOAuth2Handler.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/support/security/oauth2/GoogleOAuth2Handler.kt
@@ -144,7 +144,6 @@ class GoogleOAuth2Handler(
 
     private fun resolveRedirectUri(referer: String, redirectUriOverride: String?): String {
         val fromOverride = selectAllowedRedirectUri(redirectUriOverride)
-        return fromOverride ?: (googleOAuth2Properties.redirectUri
-            ?: googleOAuth2Properties.calculateRedirectUri(referer))
+        return fromOverride ?: googleOAuth2Properties.calculateRedirectUri(referer)
     }
 }

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/support/security/oauth2/GoogleOAuth2Properties.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/support/security/oauth2/GoogleOAuth2Properties.kt
@@ -7,21 +7,34 @@ data class GoogleOAuth2Properties(
     val clientId: String,
     val clientSecret: String,
     // 기존 path는 널 허용 + 기본값 제공
-    var redirectPath: String? = "/oauth/callback/google",
-
-    // 새 절대 URL도 널 허용 (없으면 path로 계산)
-    var redirectUri: String? = null,
+    var redirectPath: String? = "/oauth2/callback/google",
     var allowedRedirectUris: List<String>? = null,
     val scope: List<String>
 ) {
 
     fun calculateRedirectUri(baseUrl: String? = null): String {
-        // redirectUri가 설정돼 있으면 무조건 그걸 사용
-        redirectUri?.let { return it }
+        // referer 등으로 들어온 baseUrl에서 오리진만 추출해 안전하게 붙임
+        val origin = extractOrigin(baseUrl ?: "http://localhost:5173")
+        val path = (redirectPath ?: "/oauth2/callback/google").let { p -> if (p.startsWith("/")) p else "/$p" }
+        return origin.removeSuffix("/") + path
+    }
 
-        // 하위호환: baseUrl + redirectPath 조합 (필요할 때만)
-        val path = redirectPath ?: "/oauth/callback/google"
-        val base = baseUrl ?: "http://localhost:3005"
-        return "$base$path"
+    private fun extractOrigin(url: String): String {
+        return try {
+            val uri = java.net.URI(url)
+            val scheme = uri.scheme ?: "http"
+            val host = uri.host ?: uri.authority ?: "localhost"
+            val defaultPort = if (scheme.equals("https", ignoreCase = true)) 443 else 80
+            val port = if (uri.port != -1 && uri.port != defaultPort) ":${uri.port}" else ""
+            "$scheme://$host$port"
+        } catch (_: Exception) {
+            // fallback: 단순 문자열 처리
+            val trimmed = url.trim()
+            if (trimmed.startsWith("http://") || trimmed.startsWith("https://")) {
+                trimmed.substringBefore("/", trimmed)
+            } else {
+                "http://" + trimmed.substringBefore("/", trimmed)
+            }
+        }
     }
 }

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -15,7 +15,7 @@ spring:
     open-in-view: false
   cors:
     allowed-origins: ${CORS_ALLOWED_ORIGINS}
-    
+
 token:
   jwt:
     access-key: ${JWT_ACCESS_KEY}
@@ -26,7 +26,7 @@ oauth2:
   google:
     client_id: ${GOOGLE_OAUTH_CLIENT_ID} # 환경변수에서 주입
     client_secret: ${GOOGLE_OAUTH_CLIENT_SECRET} # 환경변수에서 주입
-    redirect_uri: ${GOOGLE_OAUTH_REDIRECT_URI} # 환경변수에서 주입 (전체 URL)
+    redirect-path: /oauth2/callback/google
     allowed_redirect_uris:
       - ${ALLOWED_REDIRECT_URI_LOCAL}
       - ${ALLOWED_REDIRECT_URI_DEV}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -34,7 +34,7 @@ oauth2:
   google:
     client_id: ${GOOGLE_OAUTH_CLIENT_ID} # 환경변수에서 주입
     client_secret: ${GOOGLE_OAUTH_CLIENT_SECRET} # 환경변수에서 주입
-    redirect_uri: ${GOOGLE_OAUTH_REDIRECT_URI} # 환경변수에서 주입 (전체 URL)
+    redirect-path: /oauth2/callback/google
     allowed_redirect_uris:
       - ${ALLOWED_REDIRECT_URI_LOCAL}
       - ${ALLOWED_REDIRECT_URI_DEV}


### PR DESCRIPTION
## 📄 작업 내용 요약
- GoogleOAuth2Properties
    - redirectPath 기본값을 /oauth2/callback/google 로 통일
    - calculateRedirectUri: referer에서 오리진만 추출해 안전하게 조합
    - redirectUri(절대 URL) 필드 및 관련 분기 제거
- GoogleOAuth2Handler
   - resolveRedirectUri: 고정 redirectUri 분기 제거, allowlist or referer 기반만 사용


## 📎 Issue 번호
closes #125 