### PR TITLE
[#129]; feat: 표준 토큰 응답 적용 및 타입클레임 추가

### DIFF
--- a/src/main/kotlin/com/yourssu/scouter/common/application/domain/authentication/AuthenticationController.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/application/domain/authentication/AuthenticationController.kt
@@ -85,7 +85,14 @@ class AuthenticationController(
     }
 
     @SecurityRequirements // 로그인을 필요로 하지 않는 곳은 전역 인증을 사용하지않도록 초기화
-    @Operation(summary = "토큰 재발급")
+    @Operation(
+        summary = "토큰 재발급",
+        description = "Authorization 헤더는 무시되며, 바디의 refreshToken(순수 JWT)만 사용합니다.",
+        responses = [
+            ApiResponse(responseCode = "200", description = "OK"),
+            ApiResponse(responseCode = "401", description = "Auth-001 (리프레시 토큰이 아닙니다. 등)")
+        ]
+    )
     @PostMapping("/refresh-token")
     fun refreshToken(
         @RequestBody @Valid request: TokenRefreshRequest,

--- a/src/main/kotlin/com/yourssu/scouter/common/application/domain/authentication/AuthenticationController.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/application/domain/authentication/AuthenticationController.kt
@@ -89,13 +89,10 @@ class AuthenticationController(
     @PostMapping("/refresh-token")
     fun refreshToken(
         @RequestBody @Valid request: TokenRefreshRequest,
-        @Parameter(hidden = true)
-        @RequestHeader(HttpHeaders.AUTHORIZATION, required = false) bearerRefreshHeader: String?,
     ): ResponseEntity<TokenRefreshResponse> {
-        logger.info("[Auth] POST /refresh-token | hasAuthHeader={} | bodyPresent={}", !bearerRefreshHeader.isNullOrBlank(), !request.refreshToken.isNullOrBlank())
+        logger.info("[Auth] POST /refresh-token | bodyPresent={} (Authorization header ignored)", !request.refreshToken.isNullOrBlank())
         val requestTime = LocalDateTime.now()
-        val providedRefreshToken = if (!bearerRefreshHeader.isNullOrBlank()) bearerRefreshHeader else request.refreshToken
-        val tokenDto: TokenDto = authenticationService.refreshToken(requestTime, providedRefreshToken)
+        val tokenDto: TokenDto = authenticationService.refreshToken(requestTime, request.refreshToken)
         val response: TokenRefreshResponse = TokenRefreshResponse.from(tokenDto)
 
         return ResponseEntity.ok(response)

--- a/src/main/kotlin/com/yourssu/scouter/common/application/domain/authentication/LoginResponse.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/application/domain/authentication/LoginResponse.kt
@@ -3,11 +3,13 @@ package com.yourssu.scouter.common.application.domain.authentication
 import com.yourssu.scouter.common.business.domain.authentication.LoginResult
 
 data class LoginResponse(
+    val tokenType: String,
     val accessToken: String,
     val refreshToken: String,
 ) {
     companion object {
         fun from(loginResult: LoginResult): LoginResponse = LoginResponse(
+            tokenType = "Bearer",
             accessToken = loginResult.accessToken,
             refreshToken = loginResult.refreshToken
         )

--- a/src/main/kotlin/com/yourssu/scouter/common/application/domain/authentication/TokenRefreshResponse.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/application/domain/authentication/TokenRefreshResponse.kt
@@ -3,13 +3,14 @@ package com.yourssu.scouter.common.application.domain.authentication
 import com.yourssu.scouter.common.business.domain.authentication.TokenDto
 
 data class TokenRefreshResponse(
-
+    val tokenType: String,
     val accessToken: String,
     val refreshToken: String,
 ) {
 
     companion object {
         fun from(tokenDto: TokenDto) = TokenRefreshResponse(
+            tokenType = "Bearer",
             accessToken = tokenDto.accessToken,
             refreshToken = tokenDto.refreshToken,
         )

--- a/src/main/kotlin/com/yourssu/scouter/common/application/support/authentication/AuthUserInfoArgumentResolver.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/application/support/authentication/AuthUserInfoArgumentResolver.kt
@@ -5,6 +5,7 @@ import com.yourssu.scouter.common.implement.domain.authentication.PrivateClaims
 import com.yourssu.scouter.common.implement.domain.authentication.TokenProcessor
 import com.yourssu.scouter.common.implement.domain.authentication.TokenType
 import com.yourssu.scouter.common.implement.support.exception.InvalidTokenException
+import com.yourssu.scouter.common.implement.support.exception.InvalidTokenMessages
 import io.jsonwebtoken.Claims
 import org.springframework.core.MethodParameter
 import org.springframework.http.HttpHeaders
@@ -41,7 +42,7 @@ class AuthUserInfoArgumentResolver(
         }
 
         val claims: Claims = tokenProcessor.decode(TokenType.ACCESS, accessToken)
-            ?: throw InvalidTokenException("유효한 토큰이 아닙니다.")
+            ?: throw InvalidTokenException(InvalidTokenMessages.INVALID_TOKEN)
         val privateClaims = PrivateClaims.from(claims)
 
         return AuthUserInfo(privateClaims.userId)

--- a/src/main/kotlin/com/yourssu/scouter/common/application/support/configuration/SwaggerConfiguration.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/application/support/configuration/SwaggerConfiguration.kt
@@ -66,7 +66,13 @@ class SwaggerConfiguration {
     private fun info() : Info {
         return Info()
             .title("Scouter API")
-            .description("Scouter API")
-            .version("v1.0.0")
+            .description(
+                "Changelog v1.1.0\n" +
+                "- Token 응답 표준화: tokenType + accessToken + refreshToken\n" +
+                "- 발급: 접두사 제거(순수 JWT), 수신: Bearer 유무 허용\n" +
+                "- claims.tokenType 추가 및 타입 불일치 상세 오류메시지 (Auth-001)\n" +
+                "- POST /refresh-token: Authorization 헤더 무시, body.refreshToken만 사용\n" +
+            )
+            .version("v1.1.0")
     }
 }

--- a/src/main/kotlin/com/yourssu/scouter/common/business/domain/authentication/AuthenticationService.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/business/domain/authentication/AuthenticationService.kt
@@ -1,18 +1,14 @@
 package com.yourssu.scouter.common.business.domain.authentication
 
 import com.yourssu.scouter.common.business.support.exception.NoSuchUserException
-import com.yourssu.scouter.common.implement.domain.authentication.BlacklistTokenReader
-import com.yourssu.scouter.common.implement.domain.authentication.BlacklistTokenWriter
-import com.yourssu.scouter.common.implement.domain.authentication.PrivateClaims
-import com.yourssu.scouter.common.implement.domain.authentication.Token
-import com.yourssu.scouter.common.implement.domain.authentication.TokenProcessor
-import com.yourssu.scouter.common.implement.domain.authentication.TokenType
+import com.yourssu.scouter.common.implement.domain.authentication.*
 import com.yourssu.scouter.common.implement.domain.user.UserReader
 import com.yourssu.scouter.common.implement.domain.user.UserWriter
 import com.yourssu.scouter.common.implement.support.exception.InvalidTokenException
+import com.yourssu.scouter.common.implement.support.exception.InvalidTokenMessages
 import io.jsonwebtoken.Claims
-import java.time.LocalDateTime
 import org.springframework.stereotype.Service
+import java.time.LocalDateTime
 
 @Service
 class AuthenticationService(
@@ -31,7 +27,7 @@ class AuthenticationService(
 
     fun getValidPrivateClaims(tokenType: TokenType, token: String): PrivateClaims {
         val claims: Claims = tokenProcessor.decode(tokenType, token)
-            ?: throw InvalidTokenException("유효한 토큰이 아닙니다.")
+            ?: throw InvalidTokenException(InvalidTokenMessages.INVALID_TOKEN)
         val privateClaims = PrivateClaims.from(claims)
 
         val userId: Long = privateClaims.userId
@@ -39,7 +35,7 @@ class AuthenticationService(
             throw NoSuchUserException("존재하지 않는 유저의 토큰입니다.")
         }
         if (blacklistTokenReader.isBlacklisted(userId, token)) {
-            throw InvalidTokenException("로그아웃되었습니다.")
+            throw InvalidTokenException(InvalidTokenMessages.LOGGED_OUT)
         }
 
         return privateClaims
@@ -56,8 +52,7 @@ class AuthenticationService(
     }
 
     fun refreshToken(requestTime: LocalDateTime, refreshToken: String): TokenDto {
-        val normalizedRefreshToken = if (refreshToken.startsWith("Bearer ")) refreshToken else "Bearer $refreshToken"
-        val privateClaims: PrivateClaims = getValidPrivateClaims(TokenType.REFRESH, normalizedRefreshToken)
+        val privateClaims: PrivateClaims = getValidPrivateClaims(TokenType.REFRESH, refreshToken)
         val token: Token = tokenProcessor.generateToken(requestTime, privateClaims.toMap())
 
         return TokenDto(token.accessToken, token.refreshToken)

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/support/exception/InvalidTokenMessages.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/support/exception/InvalidTokenMessages.kt
@@ -1,0 +1,8 @@
+package com.yourssu.scouter.common.implement.support.exception
+
+object InvalidTokenMessages {
+    const val INVALID_TOKEN: String = "유효한 토큰이 아닙니다."
+    const val NOT_REFRESH_TOKEN: String = "리프레시 토큰이 아닙니다."
+    const val NOT_ACCESS_TOKEN: String = "액세스 토큰이 아닙니다."
+    const val LOGGED_OUT: String = "로그아웃되었습니다."
+}

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/support/security/token/JwtTokenProcessor.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/support/security/token/JwtTokenProcessor.kt
@@ -4,6 +4,7 @@ import com.yourssu.scouter.common.implement.domain.authentication.Token
 import com.yourssu.scouter.common.implement.domain.authentication.TokenProcessor
 import com.yourssu.scouter.common.implement.domain.authentication.TokenType
 import com.yourssu.scouter.common.implement.support.exception.InvalidTokenException
+import com.yourssu.scouter.common.implement.support.exception.InvalidTokenMessages
 import io.jsonwebtoken.Claims
 import io.jsonwebtoken.JwtException
 import io.jsonwebtoken.Jwts
@@ -32,11 +33,12 @@ class JwtTokenProcessor(
         val issueDate: Date = convertToDate(issueTime)
         val key: String = jwtProperties.findTokenKey(tokenType)
         val expiredHours: Long = jwtProperties.findExpiredHours(tokenType)
+        val claimsWithTokenType: Map<String, Any> = HashMap(privateClaims).plus("tokenType" to tokenType.name)
 
-        return TOKEN_PREFIX + Jwts.builder()
+        return Jwts.builder()
             .issuedAt(issueDate)
             .expiration(Date(issueDate.time + expiredHours * 60 * 60 * 1000L))
-            .claims(privateClaims)
+            .claims(claimsWithTokenType)
             .signWith(Keys.hmacShaKeyFor(key.toByteArray(StandardCharsets.UTF_8)))
             .compact()
     }
@@ -48,33 +50,46 @@ class JwtTokenProcessor(
     }
 
     override fun decode(tokenType: TokenType, token: String): Claims? {
-        validateBearerToken(token)
+        val pureToken = findActualToken(token)
 
-        return parseToClaims(tokenType, token)
-    }
-
-    private fun validateBearerToken(token: String) {
-        if (!token.startsWith(TOKEN_PREFIX)) {
-            throw InvalidTokenException("Bearer 타입이 아닙니다.")
+        // 1) 요청된 타입의 키로 먼저 검증
+        val requestedKey: String = jwtProperties.findTokenKey(tokenType)
+        parseWithKey(requestedKey, pureToken)?.let { claims ->
+            val actualType: String? = claims["tokenType"] as? String
+            if (actualType != null && !actualType.equals(tokenType.name, ignoreCase = true)) {
+                val message = if (TokenType.REFRESH == tokenType) InvalidTokenMessages.NOT_REFRESH_TOKEN else InvalidTokenMessages.NOT_ACCESS_TOKEN
+                throw InvalidTokenException(message)
+            }
+            return claims
         }
+
+        // 2) 다른 타입의 키로 검증 성공하면 타입 불일치로 간주
+        val otherType: TokenType = if (TokenType.ACCESS == tokenType) TokenType.REFRESH else TokenType.ACCESS
+        val otherKey: String = jwtProperties.findTokenKey(otherType)
+        parseWithKey(otherKey, pureToken)?.let {
+            val message = if (TokenType.REFRESH == tokenType) InvalidTokenMessages.NOT_REFRESH_TOKEN else InvalidTokenMessages.NOT_ACCESS_TOKEN
+            throw InvalidTokenException(message)
+        }
+
+        // 3) 어떤 키로도 파싱되지 않으면 유효하지 않은 토큰으로 간주
+        return null
     }
 
-    private fun parseToClaims(tokenType: TokenType, token: String): Claims? {
-        val key: String = jwtProperties.findTokenKey(tokenType)
-
+    private fun parseWithKey(key: String, pureToken: String): Claims? {
         return try {
             Jwts.parser()
                 .verifyWith(Keys.hmacShaKeyFor(key.toByteArray(StandardCharsets.UTF_8)))
                 .build()
-                .parseSignedClaims(findPureToken(token))
+                .parseSignedClaims(pureToken)
                 .payload
         } catch (_: JwtException) {
             null
         }
     }
 
-    private fun findPureToken(token: String): String {
-        return token.substring(TOKEN_PREFIX.length)
+    private fun findActualToken(token: String): String {
+        val trimmed = token.trim()
+        return if (trimmed.startsWith(TOKEN_PREFIX)) trimmed.substring(TOKEN_PREFIX.length) else trimmed
     }
 
     override fun generateToken(issueTime: LocalDateTime, privateClaims: Map<String, Any>): Token {

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/support/security/token/JwtTokenProcessor.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/support/security/token/JwtTokenProcessor.kt
@@ -33,7 +33,10 @@ class JwtTokenProcessor(
         val issueDate: Date = convertToDate(issueTime)
         val key: String = jwtProperties.findTokenKey(tokenType)
         val expiredHours: Long = jwtProperties.findExpiredHours(tokenType)
-        val claimsWithTokenType: Map<String, Any> = HashMap(privateClaims).plus("tokenType" to tokenType.name)
+        val claimsWithTokenType: Map<String, Any> = buildMap {
+            putAll(privateClaims)
+            put("tokenType", tokenType.name)
+        }
 
         return Jwts.builder()
             .issuedAt(issueDate)

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/support/security/token/JwtTokenProcessor.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/support/security/token/JwtTokenProcessor.kt
@@ -59,7 +59,7 @@ class JwtTokenProcessor(
         val requestedKey: String = jwtProperties.findTokenKey(tokenType)
         parseWithKey(requestedKey, pureToken)?.let { claims ->
             val actualType: String? = claims["tokenType"] as? String
-            if (actualType != null && !actualType.equals(tokenType.name, ignoreCase = true)) {
+            if (actualType != null && actualType != tokenType.name) {
                 val message = if (TokenType.REFRESH == tokenType) InvalidTokenMessages.NOT_REFRESH_TOKEN else InvalidTokenMessages.NOT_ACCESS_TOKEN
                 throw InvalidTokenException(message)
             }

--- a/src/test/kotlin/com/yourssu/scouter/common/implement/support/security/token/JwtTokenProcessorTest.kt
+++ b/src/test/kotlin/com/yourssu/scouter/common/implement/support/security/token/JwtTokenProcessorTest.kt
@@ -29,7 +29,7 @@ class JwtTokenProcessorTest {
         val actual = tokenProcessor.encode(LocalDateTime.now(), TokenType.ACCESS, privateClaims)
 
         // then
-        assertThat(actual).contains("Bearer ")
+        assertThat(actual).doesNotContain("Bearer ")
     }
 
     @Test
@@ -39,9 +39,8 @@ class JwtTokenProcessorTest {
         val invalidTypeToken = "Basic12 abcde"
 
         // when & then
-        Assertions.assertThatThrownBy { tokenProcessor.decode(TokenType.ACCESS, invalidTypeToken) }
-            .isInstanceOf(InvalidTokenException::class.java)
-            .hasMessage("Bearer 타입이 아닙니다.")
+        val actual: Claims? = tokenProcessor.decode(TokenType.ACCESS, invalidTypeToken)
+        assertThat(actual).isNull()
     }
 
     @Test
@@ -76,5 +75,75 @@ class JwtTokenProcessorTest {
 
         // then
         assertThat((actual!![keyName] as Number).toLong()).isEqualTo(userId)
+    }
+
+    @Test
+    fun `리프레시 토큰이 아닙니다 예외를 던진다`() {
+        // given
+        val tokenProcessor = JwtTokenProcessor(jwtProperties)
+        val claims = mapOf("userId" to 1L)
+        val accessToken = tokenProcessor.encode(
+            LocalDateTime.now(ZoneId.of("Asia/Seoul")),
+            TokenType.ACCESS,
+            claims
+        )
+
+        // when & then
+        Assertions.assertThatThrownBy { tokenProcessor.decode(TokenType.REFRESH, accessToken) }
+            .isInstanceOf(InvalidTokenException::class.java)
+            .hasMessage("리프레시 토큰이 아닙니다.")
+    }
+
+    @Test
+    fun `액세스 토큰이 아닙니다 예외를 던진다`() {
+        // given
+        val tokenProcessor = JwtTokenProcessor(jwtProperties)
+        val claims = mapOf("userId" to 1L)
+        val refreshToken = tokenProcessor.encode(
+            LocalDateTime.now(ZoneId.of("Asia/Seoul")),
+            TokenType.REFRESH,
+            claims
+        )
+
+        // when & then
+        Assertions.assertThatThrownBy { tokenProcessor.decode(TokenType.ACCESS, refreshToken) }
+            .isInstanceOf(InvalidTokenException::class.java)
+            .hasMessage("액세스 토큰이 아닙니다.")
+    }
+
+    @Test
+    fun `Bearer 접두사가 있어도 디코딩된다`() {
+        // given
+        val tokenProcessor = JwtTokenProcessor(jwtProperties)
+        val claims = mapOf("userId" to 1L)
+        val token = tokenProcessor.encode(
+            LocalDateTime.now(ZoneId.of("Asia/Seoul")),
+            TokenType.ACCESS,
+            claims
+        )
+
+        // when
+        val actual: Claims? = tokenProcessor.decode(TokenType.ACCESS, "Bearer $token")
+
+        // then
+        assertThat(actual).isNotNull()
+    }
+
+    @Test
+    fun `발급된 토큰에 tokenType 클레임이 포함된다`() {
+        // given
+        val tokenProcessor = JwtTokenProcessor(jwtProperties)
+        val claims = mapOf("userId" to 1L)
+        val accessToken = tokenProcessor.encode(
+            LocalDateTime.now(ZoneId.of("Asia/Seoul")),
+            TokenType.ACCESS,
+            claims
+        )
+
+        // when
+        val actual: Claims? = tokenProcessor.decode(TokenType.ACCESS, accessToken)
+
+        // then
+        assertThat(actual!!["tokenType"]).isEqualTo("ACCESS")
     }
 }


### PR DESCRIPTION
## 원인 및 해결 
- 클라가 잘못된 토큰종류를 사용 (refresh만 보내야하는데 access토큰 보내기) -> 아마 이거일 것 같음
- 근데 페카가 "스펙상 accessToken에 종속되지 않은 API인 /refresh-token 호출시에는 요청 헤더에 accessToken을 넣지 않게 만드는 방식" 으로 변경 -> 이미 해결됨

## 📄 작업 내용 요약
그래서 이미 해결되었지만, 나중에 이런 오류가 났을때 원인파악을 빠르게 하기 위해 표준화방식으로 변경

BREAKING CHANGE: 
- 응답 토큰이 이제 “순수 JWT”로 반환. 클라가 요청 시에만 Authorization: Bearer <accessToken>로 조립 필요.

그외:
- 접두사 제거 발급, 수신 시 접두사 유무 허용
- 토큰 타입 클레임 추가 및 불일치 시 상세 에러 메시지 (ex. 액세스 토큰이 아닙니다)
- /refresh-token Authorization 헤더 무시, 바디 refreshToken만 사용
- 메시지 상수화(InvalidTokenMessages), 테스트 보강


<details>
  <summary>구체적인 api변경사항 요약</summary>

`공통`
- 서버 응답 토큰은 “순수 JWT”로 반환. 응답 바디에 tokenType: "Bearer" 추가.
- 보호 API 호출 시에만 헤더로 Authorization: Bearer <accessToken> 조립.

`POST /oauth2/login`
- 응답: { tokenType: "Bearer", accessToken: "<JWT>", refreshToken: "<JWT>" }

`POST /refresh-token`
- 요청: Authorization 헤더 사용 금지. 바디 { "refreshToken": "<JWT>" }만 전송.
- 응답: { tokenType: "Bearer", accessToken: "<JWT>", refreshToken: "<JWT>" }
- 오류(401, Auth-001): “리프레시 토큰이 아닙니다.”(refresh 자리로 access 보낸 경우)

`POST /logout`
- 요청: 헤더 Authorization: Bearer <accessToken> + 바디 { "refreshToken": "<JWT>" } (순수jwt)
- 응답: 204 No Content
- 오류(401, Auth-001): 블랙리스트면 “로그아웃되었습니다.”

`GET /validate-token`
- 요청: 헤더 Authorization: Bearer <accessToken>
- 응답: { "validated": true | false }

`보호 API 전반`
- Authorization 헤더 누락 시 Auth-003 발생
</details>

## 📎 Issue 번호
closes #129 
