### PR TITLE
[#115]; refactor!: 잘못된 응답구조 변경

### DIFF
--- a/src/main/kotlin/com/yourssu/scouter/ats/application/domain/applicant/ApplicantSyncController.kt
+++ b/src/main/kotlin/com/yourssu/scouter/ats/application/domain/applicant/ApplicantSyncController.kt
@@ -9,6 +9,7 @@ import io.swagger.v3.oas.annotations.headers.Header
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.tags.Tag
 import java.time.LocalDateTime
+import java.net.URI
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
@@ -22,13 +23,19 @@ class ApplicantSyncController(
     private val applicantSyncService: ApplicantSyncService,
 ) {
 
+    private val applicantsLocation: URI = URI.create("/applicants")
+
+    private fun createdApplicants(response: ApplicantSyncResponse): ResponseEntity<ApplicantSyncResponse> {
+        return ResponseEntity.created(applicantsLocation).body(response)
+    }
+
     @Operation(
         summary = "구글폼 응답을 지원자 목록에 업데이트",
         description = "현재 로그인 되어있는 사용자의 계정을 이용해 지원자의 구글폼 응답을 동기화 합니다."
     )
-    @ApiResponse(description = "OK", responseCode = "200", headers = [
+    @ApiResponse(description = "CREATED", responseCode = "201", headers = [
         Header(name = "Location", description = "/applicants")
-    ]) // 노션 api 명세랑 안맞는 부분 api 명세 상 201 <-> 실제는 200
+    ])
     @PostMapping("/applicants/include-from-forms")
     fun includeFromForms(
         @AuthUser authUserInfo: AuthUserInfo,
@@ -36,9 +43,12 @@ class ApplicantSyncController(
         val result: ApplicantSyncResult = applicantSyncService.includeFromForms(authUserInfo.userId)
         val response: ApplicantSyncResponse = ApplicantSyncResponse.from(result)
 
-        return ResponseEntity.ok(response)
+        return createdApplicants(response)
     }
 
+    @ApiResponse(description = "CREATED", responseCode = "201", headers = [
+        Header(name = "Location", description = "/applicants")
+    ])
     @PostMapping("/applicants/include-from-forms/semesters/{semesterId}")
     fun includeFromFormsBySemesterAndPart(
         @AuthUser authUserInfo: AuthUserInfo,
@@ -47,7 +57,7 @@ class ApplicantSyncController(
         val result: ApplicantSyncResult = applicantSyncService.includeFromForms(authUserInfo.userId, semesterId)
         val response: ApplicantSyncResponse = ApplicantSyncResponse.from(result)
 
-        return ResponseEntity.ok(response)
+        return createdApplicants(response)
     }
 
     @Operation(summary = "마지막 동기화 시간 조회")

--- a/src/main/kotlin/com/yourssu/scouter/ats/application/domain/applicant/ApplicantSyncController.kt
+++ b/src/main/kotlin/com/yourssu/scouter/ats/application/domain/applicant/ApplicantSyncController.kt
@@ -41,9 +41,7 @@ class ApplicantSyncController(
         @AuthUser authUserInfo: AuthUserInfo,
     ): ResponseEntity<ApplicantSyncResponse> {
         val result: ApplicantSyncResult = applicantSyncService.includeFromForms(authUserInfo.userId)
-        val response: ApplicantSyncResponse = ApplicantSyncResponse.from(result)
-
-        return createdApplicants(response)
+        return result.toCreatedResponse(applicantsLocation, ApplicantSyncResponse::from)
     }
 
     @ApiResponse(description = "CREATED", responseCode = "201", headers = [
@@ -55,9 +53,7 @@ class ApplicantSyncController(
         @PathVariable semesterId: Long,
     ): ResponseEntity<ApplicantSyncResponse> {
         val result: ApplicantSyncResult = applicantSyncService.includeFromForms(authUserInfo.userId, semesterId)
-        val response: ApplicantSyncResponse = ApplicantSyncResponse.from(result)
-
-        return createdApplicants(response)
+        return result.toCreatedResponse(applicantsLocation, ApplicantSyncResponse::from)
     }
 
     @Operation(summary = "마지막 동기화 시간 조회")

--- a/src/main/kotlin/com/yourssu/scouter/ats/application/domain/applicant/ApplicantSyncExtensions.kt
+++ b/src/main/kotlin/com/yourssu/scouter/ats/application/domain/applicant/ApplicantSyncExtensions.kt
@@ -1,0 +1,10 @@
+package com.yourssu.scouter.ats.application.domain.applicant
+
+import com.yourssu.scouter.ats.business.domain.applicant.ApplicantSyncResult
+import java.net.URI
+import org.springframework.http.ResponseEntity
+
+fun ApplicantSyncResult.toCreatedResponse(location: URI, mapper: (ApplicantSyncResult) -> ApplicantSyncResponse): ResponseEntity<ApplicantSyncResponse> {
+    val response: ApplicantSyncResponse = mapper(this)
+    return ResponseEntity.created(location).body(response)
+}

--- a/src/main/kotlin/com/yourssu/scouter/common/application/support/configuration/SwaggerConfiguration.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/application/support/configuration/SwaggerConfiguration.kt
@@ -67,12 +67,9 @@ class SwaggerConfiguration {
         return Info()
             .title("Scouter API")
             .description(
-                "Changelog v1.1.0\n" +
-                "- Token 응답 표준화: tokenType + accessToken + refreshToken\n" +
-                "- 발급: 접두사 제거(순수 JWT), 수신: Bearer 유무 허용\n" +
-                "- claims.tokenType 추가 및 타입 불일치 상세 오류메시지 (Auth-001)\n" +
-                "- POST /refresh-token: Authorization 헤더 무시, body.refreshToken만 사용\n"
+                "Changelog v1.1.1\n" +
+                "- Applicants: POST /applicants/include-from-forms(및 /semesters/{semesterId}) 201 Created + Location 헤더\n"
             )
-            .version("v1.1.0")
+            .version("v1.1.1")
     }
 }

--- a/src/main/kotlin/com/yourssu/scouter/common/application/support/configuration/SwaggerConfiguration.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/application/support/configuration/SwaggerConfiguration.kt
@@ -68,6 +68,7 @@ class SwaggerConfiguration {
             .title("Scouter API")
             .description(
                 "Changelog v1.1.1\n" +
+                "- Members: POST /members/include-from-applicants(및 /{semesterString}) 생성 시 201 Created + Location 헤더, 생성 0건 시 200 OK\n" +
                 "- Applicants: POST /applicants/include-from-forms(및 /semesters/{semesterId}) 201 Created + Location 헤더\n"
             )
             .version("v1.1.1")

--- a/src/main/kotlin/com/yourssu/scouter/hrms/application/domain/member/MemberSyncController.kt
+++ b/src/main/kotlin/com/yourssu/scouter/hrms/application/domain/member/MemberSyncController.kt
@@ -5,7 +5,10 @@ import com.yourssu.scouter.common.application.support.authentication.AuthUserInf
 import com.yourssu.scouter.hrms.business.domain.member.MemberSyncResult
 import com.yourssu.scouter.hrms.business.domain.member.MemberSyncService
 import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.headers.Header
+import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.tags.Tag
+import java.net.URI
 import java.time.LocalDateTime
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
@@ -20,17 +23,34 @@ class MemberSyncController(
     private val memberSyncService: MemberSyncService,
 ) {
 
+    private val membersLocation: URI = URI.create("/members")
+
+    private fun membersResponse(result: MemberSyncResult): ResponseEntity<MemberSyncResponse> {
+        val response = MemberSyncResponse(result.failureMessages, result.createdCount)
+        return if (result.createdCount > 0) {
+            ResponseEntity.created(membersLocation).body(response)
+        } else {
+            ResponseEntity.ok(response)
+        }
+    }
+
     @Operation(summary = "지원자 중 합격자 멤버 동기화", description = "리크루팅 지원자 중 합격자를 멤버에 동기화 합니다.")
+    @ApiResponse(description = "OK", responseCode = "200")
+    @ApiResponse(description = "CREATED", responseCode = "201", headers = [
+        Header(name = "Location", description = "/members")
+    ])
     @PostMapping("/members/include-from-applicants")
     fun includeFromApplicants(
         @AuthUser authUserInfo: AuthUserInfo,
     ): ResponseEntity<MemberSyncResponse> {
         val result: MemberSyncResult = memberSyncService.includeAcceptedApplicants(authUserInfo.userId)
-        val response = MemberSyncResponse(result.failureMessages)
-
-        return ResponseEntity.ok(response)
+        return membersResponse(result)
     }
 
+    @ApiResponse(description = "OK", responseCode = "200")
+    @ApiResponse(description = "CREATED", responseCode = "201", headers = [
+        Header(name = "Location", description = "/members")
+    ])
     @PostMapping("/members/include-from-applicants/{semesterString}")
     fun includeFromApplicants(
         @AuthUser authUserInfo: AuthUserInfo,
@@ -38,9 +58,7 @@ class MemberSyncController(
     ): ResponseEntity<MemberSyncResponse> {
         val result: MemberSyncResult =
             memberSyncService.includeAcceptedApplicants(authUserInfo.userId, semesterString)
-        val response = MemberSyncResponse(result.failureMessages)
-
-        return ResponseEntity.ok(response)
+        return membersResponse(result)
     }
 
     @Operation(summary = "마지막 동기화 시간 조회", description = "유어슈 멤버의 마지막 동기화 시간을 조회합니다.")

--- a/src/main/kotlin/com/yourssu/scouter/hrms/application/domain/member/MemberSyncController.kt
+++ b/src/main/kotlin/com/yourssu/scouter/hrms/application/domain/member/MemberSyncController.kt
@@ -25,15 +25,6 @@ class MemberSyncController(
 
     private val membersLocation: URI = URI.create("/members")
 
-    private fun membersResponse(result: MemberSyncResult): ResponseEntity<MemberSyncResponse> {
-        val response = MemberSyncResponse(result.failureMessages, result.createdCount)
-        return if (result.createdCount > 0) {
-            ResponseEntity.created(membersLocation).body(response)
-        } else {
-            ResponseEntity.ok(response)
-        }
-    }
-
     @Operation(summary = "지원자 중 합격자 멤버 동기화", description = "리크루팅 지원자 중 합격자를 멤버에 동기화 합니다.")
     @ApiResponse(description = "OK", responseCode = "200")
     @ApiResponse(description = "CREATED", responseCode = "201", headers = [
@@ -44,7 +35,7 @@ class MemberSyncController(
         @AuthUser authUserInfo: AuthUserInfo,
     ): ResponseEntity<MemberSyncResponse> {
         val result: MemberSyncResult = memberSyncService.includeAcceptedApplicants(authUserInfo.userId)
-        return membersResponse(result)
+        return result.toResponse(membersLocation)
     }
 
     @ApiResponse(description = "OK", responseCode = "200")
@@ -58,7 +49,7 @@ class MemberSyncController(
     ): ResponseEntity<MemberSyncResponse> {
         val result: MemberSyncResult =
             memberSyncService.includeAcceptedApplicants(authUserInfo.userId, semesterString)
-        return membersResponse(result)
+        return result.toResponse(membersLocation)
     }
 
     @Operation(summary = "마지막 동기화 시간 조회", description = "유어슈 멤버의 마지막 동기화 시간을 조회합니다.")

--- a/src/main/kotlin/com/yourssu/scouter/hrms/application/domain/member/MemberSyncExtensions.kt
+++ b/src/main/kotlin/com/yourssu/scouter/hrms/application/domain/member/MemberSyncExtensions.kt
@@ -1,0 +1,14 @@
+package com.yourssu.scouter.hrms.application.domain.member
+
+import com.yourssu.scouter.hrms.business.domain.member.MemberSyncResult
+import java.net.URI
+import org.springframework.http.ResponseEntity
+
+fun MemberSyncResult.toResponse(location: URI): ResponseEntity<MemberSyncResponse> {
+    val response = MemberSyncResponse(this.failureMessages, this.createdCount)
+    return if (this.createdCount > 0) {
+        ResponseEntity.created(location).body(response)
+    } else {
+        ResponseEntity.ok(response)
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/hrms/application/domain/member/MemberSyncResponse.kt
+++ b/src/main/kotlin/com/yourssu/scouter/hrms/application/domain/member/MemberSyncResponse.kt
@@ -2,4 +2,5 @@ package com.yourssu.scouter.hrms.application.domain.member
 
 data class MemberSyncResponse(
     val failureMessages: List<String>,
+    val createdCount: Int,
 )

--- a/src/main/kotlin/com/yourssu/scouter/hrms/business/domain/member/MemberService.kt
+++ b/src/main/kotlin/com/yourssu/scouter/hrms/business/domain/member/MemberService.kt
@@ -44,12 +44,13 @@ class MemberService(
         return writtenActiveMember.id!!
     }
 
-    fun createMemberWithActiveStateIfNotExists(newMember: Member) {
+    fun createMemberWithActiveStateIfNotExists(newMember: Member): Boolean {
         if (memberReader.existsByStudentId(newMember.studentId)) {
-            return
+            return false
         }
 
         memberWriter.writeMemberWithActiveStatus(newMember, false)
+        return true
     }
 
     fun readAllActiveByFilters(

--- a/src/main/kotlin/com/yourssu/scouter/hrms/business/domain/member/MemberSyncResult.kt
+++ b/src/main/kotlin/com/yourssu/scouter/hrms/business/domain/member/MemberSyncResult.kt
@@ -1,5 +1,6 @@
 package com.yourssu.scouter.hrms.business.domain.member
 
 data class MemberSyncResult(
-    val failureMessages: List<String>,
+    val failureMessages: List<String> = emptyList(),
+    val createdCount: Int = 0,
 )

--- a/src/main/kotlin/com/yourssu/scouter/hrms/business/domain/member/MemberSyncService.kt
+++ b/src/main/kotlin/com/yourssu/scouter/hrms/business/domain/member/MemberSyncService.kt
@@ -53,18 +53,22 @@ class MemberSyncService(
         val forms: List<GoogleDriveFile> = googleDriveReader.getFiles(googleAccessToken, query)
         val additionalInfos = processForms(googleAccessToken, forms)
 
-        val failureMessages: List<String> =
+        val (failureMessages, createdCount) =
             mergeToActiveMemberAndReturnFailMessages(acceptedApplicants, additionalInfos)
 
-        return MemberSyncResult(failureMessages)
+        return MemberSyncResult(
+            failureMessages = failureMessages,
+            createdCount = createdCount,
+        )
     }
 
     private fun mergeToActiveMemberAndReturnFailMessages(
         acceptedApplicants: List<Applicant>,
         additionalInfos: List<AcceptedApplicantResponse>,
-    ): List<String> {
+    ): Pair<List<String>, Int> {
         val departments: List<Department> = departmentReader.readAll()
         val failureMessages = mutableListOf<String>()
+        var createdCount = 0
         val acceptedApplicantsMap = acceptedApplicants.associateBy { it.studentId }
         val acceptedResponseMap = additionalInfos.associateBy { it.studentId }
         for ((studentId, applicant) in acceptedApplicantsMap) {
@@ -100,10 +104,13 @@ class MemberSyncService(
             val memberSyncLog = MemberSyncLog.create()
 
             memberSyncLogWriter.write(memberSyncLog)
-            memberService.createMemberWithActiveStateIfNotExists(newMember)
+            val created: Boolean = memberService.createMemberWithActiveStateIfNotExists(newMember)
+            if (created) {
+                createdCount += 1
+            }
         }
 
-        return failureMessages
+        return failureMessages to createdCount
     }
 
     private fun processForms(

--- a/src/test/kotlin/com/yourssu/scouter/hrms/application/domain/member/MemberSyncExtensionsTest.kt
+++ b/src/test/kotlin/com/yourssu/scouter/hrms/application/domain/member/MemberSyncExtensionsTest.kt
@@ -1,0 +1,41 @@
+package com.yourssu.scouter.hrms.application.domain.member
+
+import com.yourssu.scouter.hrms.business.domain.member.MemberSyncResult
+import java.net.URI
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.http.HttpStatus
+
+class MemberSyncExtensionsTest {
+
+    @Test
+    fun `toResponse는 createdCount가 1 이상이면 201과 Location을 반환한다`() {
+        // given
+        val result = MemberSyncResult(failureMessages = emptyList(), createdCount = 2)
+        val location = URI.create("/members")
+
+        // when
+        val response = result.toResponse(location)
+
+        // then
+        assertThat(response.statusCode).isEqualTo(HttpStatus.CREATED)
+        assertThat(response.headers.location?.toString()).isEqualTo("/members")
+        assertThat(response.body!!.createdCount).isEqualTo(2)
+    }
+
+    @Test
+    fun `toResponse는 createdCount가 0이면 200을 반환한다`() {
+        // given
+        val result = MemberSyncResult(failureMessages = listOf("no changes"), createdCount = 0)
+        val location = URI.create("/members")
+
+        // when
+        val response = result.toResponse(location)
+
+        // then
+        assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
+        assertThat(response.headers.location).isNull()
+        assertThat(response.body!!.failureMessages).containsExactly("no changes")
+        assertThat(response.body!!.createdCount).isEqualTo(0)
+    }
+}


### PR DESCRIPTION
## 📄 작업 내용 요약

## 특이사항
applicants/include-from-forms 뿐만아니라 members도 201로 변환고려했으나

멤버가 “생길 수 있다면” 201을 쓸 수 있지만, members는 동기화 특성상 신규맴버가 생성될 수도 있고 아닐 수도 있음
-> 걍 200으로 단순화

**_서브이슈 133관련 작업_**

-> 에민 코멘트보고 클라의 응답 명확성을 위해 조건에 따라 members/200/201반환하도록 변경
++) 설계고려사항 refactor: 컨트롤러의 공통헤더 대신 extenstions 함수로 분리

## 📎 Issue 번호
closes #115
closes #133 
