### PR TITLE
[#186]; fix(mail-template): bodyHtml 엔티티 매핑과 DB스키마를 일치시킨다.

### DIFF
--- a/src/main/kotlin/com/yourssu/scouter/common/storage/domain/mail/MailEntity.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/storage/domain/mail/MailEntity.kt
@@ -16,6 +16,8 @@ import jakarta.persistence.Lob
 import jakarta.persistence.OneToMany
 import jakarta.persistence.Table
 import jakarta.persistence.Transient
+import org.hibernate.annotations.JdbcTypeCode
+import org.hibernate.type.SqlTypes
 
 @Entity
 @Table(name = "mail")
@@ -31,6 +33,8 @@ class MailEntity(
     val mailSubject: String,
 
     @Lob
+    @JdbcTypeCode(SqlTypes.LONGVARCHAR)
+    @Column(columnDefinition = "LONGTEXT")
     val mailBody: String,
 
     @Enumerated(EnumType.STRING)

--- a/src/main/kotlin/com/yourssu/scouter/common/storage/domain/mail/template/MailTemplateEntity.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/storage/domain/mail/template/MailTemplateEntity.kt
@@ -1,8 +1,10 @@
 package com.yourssu.scouter.common.storage.domain.mail.template
 
+import com.yourssu.scouter.common.implement.domain.mail.template.MailTemplate
 import jakarta.persistence.*
 import java.time.LocalDateTime
-import com.yourssu.scouter.common.implement.domain.mail.template.MailTemplate
+import org.hibernate.annotations.JdbcTypeCode
+import org.hibernate.type.SqlTypes
 
 @Entity
 @Table(name = "mail_template")
@@ -16,7 +18,8 @@ class MailTemplateEntity(
     val title: String,
 
     @Lob
-    @Column(nullable = false)
+    @JdbcTypeCode(SqlTypes.LONGVARCHAR)
+    @Column(nullable = false, columnDefinition = "LONGTEXT")
     val bodyHtml: String,
 
     @Column(nullable = false)


### PR DESCRIPTION
## 📄 작업 내용 요약
- BREAKING CHANGE: DB 스키마 측에서 mail_template.body_html컬럼을  LONGTEXT 타입으로 변경했습니다.

그외 변경사항
- mail.mail_body도 기존타입인 longtext를 명시적으로 매핑하는 코드를 추가했습니다.

## 📎 Issue 번호
closed #186 
