### PR TITLE
[#208]; fix(mail): reservationTime 타입을 LocalDateTime에서 Instant로 변경하여 UTC 타임존 처리

### DIFF
--- a/src/main/kotlin/com/yourssu/scouter/common/application/domain/mail/MailReserveRequest.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/application/domain/mail/MailReserveRequest.kt
@@ -3,8 +3,7 @@ package com.yourssu.scouter.common.application.domain.mail
 import com.yourssu.scouter.common.business.domain.mail.MailBodyFormat
 import com.yourssu.scouter.common.implement.domain.mail.MailReserveCommand
 import io.swagger.v3.oas.annotations.media.Schema
-import java.time.LocalDateTime
-import org.springframework.format.annotation.DateTimeFormat
+import java.time.Instant
 import org.springframework.web.multipart.MultipartFile
 
 @Schema(description = "메일 예약 요청")
@@ -28,9 +27,8 @@ data class MailReserveRequest(
     @field:Schema(description = "본문 형식", example = "HTML", allowableValues = ["HTML", "PLAIN_TEXT"])
     val bodyFormat: String,
 
-    @field:Schema(description = "예약 발송 시간 (ISO 8601)", example = "2026-02-06T11:00:00")
-    @field:DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
-    val reservationTime: LocalDateTime
+    @field:Schema(description = "예약 발송 시간 (ISO 8601, UTC)", example = "2026-02-06T02:00:00Z")
+    val reservationTime: Instant
 ) {
 
     fun toCommand(

--- a/src/main/kotlin/com/yourssu/scouter/common/business/domain/mail/MailService.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/business/domain/mail/MailService.kt
@@ -9,7 +9,8 @@ import com.yourssu.scouter.common.implement.domain.mail.MailReservationWriter
 import com.yourssu.scouter.common.implement.domain.mail.MailReserveCommand
 import com.yourssu.scouter.common.implement.domain.mail.MailWriter
 import com.yourssu.scouter.common.implement.domain.user.UserReader
-import java.time.LocalDateTime
+import java.time.Instant
+import java.time.temporal.ChronoUnit
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 
@@ -37,7 +38,7 @@ class MailService(
     }
 
     fun sendReservedMails() {
-        val now = LocalDateTime.now()
+        val now = Instant.now()
         val reservations = mailReservationReader.readAllBefore(now)
         for (reservation in reservations) {
             try {
@@ -59,7 +60,7 @@ class MailService(
                 mailReservationWriter.delete(reservation)
             } catch (e: Exception) {
                 log.error("예약 메일 발송 실패: mailId={}", reservation.mailId, e)
-                if (reservation.reservationTime.plusHours(MAX_RETRY_HOURS).isBefore(now)) {
+                if (reservation.reservationTime.plus(MAX_RETRY_HOURS, ChronoUnit.HOURS).isBefore(now)) {
                     log.error("최대 재시도 기간({}시간) 초과로 예약 삭제: mailId={}", MAX_RETRY_HOURS, reservation.mailId)
                     mailReservationWriter.delete(reservation)
                 }

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/domain/mail/MailReservation.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/domain/mail/MailReservation.kt
@@ -1,9 +1,9 @@
 package com.yourssu.scouter.common.implement.domain.mail
 
-import java.time.LocalDateTime
+import java.time.Instant
 
 class MailReservation(
     val id: Long? = null,
     val mailId: Long,
-    val reservationTime: LocalDateTime,
+    val reservationTime: Instant,
 )

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/domain/mail/MailReservationReader.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/domain/mail/MailReservationReader.kt
@@ -1,6 +1,6 @@
 package com.yourssu.scouter.common.implement.domain.mail
 
-import java.time.LocalDateTime
+import java.time.Instant
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
 
@@ -10,7 +10,7 @@ class MailReservationReader(
     private val mailReservationRepository: MailReservationRepository,
 ) {
 
-    fun readAllBefore(time: LocalDateTime): List<MailReservation> {
+    fun readAllBefore(time: Instant): List<MailReservation> {
         return mailReservationRepository.findAllByReservationTimeLessThanEqual(time)
     }
 }

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/domain/mail/MailReservationRepository.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/domain/mail/MailReservationRepository.kt
@@ -1,8 +1,10 @@
 package com.yourssu.scouter.common.implement.domain.mail
 
+import java.time.Instant
+
 interface MailReservationRepository {
 
     fun save(mailReservation: MailReservation): MailReservation
-    fun findAllByReservationTimeLessThanEqual(reservationTime: java.time.LocalDateTime): List<MailReservation>
+    fun findAllByReservationTimeLessThanEqual(reservationTime: Instant): List<MailReservation>
     fun deleteById(id: Long)
 }

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/domain/mail/MailReserveCommand.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/domain/mail/MailReserveCommand.kt
@@ -2,7 +2,7 @@ package com.yourssu.scouter.common.implement.domain.mail
 
 import com.yourssu.scouter.common.business.domain.mail.MailBodyFormat
 import jakarta.mail.util.ByteArrayDataSource
-import java.time.LocalDateTime
+import java.time.Instant
 import org.springframework.web.multipart.MultipartFile
 
 data class MailReserveCommand(
@@ -15,7 +15,7 @@ data class MailReserveCommand(
     val bodyFormat: MailBodyFormat,
     val inlineImages: List<MultipartFile> = emptyList(),
     val attachments: List<MultipartFile> = emptyList(),
-    val reservationTime: LocalDateTime,
+    val reservationTime: Instant,
 ) {
     fun toMail(
         senderEmailAddress: String,

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/domain/mail/MailWriter.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/domain/mail/MailWriter.kt
@@ -1,6 +1,6 @@
 package com.yourssu.scouter.common.implement.domain.mail
 
-import java.time.LocalDateTime
+import java.time.Instant
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
 
@@ -11,7 +11,7 @@ class MailWriter(
     private val mailReservationRepository: MailReservationRepository,
 ) {
 
-    fun reserve(mail: Mail, reservationTime: LocalDateTime) {
+    fun reserve(mail: Mail, reservationTime: Instant) {
         val savedMail: Mail = mailRepository.save(mail)
         val mailReservation = MailReservation(
             mailId = savedMail.id!!,

--- a/src/main/kotlin/com/yourssu/scouter/common/storage/domain/mail/JpaMailReservationRepository.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/storage/domain/mail/JpaMailReservationRepository.kt
@@ -1,8 +1,8 @@
 package com.yourssu.scouter.common.storage.domain.mail
 
 import org.springframework.data.jpa.repository.JpaRepository
-import java.time.LocalDateTime
+import java.time.Instant
 
 interface JpaMailReservationRepository : JpaRepository<MailReservationEntity, Long> {
-    fun findAllByReservationTimeLessThanEqual(reservationTime: LocalDateTime): List<MailReservationEntity>
+    fun findAllByReservationTimeLessThanEqual(reservationTime: Instant): List<MailReservationEntity>
 }

--- a/src/main/kotlin/com/yourssu/scouter/common/storage/domain/mail/MailReservationEntity.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/storage/domain/mail/MailReservationEntity.kt
@@ -7,7 +7,7 @@ import jakarta.persistence.GeneratedValue
 import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
 import jakarta.persistence.Table
-import java.time.LocalDateTime
+import java.time.Instant
 
 @Entity
 @Table(name = "mail_reservation")
@@ -21,7 +21,7 @@ class MailReservationEntity(
     val mailId: Long,
 
     @Column(nullable = false)
-    val reservationTime: LocalDateTime,
+    val reservationTime: Instant,
 ) {
 
     companion object {

--- a/src/main/kotlin/com/yourssu/scouter/common/storage/domain/mail/MailReservationRepositoryImpl.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/storage/domain/mail/MailReservationRepositoryImpl.kt
@@ -13,7 +13,7 @@ class MailReservationRepositoryImpl(
         return jpaMailReservationRepository.save(MailReservationEntity.from(mailReservation)).toDomain()
     }
 
-    override fun findAllByReservationTimeLessThanEqual(reservationTime: java.time.LocalDateTime): List<MailReservation> {
+    override fun findAllByReservationTimeLessThanEqual(reservationTime: java.time.Instant): List<MailReservation> {
         return jpaMailReservationRepository.findAllByReservationTimeLessThanEqual(reservationTime).map { it.toDomain() }
     }
 


### PR DESCRIPTION
## 📄 작업 내용 요약
Instant는 UTC 기준의 절대 시점을 표현하며, Z suffix를 정확히 파싱합니다.
스케줄러도 Instant.now()(UTC)로 비교하므로 서버 타임존과 무관하게 정확한 시간에 발송됩니다.

### 다른 방식을 택하지않은 이유
- DTO에서만 Instant로 받고 KST LocalDateTime으로 변환하는 방식
    - 변경 범위는 Request DTO 하나로 최소화되지만, 서버가 항상 KST에서 돌아야 한다는 암묵적 가정이 생김
    - 클라우드 환경에서 서버 타임존이 UTC로 설정되는 경우 동일한 버그가 재발함
    - LocalDateTime이 실제로는 KST라는 컨벤션을 코드에서 강제할 수 없어 유지보수 시 혼동 가능

- 스케줄러만 LocalDateTime.now(ZoneOffset.UTC)로 변경하는 방식
  - 1줄 변경으로 가장 간단하지만, "타임존이 없는 타입인데 실제로는 UTC"라는 모순적 컨벤션이 됨
  - 다른 개발자가 LocalDateTime.now()(KST)로 비교하는 코드를 추가하면 동일한 버그 재발
  - 타입 시스템이 보호해주지 않으므로 리뷰에서도 놓치기 쉬움

- Instant를 선택한 이유
  - 타입 자체가 UTC임을 보장하므로 타임존 실수가 구조적으로 불가능
  - Instant.now()는 서버 타임존 설정과 무관하게 항상 UTC 반환
  - MySQL 8 + Hibernate 6 환경에서 Instant도 datetime으로 매핑되어 DB 스키마 변경 불필요

## 📎 Issue 번호
closes #208 
