### PR TITLE
[#222]; feat: 메일 템플릿 이미지 조회 기능 추가

### DIFF
--- a/src/main/kotlin/com/yourssu/scouter/common/application/domain/mail/MailImageController.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/application/domain/mail/MailImageController.kt
@@ -1,0 +1,49 @@
+package com.yourssu.scouter.common.application.domain.mail
+
+import com.yourssu.scouter.common.application.support.authentication.AuthUser
+import com.yourssu.scouter.common.application.support.authentication.AuthUserInfo
+import com.yourssu.scouter.common.business.domain.mail.MailFileService
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@Tag(name = "메일")
+@RestController
+@RequestMapping("/api/mails/images")
+class MailImageController(
+    private val mailFileService: MailFileService,
+) {
+    @Operation(
+        summary = "메일 이미지 조회 (302 Redirect)",
+        description =
+            "업로드된 이미지 파일의 S3 presigned GET URL을 생성하고, 해당 URL로 302 리다이렉트합니다.\n\n" +
+                "**사용 방법:**\n" +
+                "- `<img src=\"/api/mails/images/{fileId}\">` 형태로 HTML에서 직접 사용 가능합니다.\n" +
+                "- 브라우저 주소창에서 직접 호출하면 이미지가 표시됩니다.\n\n" +
+                "**Swagger UI 제한:**\n" +
+                "- Swagger UI는 302 응답을 자동으로 따라가며, S3 도메인과의 CORS 차이로 인해 정상 동작하더라도 에러로 표시될 수 있습니다.\n" +
+                "- 테스트 시에는 브라우저 주소창에서 직접 호출하거나 curl을 사용해 주세요.\n\n" +
+                "**Presigned URL:**\n" +
+                "- 생성된 URL은 10분간 유효합니다.",
+    )
+    @ApiResponses(
+        ApiResponse(responseCode = "302", description = "Found - S3 presigned URL로 리다이렉트"),
+        ApiResponse(responseCode = "404", description = "Not Found - 파일을 찾을 수 없거나 삭제된 파일"),
+    )
+    @GetMapping("/{fileId}")
+    fun redirectToImage(
+        @AuthUser authUserInfo: AuthUserInfo,
+        @Parameter(description = "파일 ID") @PathVariable fileId: Long,
+        response: HttpServletResponse,
+    ) {
+        val presignedGetUrl = mailFileService.createPresignedGetUrl(authUserInfo.userId, fileId)
+        response.sendRedirect(presignedGetUrl)
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/common/business/domain/mail/MailFileService.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/business/domain/mail/MailFileService.kt
@@ -28,11 +28,12 @@ class MailFileService(
     fun createPresignedPutUrl(command: MailFilePresignCommand): MailFilePresignResult {
         val key = MailStorageKeyGenerator.generate(command.usage, command.userId, command.fileName)
         val storageKey = mailFileStorage.resolveStorageKey(key)
-        val putUrl = mailFileStorage.createPresignedPutUrl(
-            key = key,
-            contentType = command.contentType,
-            expireDuration = presignDuration,
-        )
+        val putUrl =
+            mailFileStorage.createPresignedPutUrl(
+                key = key,
+                contentType = command.contentType,
+                expireDuration = presignDuration,
+            )
 
         return MailFilePresignResult(
             s3Key = storageKey,
@@ -67,6 +68,17 @@ class MailFileService(
         val file = mailFileValidator.requireFile(userId, fileId)
         mailFileValidator.validateNotUsed(file)
         mailUploadedFileRepository.save(file.copy(status = MailUploadedFileStatus.DELETED))
+    }
+
+    fun createPresignedGetUrl(
+        userId: Long,
+        fileId: Long,
+    ): String {
+        val file = mailFileValidator.requireFile(userId, fileId)
+        return mailFileStorage.createPresignedGetUrl(
+            key = file.storageKey,
+            expireDuration = presignDuration,
+        )
     }
 
     @Transactional

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/domain/mail/MailFileStorage.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/domain/mail/MailFileStorage.kt
@@ -17,5 +17,10 @@ interface MailFileStorage {
         expireDuration: Duration,
     ): String
 
+    fun createPresignedGetUrl(
+        key: String,
+        expireDuration: Duration,
+    ): String
+
     fun resolveStorageKey(key: String): String
 }

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/support/storage/S3MailFileStorage.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/support/storage/S3MailFileStorage.kt
@@ -10,6 +10,7 @@ import software.amazon.awssdk.services.s3.S3Client
 import software.amazon.awssdk.services.s3.model.GetObjectRequest
 import software.amazon.awssdk.services.s3.model.PutObjectRequest
 import software.amazon.awssdk.services.s3.presigner.S3Presigner
+import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest
 import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest
 import java.time.Duration
 
@@ -86,6 +87,28 @@ class S3MailFileStorage(
             presigner.presignPutObject(presignRequest).url().toString()
         } catch (e: Exception) {
             throw IllegalStateException("S3 업로드용 presigned URL 생성에 실패했습니다: $key", e)
+        }
+    }
+
+    override fun createPresignedGetUrl(
+        key: String,
+        expireDuration: Duration,
+    ): String {
+        return try {
+            val getObjectRequest =
+                GetObjectRequest.builder()
+                    .bucket(properties.bucket)
+                    .key(key)
+                    .build()
+            val presignRequest =
+                GetObjectPresignRequest.builder()
+                    .signatureDuration(expireDuration)
+                    .getObjectRequest(getObjectRequest)
+                    .build()
+
+            presigner.presignGetObject(presignRequest).url().toString()
+        } catch (e: Exception) {
+            throw IllegalStateException("S3 다운로드용 presigned URL 생성에 실패했습니다: $key", e)
         }
     }
 


### PR DESCRIPTION
## 📄 작업 내용 요약
메일 템플릿 이미지 조회를 위한 Presign URL을 발급하고 해당 url로 리다이렉트 해주는 api 구현

## 📎 Issue 번호
<!-- closed #번호 -->
closed #222 