### PR TITLE
[#265]; feat(hrms): local/dev에서 멤버 민감정보 권한 토글하는 dev API 추가

### DIFF
--- a/src/main/kotlin/com/yourssu/scouter/hrms/application/domain/member/DevMemberPrivacyAdminController.kt
+++ b/src/main/kotlin/com/yourssu/scouter/hrms/application/domain/member/DevMemberPrivacyAdminController.kt
@@ -1,0 +1,66 @@
+package com.yourssu.scouter.hrms.application.domain.member
+
+import com.yourssu.scouter.common.application.support.authentication.AuthUser
+import com.yourssu.scouter.common.application.support.authentication.AuthUserInfo
+import com.yourssu.scouter.hrms.business.domain.member.MemberPrivacyService
+import com.yourssu.scouter.hrms.business.support.DevPrivilegeTestHolder
+import com.yourssu.scouter.hrms.business.support.exception.MemberAccessDeniedException
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.context.annotation.Profile
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+/**
+ * local, dev 프로필 전용. 스카우터 팀원이 자기 자신의 민감정보 열람 권한을 일시적으로 끄고/켜서
+ * 마스킹 동작을 Swagger 등으로 테스트할 수 있게 함.
+ */
+@Profile("local", "dev")
+@Tag(name = "[DEV] 멤버 민감정보 권한 테스트")
+@RestController
+@RequestMapping("/internal/dev/member-privacy")
+class DevMemberPrivacyAdminController(
+    private val memberPrivacyService: MemberPrivacyService,
+    private val devPrivilegeTestHolder: DevPrivilegeTestHolder,
+) {
+
+    @Operation(
+        summary = "나를 비권한자로 전환 (테스트용)",
+        description = "이후 멤버 API 호출 시 내 계정은 민감정보가 마스킹된 응답을 받습니다. 스카우터 팀원만 호출 가능.",
+    )
+    @ApiResponses(
+        ApiResponse(responseCode = "204", description = "적용됨"),
+        ApiResponse(responseCode = "403", description = "스카우터 팀원이 아님"),
+    )
+    @PostMapping("/privileged/self/disable")
+    fun disablePrivilegeForSelf(@AuthUser authUserInfo: AuthUserInfo): ResponseEntity<Unit> {
+        requireScouterTeamMember(authUserInfo.userId)
+        devPrivilegeTestHolder.markAsNonPrivilegedForTest(authUserInfo.userId)
+        return ResponseEntity.noContent().build()
+    }
+
+    @Operation(
+        summary = "나를 권한자로 복원 (테스트용)",
+        description = "비권한자로 전환한 상태를 해제하고, 다시 민감정보 열람 권한이 있는 상태로 돌립니다.",
+    )
+    @ApiResponses(
+        ApiResponse(responseCode = "204", description = "적용됨"),
+        ApiResponse(responseCode = "403", description = "스카우터 팀원이 아님"),
+    )
+    @PostMapping("/privileged/self/enable")
+    fun enablePrivilegeForSelf(@AuthUser authUserInfo: AuthUserInfo): ResponseEntity<Unit> {
+        requireScouterTeamMember(authUserInfo.userId)
+        devPrivilegeTestHolder.unmark(authUserInfo.userId)
+        return ResponseEntity.noContent().build()
+    }
+
+    private fun requireScouterTeamMember(userId: Long) {
+        if (!memberPrivacyService.isScouterTeamMember(userId)) {
+            throw MemberAccessDeniedException("이 API는 스카우터 팀원만 사용할 수 있습니다.")
+        }
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/hrms/business/domain/member/MemberPrivacyService.kt
+++ b/src/main/kotlin/com/yourssu/scouter/hrms/business/domain/member/MemberPrivacyService.kt
@@ -1,13 +1,16 @@
 package com.yourssu.scouter.hrms.business.domain.member
 
 import com.yourssu.scouter.common.implement.domain.user.UserReader
+import com.yourssu.scouter.hrms.business.support.DevPrivilegeTestHolder
 import com.yourssu.scouter.hrms.implement.domain.member.MemberReader
+import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Service
 
 @Service
 class MemberPrivacyService(
     private val userReader: UserReader,
     private val memberReader: MemberReader,
+    @Autowired(required = false) private val devPrivilegeTestHolder: DevPrivilegeTestHolder? = null,
 ) {
 
     private val privilegedEmails: Set<String> = setOf(
@@ -18,7 +21,17 @@ class MemberPrivacyService(
         "piki.urssu@gmail.com",
     )
 
+    /** 스카우터 팀원(privilegedEmails 목록) 여부. dev 어드민 API 호출 권한 판별용. */
+    fun isScouterTeamMember(userId: Long): Boolean {
+        val user = userReader.readById(userId)
+        val email: String = user.getEmailAddress()
+        return privilegedEmails.contains(email)
+    }
+
     fun isPrivilegedUser(userId: Long): Boolean {
+        if (devPrivilegeTestHolder?.isMarkedAsNonPrivileged(userId) == true) {
+            return false
+        }
         val user = userReader.readById(userId)
         val email: String = user.getEmailAddress()
 

--- a/src/main/kotlin/com/yourssu/scouter/hrms/business/support/DevPrivilegeTestHolder.kt
+++ b/src/main/kotlin/com/yourssu/scouter/hrms/business/support/DevPrivilegeTestHolder.kt
@@ -1,0 +1,27 @@
+package com.yourssu.scouter.hrms.business.support
+
+import org.springframework.context.annotation.Profile
+import org.springframework.stereotype.Component
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * dev 프로필 전용. 민감정보 열람 권한 테스트 시 "일시적으로 비권한자로 동작"할 userId를 보관.
+ * DB 없이 인메모리로만 유지되며, 서버 재시작 시 초기화됨.
+ */
+@Profile("local", "dev")
+@Component
+class DevPrivilegeTestHolder {
+
+    private val forcedNonPrivilegedUserIds = ConcurrentHashMap.newKeySet<Long>()
+
+    fun isMarkedAsNonPrivileged(userId: Long): Boolean =
+        forcedNonPrivilegedUserIds.contains(userId)
+
+    fun markAsNonPrivilegedForTest(userId: Long) {
+        forcedNonPrivilegedUserIds.add(userId)
+    }
+
+    fun unmark(userId: Long) {
+        forcedNonPrivilegedUserIds.remove(userId)
+    }
+}


### PR DESCRIPTION
## 📄 작업 내용 요약
HRMS 멤버 민감정보 마스킹을 local/dev 환경에서 스카우터 팀원이 직접 검증할 수 있도록, 권한 토글용 dev API를 추가했습니다.
아직 DB 스키마는 건드리지 않고, 인메모리 Set 기반으로만 일시적인 비권한 상태를 강제합니다.

## 📎 Issue 번호
closed #265 
