### PR TITLE
[#275] fix: 메일 파일 조회/참조 userId 검증 제거

### DIFF
--- a/src/main/kotlin/com/yourssu/scouter/common/application/domain/mail/MailFileController.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/application/domain/mail/MailFileController.kt
@@ -161,9 +161,7 @@ data class MailFileSummary(
     val createdAt: java.time.Instant?,
 ) {
     companion object {
-        fun from(
-            file: MailUploadedFile,
-        ): MailFileSummary {
+        fun from(file: MailUploadedFile): MailFileSummary {
             return MailFileSummary(
                 fileId = file.id!!,
                 usage = file.usage,

--- a/src/main/kotlin/com/yourssu/scouter/common/business/domain/mail/MailFileService.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/business/domain/mail/MailFileService.kt
@@ -54,19 +54,18 @@ class MailFileService(
         userId: Long,
         fileId: Long,
     ) {
-        val file = mailFileValidator.requireFile(userId, fileId)
+        val file = mailFileValidator.requireOwnedFile(userId, fileId)
         mailFileValidator.validateNotUsed(file)
         mailUploadedFileRepository.save(file.copy(status = MailUploadedFileStatus.DELETED))
     }
 
-    fun getPublicUrl(cid: String, fileUsage: MailFileUsage) =
-        mailFileStorage.getPublicUrl(fileUsage.name.lowercase() + '/' + cid)
+    fun getPublicUrl(
+        cid: String,
+        fileUsage: MailFileUsage,
+    ) = mailFileStorage.getPublicUrl(fileUsage.name.lowercase() + '/' + cid)
 
     @Transactional
-    fun resolveAttachmentReferences(
-        userId: Long,
-        references: List<MailAttachmentReference>,
-    ): List<MailAttachmentReference> {
-        return mailFileReferenceResolver.resolveAttachmentReferences(userId, references)
+    fun resolveAttachmentReferences(references: List<MailAttachmentReference>): List<MailAttachmentReference> {
+        return mailFileReferenceResolver.resolveAttachmentReferences(references)
     }
 }

--- a/src/main/kotlin/com/yourssu/scouter/common/business/domain/mail/MailService.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/business/domain/mail/MailService.kt
@@ -49,7 +49,7 @@ class MailService(
         val sender = userReader.readById(command.senderUserId)
         val resolvedCommand =
             command.copy(
-                attachmentReferences = mailFileService.resolveAttachmentReferences(command.senderUserId, command.attachmentReferences),
+                attachmentReferences = mailFileService.resolveAttachmentReferences(command.attachmentReferences),
             )
         val mail: Mail = resolvedCommand.toMail(sender.getEmailAddress())
 
@@ -262,7 +262,7 @@ class MailService(
 
         val resolvedCommand =
             command.copy(
-                attachmentReferences = mailFileService.resolveAttachmentReferences(userId, command.attachmentReferences),
+                attachmentReferences = mailFileService.resolveAttachmentReferences(command.attachmentReferences),
             )
 
         val updatedMail =

--- a/src/main/kotlin/com/yourssu/scouter/common/business/domain/mail/template/MailTemplateService.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/business/domain/mail/template/MailTemplateService.kt
@@ -48,7 +48,6 @@ class MailTemplateService(
             variables = template.variables,
             attachmentReferences =
                 mailFileService.resolveAttachmentReferences(
-                    template.createdBy,
                     template.attachmentReferences,
                 ),
             createdBy = template.createdBy,

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/domain/mail/MailFileReferenceResolver.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/domain/mail/MailFileReferenceResolver.kt
@@ -9,22 +9,20 @@ class MailFileReferenceResolver(
     private val mailUploadedFileRepository: MailUploadedFileRepository,
 ) {
     fun resolveAttachmentReferences(
-        userId: Long,
         references: List<MailAttachmentReference>,
     ): List<MailAttachmentReference> {
-        val resolved = references.map { resolveAttachmentReference(userId, it) }
-        markUsed(userId, references.mapNotNull { it.fileId })
+        val resolved = references.map { resolveAttachmentReference(it) }
+        markUsed(references.mapNotNull { it.fileId })
         return resolved
     }
 
     private fun resolveAttachmentReference(
-        userId: Long,
         reference: MailAttachmentReference,
     ): MailAttachmentReference {
         val fileId =
             reference.fileId
                 ?: throw MailFileInvalidUsageException("attachmentReferences.fileId는 필수입니다.")
-        val file = mailFileValidator.requireFile(userId, fileId)
+        val file = mailFileValidator.requireFile(fileId)
         mailFileValidator.validateUsage(file, MailFileUsage.ATTACHMENT)
         return reference.copy(
             fileName = file.fileName,
@@ -34,12 +32,11 @@ class MailFileReferenceResolver(
     }
 
     private fun markUsed(
-        userId: Long,
         fileIds: List<Long>,
     ) {
         if (fileIds.isEmpty()) return
         fileIds.distinct()
-            .map { mailFileValidator.requireFile(userId, it) }
+            .map { mailFileValidator.requireFile(it) }
             .filter { !it.used }
             .forEach { mailUploadedFileRepository.save(it.copy(used = true)) }
     }

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/domain/mail/MailFileValidator.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/domain/mail/MailFileValidator.kt
@@ -30,18 +30,23 @@ class MailFileValidator(
         }
     }
 
-    fun requireFile(
-        userId: Long,
-        fileId: Long,
-    ): MailUploadedFile {
+    fun requireFile(fileId: Long): MailUploadedFile {
         val file =
             mailUploadedFileRepository.findById(fileId)
                 ?: throw MailFileNotFoundException("파일을 찾을 수 없습니다. fileId=$fileId")
-        if (file.userId != userId) {
-            throw MailFileAccessDeniedException("파일 접근 권한이 없습니다. fileId=$fileId")
-        }
         if (file.status != MailUploadedFileStatus.ACTIVE) {
             throw MailFileNotFoundException("삭제된 파일입니다. fileId=$fileId")
+        }
+        return file
+    }
+
+    fun requireOwnedFile(
+        userId: Long,
+        fileId: Long,
+    ): MailUploadedFile {
+        val file = requireFile(fileId)
+        if (file.userId != userId) {
+            throw MailFileAccessDeniedException("파일 접근 권한이 없습니다. fileId=$fileId")
         }
         return file
     }

--- a/src/test/kotlin/com/yourssu/scouter/common/business/domain/mail/MailFileServiceTest.kt
+++ b/src/test/kotlin/com/yourssu/scouter/common/business/domain/mail/MailFileServiceTest.kt
@@ -61,7 +61,7 @@ class MailFileServiceTest {
                 status = MailUploadedFileStatus.ACTIVE,
                 used = true,
             )
-        whenever(validator.requireFile(7L, 5L)).thenReturn(usedFile)
+        whenever(validator.requireOwnedFile(7L, 5L)).thenReturn(usedFile)
         whenever(validator.validateNotUsed(usedFile)).thenThrow(
             MailFileAlreadyUsedException("이미 사용된 파일은 삭제할 수 없습니다."),
         )
@@ -82,11 +82,11 @@ class MailFileServiceTest {
                     storageKey = "mail-files/attachment/7/guide.pdf",
                 ),
             )
-        whenever(referenceResolver.resolveAttachmentReferences(7L, references)).thenThrow(
+        whenever(referenceResolver.resolveAttachmentReferences(references)).thenThrow(
             MailFileInvalidUsageException("attachmentReferences.fileId는 필수입니다."),
         )
 
-        assertThatThrownBy { service.resolveAttachmentReferences(userId = 7L, references = references) }
+        assertThatThrownBy { service.resolveAttachmentReferences(references = references) }
             .isInstanceOf(MailFileInvalidUsageException::class.java)
             .hasMessageContaining("fileId는 필수")
     }

--- a/src/test/kotlin/com/yourssu/scouter/common/business/domain/mail/MailServiceTest.kt
+++ b/src/test/kotlin/com/yourssu/scouter/common/business/domain/mail/MailServiceTest.kt
@@ -1,13 +1,13 @@
 package com.yourssu.scouter.common.business.domain.mail
 
-import com.yourssu.scouter.common.implement.domain.authentication.OAuth2Type
 import com.yourssu.scouter.common.business.domain.authentication.OAuth2Service
+import com.yourssu.scouter.common.implement.domain.authentication.OAuth2Type
 import com.yourssu.scouter.common.implement.domain.mail.Mail
-import com.yourssu.scouter.common.implement.domain.mail.MailReservation
-import com.yourssu.scouter.common.implement.domain.mail.MailReservationStatus
 import com.yourssu.scouter.common.implement.domain.mail.MailRepository
+import com.yourssu.scouter.common.implement.domain.mail.MailReservation
 import com.yourssu.scouter.common.implement.domain.mail.MailReservationReader
 import com.yourssu.scouter.common.implement.domain.mail.MailReservationRepository
+import com.yourssu.scouter.common.implement.domain.mail.MailReservationStatus
 import com.yourssu.scouter.common.implement.domain.mail.MailReservationWriter
 import com.yourssu.scouter.common.implement.domain.mail.MailWriter
 import com.yourssu.scouter.common.implement.domain.user.TokenInfo
@@ -17,14 +17,13 @@ import com.yourssu.scouter.common.implement.domain.user.UserReader
 import com.yourssu.scouter.common.implement.support.exception.MailFailedException
 import com.yourssu.scouter.common.implement.support.exception.MailReservationAccessDeniedException
 import com.yourssu.scouter.common.implement.support.exception.MailReservationAlreadyProcessedException
-import com.yourssu.scouter.common.implement.support.exception.MailReservationNotYetDueException
 import com.yourssu.scouter.common.implement.support.exception.MailReservationNotFoundException
+import com.yourssu.scouter.common.implement.support.exception.MailReservationNotYetDueException
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
-import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
@@ -32,7 +31,6 @@ import java.time.Instant
 
 @Suppress("NonAsciiCharacters")
 class MailServiceTest {
-
     private val mailWriter = mock<MailWriter>()
     private val mailFileService = mock<MailFileService>()
     private val userReader = mock<UserReader>()
@@ -206,10 +204,9 @@ class MailServiceTest {
 
         whenever(
             mailFileService.resolveAttachmentReferences(
-                eq(userId),
                 any(),
             ),
-        ).thenAnswer { invocation -> invocation.getArgument(1) }
+        ).thenAnswer { invocation -> invocation.getArgument(0) }
 
         val command =
             MailReserveCommand(
@@ -589,4 +586,3 @@ class MailServiceTest {
             .hasMessageContaining("메일 발송에 실패했습니다")
     }
 }
-


### PR DESCRIPTION
## Summary
- 메일 파일 조회/첨부 참조 해석 경로에서 userId 기반 권한 차단을 제거했습니다.
- 파일 삭제 경로는 소유자 검증(requireOwnedFile)을 유지해 임의 삭제 위험을 방지했습니다.
- 관련 서비스/컨트롤러/테스트를 시그니처에 맞게 정리하고 테스트 및 빌드 통과를 확인했습니다.

## Linked Issue
- Closes #275

## Verification
- ./gradlew test --tests "*MailFileServiceTest" --tests "*MailServiceTest"
- ./gradlew build