### PR TITLE
[#277] fix: S3 메일 파일 key 정규화로 NoSuchKey 방지

### DIFF
--- a/src/main/kotlin/com/yourssu/scouter/common/implement/support/storage/S3MailFileStorage.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/support/storage/S3MailFileStorage.kt
@@ -34,8 +34,8 @@ class S3MailFileStorage(
         bytes: ByteArray,
         contentType: String,
     ): String {
+        val resolvedKey = resolveKey(key)
         return try {
-            val resolvedKey = resolveKey(key)
             val request =
                 PutObjectRequest.builder()
                     .bucket(properties.bucket)
@@ -46,13 +46,16 @@ class S3MailFileStorage(
 
             resolvedKey
         } catch (e: Exception) {
-            throw IllegalStateException("S3 파일 업로드에 실패했습니다: $key", e)
+            throw IllegalStateException(
+                "S3 파일 업로드에 실패했습니다. bucket=${properties.bucket}, key=$key, resolvedKey=$resolvedKey",
+                e,
+            )
         }
     }
 
     override fun download(key: String): ByteArray {
+        val resolvedKey = resolveKey(key)
         return try {
-            val resolvedKey = resolveKey(key)
             val request =
                 GetObjectRequest.builder()
                     .bucket(properties.bucket)
@@ -61,7 +64,10 @@ class S3MailFileStorage(
 
             client.getObjectAsBytes(request).asByteArray()
         } catch (e: Exception) {
-            throw IllegalStateException("S3 파일 다운로드에 실패했습니다: $key", e)
+            throw IllegalStateException(
+                "S3 파일 다운로드에 실패했습니다. bucket=${properties.bucket}, key=$key, resolvedKey=$resolvedKey",
+                e,
+            )
         }
     }
 
@@ -70,8 +76,8 @@ class S3MailFileStorage(
         contentType: String,
         expireDuration: Duration,
     ): String {
+        val resolvedKey = resolveKey(key)
         return try {
-            val resolvedKey = resolveKey(key)
             val putObjectRequest =
                 PutObjectRequest.builder()
                     .bucket(properties.bucket)
@@ -86,7 +92,10 @@ class S3MailFileStorage(
 
             presigner.presignPutObject(presignRequest).url().toString()
         } catch (e: Exception) {
-            throw IllegalStateException("S3 업로드용 presigned URL 생성에 실패했습니다: $key", e)
+            throw IllegalStateException(
+                "S3 업로드용 presigned URL 생성에 실패했습니다. bucket=${properties.bucket}, key=$key, resolvedKey=$resolvedKey",
+                e,
+            )
         }
     }
 
@@ -96,11 +105,17 @@ class S3MailFileStorage(
     }
 
     private fun resolveKey(key: String): String {
+        val normalizedKey = key.trim().removePrefix("/")
         if (properties.keyPrefix.isBlank()) {
-            return key
+            return normalizedKey
         }
 
-        return "${properties.keyPrefix.trimEnd('/')}/$key"
+        val normalizedPrefix = properties.keyPrefix.trim().trim('/')
+        if (normalizedKey == normalizedPrefix || normalizedKey.startsWith("$normalizedPrefix/")) {
+            return normalizedKey
+        }
+
+        return "$normalizedPrefix/$normalizedKey"
     }
 
     @PreDestroy

--- a/src/test/kotlin/com/yourssu/scouter/common/implement/support/storage/S3MailFileStorageKeyResolutionTest.kt
+++ b/src/test/kotlin/com/yourssu/scouter/common/implement/support/storage/S3MailFileStorageKeyResolutionTest.kt
@@ -1,0 +1,50 @@
+package com.yourssu.scouter.common.implement.support.storage
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+@Suppress("NonAsciiCharacters")
+class S3MailFileStorageKeyResolutionTest {
+    private fun createStorage(prefix: String): S3MailFileStorage {
+        return S3MailFileStorage(
+            MailS3StorageProperties(
+                bucket = "test-bucket",
+                region = "ap-northeast-2",
+                keyPrefix = prefix,
+            ),
+        )
+    }
+
+    @Test
+    fun `getPublicUrl은 상대 key에 prefix를 1회만 붙인다`() {
+        val storage = createStorage("dev/mail-files")
+
+        val url = storage.getPublicUrl("attachment/2/sample.png")
+
+        assertThat(url)
+            .isEqualTo("https://test-bucket.s3.ap-northeast-2.amazonaws.com/dev/mail-files/attachment/2/sample.png")
+        storage.close()
+    }
+
+    @Test
+    fun `getPublicUrl은 이미 prefix가 포함된 key를 중복 prefix하지 않는다`() {
+        val storage = createStorage("dev/mail-files")
+
+        val url = storage.getPublicUrl("dev/mail-files/attachment/2/sample.png")
+
+        assertThat(url)
+            .isEqualTo("https://test-bucket.s3.ap-northeast-2.amazonaws.com/dev/mail-files/attachment/2/sample.png")
+        storage.close()
+    }
+
+    @Test
+    fun `getPublicUrl은 선행 슬래시가 있어도 정상 key로 정규화한다`() {
+        val storage = createStorage("dev/mail-files")
+
+        val url = storage.getPublicUrl("/dev/mail-files/attachment/2/sample.png")
+
+        assertThat(url)
+            .isEqualTo("https://test-bucket.s3.ap-northeast-2.amazonaws.com/dev/mail-files/attachment/2/sample.png")
+        storage.close()
+    }
+}


### PR DESCRIPTION
## Summary
- S3 mail file key 해석을 idempotent하게 정규화해 prefix 중복 부착을 방지했습니다.
- 업로드/다운로드/presigned URL 예외 메시지에 resolvedKey를 포함해 운영 추적성을 높였습니다.
- key 정규화 회귀 테스트를 추가했습니다.

## Linked Issue
- Closes #277

## Verification
- ./gradlew test --tests "*S3MailFileStorageKeyResolutionTest"
- ./gradlew build