### PR TITLE
[#279]; fix(ATS): 26-1 지원자 동기화 - 나이(출생연도) 정규화 및 매핑 merge 방식 적용

### DIFF
--- a/src/main/kotlin/com/yourssu/scouter/ats/business/domain/applicant/FormResponseToApplicantProcessor.kt
+++ b/src/main/kotlin/com/yourssu/scouter/ats/business/domain/applicant/FormResponseToApplicantProcessor.kt
@@ -1,5 +1,6 @@
 package com.yourssu.scouter.ats.business.domain.applicant
 
+import com.yourssu.scouter.ats.business.support.utils.AgeNormalizer
 import com.yourssu.scouter.ats.business.support.utils.AvailableTimeParser
 import com.yourssu.scouter.ats.implement.domain.applicant.Applicant
 import com.yourssu.scouter.ats.implement.domain.applicant.ApplicantState
@@ -42,25 +43,20 @@ class FormResponseToApplicantProcessor(
         part: Part,
         question: MappingQuestionDto,
     ): ApplicantSyncInfo {
-        val applicant =
-            Applicant(
-                name = userResponse.getAnswer(question.nameQuestion) ?: "",
-                email = userResponse.getAnswer(question.emailQuestion) ?: userResponse.respondentEmail ?: "",
-                phoneNumber = userResponse.getAnswer(question.phoneNumberQuestion) ?: "",
-                age = userResponse.getAnswer(question.ageQuestion) ?: "",
-                department = userResponse.getAnswer(question.departmentQuestion) ?: "",
-                studentId = userResponse.getAnswer(question.studentIdQuestion) ?: "",
-                part = part,
-                state = ApplicantState.UNDER_REVIEW,
-                applicationDateTime = userResponse.createTime,
-                applicationSemester = applicationSemester,
-                academicSemester = userResponse.getAnswer(question.academicSemesterQuestion) ?: "",
-                availableTimes =
-                    availableTimeParser.parse(
-                        responseItems = userResponse.responseItems,
-                        availableTimeQuestion = question.availableTimeQuestion,
-                    ),
-            )
+        val applicant = Applicant(
+            name = userResponse.getAnswer(question.nameQuestion) ?: "",
+            email = userResponse.getAnswer(question.emailQuestion) ?: userResponse.respondentEmail ?: "",
+            phoneNumber = userResponse.getAnswer(question.phoneNumberQuestion) ?: "",
+            age = AgeNormalizer.normalize(userResponse.getAnswer(question.ageQuestion)),
+            department = userResponse.getAnswer(question.departmentQuestion) ?: "",
+            studentId = userResponse.getAnswer(question.studentIdQuestion) ?: "",
+            part = part,
+            state = ApplicantState.UNDER_REVIEW,
+            applicationDateTime = userResponse.createTime,
+            applicationSemester = applicationSemester,
+            academicSemester = userResponse.getAnswer(question.academicSemesterQuestion) ?: "",
+            availableTimes = availableTimeParser.parse(userResponse.getAll(question.availableTimeQuestion))
+        )
 
         return ApplicantSyncInfo(applicant, formId, userResponse.responseId)
     }
@@ -80,25 +76,20 @@ class FormResponseToApplicantProcessor(
         userResponse: UserResponse,
         applicantSyncMapping: ApplicantSyncMapping,
     ): ApplicantSyncInfo {
-        val applicant =
-            Applicant(
-                name = userResponse.getAnswer(applicantSyncMapping.nameQuestion) ?: "",
-                email = userResponse.getAnswer(applicantSyncMapping.emailQuestion) ?: userResponse.respondentEmail ?: "",
-                phoneNumber = userResponse.getAnswer(applicantSyncMapping.phoneNumberQuestion) ?: "",
-                age = userResponse.getAnswer(applicantSyncMapping.ageQuestion) ?: "",
-                department = userResponse.getAnswer(applicantSyncMapping.departmentQuestion) ?: "",
-                studentId = userResponse.getAnswer(applicantSyncMapping.studentIdQuestion) ?: "",
-                part = applicantSyncMapping.part,
-                state = ApplicantState.UNDER_REVIEW,
-                applicationDateTime = userResponse.createTime,
-                applicationSemester = applicantSyncMapping.applicationSemester,
-                academicSemester = userResponse.getAnswer(applicantSyncMapping.academicSemesterQuestion) ?: "",
-                availableTimes =
-                    availableTimeParser.parse(
-                        responseItems = userResponse.responseItems,
-                        availableTimeQuestion = applicantSyncMapping.availableTimeQuestion,
-                    ),
-            )
+        val applicant = Applicant(
+            name = userResponse.getAnswer(applicantSyncMapping.nameQuestion) ?: "",
+            email = userResponse.getAnswer(applicantSyncMapping.emailQuestion) ?: userResponse.respondentEmail ?: "",
+            phoneNumber = userResponse.getAnswer(applicantSyncMapping.phoneNumberQuestion) ?: "",
+            age = AgeNormalizer.normalize(userResponse.getAnswer(applicantSyncMapping.ageQuestion)),
+            department = userResponse.getAnswer(applicantSyncMapping.departmentQuestion) ?: "",
+            studentId = userResponse.getAnswer(applicantSyncMapping.studentIdQuestion) ?: "",
+            part = applicantSyncMapping.part,
+            state = ApplicantState.UNDER_REVIEW,
+            applicationDateTime = userResponse.createTime,
+            applicationSemester = applicantSyncMapping.applicationSemester,
+            academicSemester = userResponse.getAnswer(applicantSyncMapping.academicSemesterQuestion) ?: "",
+            availableTimes = availableTimeParser.parse(userResponse.getAll(applicantSyncMapping.availableTimeQuestion)),
+        )
 
         return ApplicantSyncInfo(applicant, applicantSyncMapping.formId, userResponse.responseId)
     }

--- a/src/main/kotlin/com/yourssu/scouter/ats/business/support/utils/AgeNormalizer.kt
+++ b/src/main/kotlin/com/yourssu/scouter/ats/business/support/utils/AgeNormalizer.kt
@@ -1,0 +1,29 @@
+package com.yourssu.scouter.ats.business.support.utils
+
+/**
+ * 출생연도/나이 응답을 "XX년생" 형태로 통일.
+ * 예: "00년생", "02", "2003년생", "2000" -> "00년생", "02년생", "03년생", "00년생"
+ * 전각 숫자(０１２３)도 반각으로 변환 후 파싱.
+ */
+object AgeNormalizer {
+
+    private val digitsRegex = Regex("\\d+")
+
+    fun normalize(raw: String?): String {
+        if (raw.isNullOrBlank()) return ""
+        val normalized = raw.trim().replaceFullWidthDigits()
+        val digits = digitsRegex.find(normalized)?.value ?: return ""
+        val twoDigits = when {
+            digits.length >= 4 -> digits.takeLast(2)
+            digits.length == 2 -> digits
+            digits.length == 1 -> "0$digits"
+            else -> digits.takeLast(2)
+        }
+        return "${twoDigits}년생"
+    }
+
+    private fun String.replaceFullWidthDigits(): String =
+        map { c ->
+            if (c in '\uFF10'..'\uFF19') (c.code - 0xFF10 + 0x30).toChar() else c
+        }.joinToString("")
+}

--- a/src/main/kotlin/com/yourssu/scouter/ats/implement/domain/applicant/ApplicantSyncMappingRepository.kt
+++ b/src/main/kotlin/com/yourssu/scouter/ats/implement/domain/applicant/ApplicantSyncMappingRepository.kt
@@ -5,4 +5,5 @@ interface ApplicantSyncMappingRepository {
     fun save(applicantSyncMapping: ApplicantSyncMapping)
     fun findAllByApplicationSemesterId(semesterId: Long): List<ApplicantSyncMapping>
     fun count(): Long
+    fun existsByApplicationSemesterIdAndPartId(applicationSemesterId: Long, partId: Long): Boolean
 }

--- a/src/main/kotlin/com/yourssu/scouter/ats/implement/domain/applicant/ApplicantSyncMappingRepositoryImpl.kt
+++ b/src/main/kotlin/com/yourssu/scouter/ats/implement/domain/applicant/ApplicantSyncMappingRepositoryImpl.kt
@@ -20,4 +20,8 @@ class ApplicantSyncMappingRepositoryImpl(
     override fun count(): Long {
         return jpaApplicantSyncMappingRepository.count()
     }
+
+    override fun existsByApplicationSemesterIdAndPartId(applicationSemesterId: Long, partId: Long): Boolean {
+        return jpaApplicantSyncMappingRepository.existsByApplicationSemester_IdAndPart_Id(applicationSemesterId, partId)
+    }
 }

--- a/src/main/kotlin/com/yourssu/scouter/ats/storage/domain/applicant/JpaApplicantSyncMappingRepository.kt
+++ b/src/main/kotlin/com/yourssu/scouter/ats/storage/domain/applicant/JpaApplicantSyncMappingRepository.kt
@@ -5,4 +5,6 @@ import org.springframework.data.jpa.repository.JpaRepository
 interface JpaApplicantSyncMappingRepository : JpaRepository<ApplicantSyncMappingEntity, Long> {
 
     fun findAllByApplicationSemesterId(applicationSemesterId: Long): List<ApplicantSyncMappingEntity>
+
+    fun existsByApplicationSemester_IdAndPart_Id(applicationSemesterId: Long, partId: Long): Boolean
 }

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/support/initialization/ApplicantSyncMappingInitializer.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/support/initialization/ApplicantSyncMappingInitializer.kt
@@ -22,9 +22,6 @@ class ApplicantSyncMappingInitializer(
 ) : CommandLineRunner {
 
     override fun run(vararg args: String?) {
-        if (alreadyInitialized()) {
-            return
-        }
         val semesters: List<Semester> = semesterRepository.findAll()
         val parts: List<Part> = partRepository.findAll()
 
@@ -34,6 +31,11 @@ class ApplicantSyncMappingInitializer(
                 ?: throw IllegalArgumentException("Semester not found: ${targetSemester.year} ${targetSemester.term}")
             val part: Part = parts.find { it.name == mappingData.part }
                 ?: throw IllegalArgumentException("Part not found: ${mappingData.part}")
+
+            val semesterId = semester.id ?: continue
+            if (applicantSyncMappingRepository.existsByApplicationSemesterIdAndPartId(semesterId, part.id!!)) {
+                continue
+            }
 
             val applicantSyncMapping = ApplicantSyncMapping(
                 applicationSemester = semester,
@@ -52,6 +54,4 @@ class ApplicantSyncMappingInitializer(
             applicantSyncMappingRepository.save(applicantSyncMapping)
         }
     }
-
-    private fun alreadyInitialized() = applicantSyncMappingRepository.count() != 0L
 }

--- a/src/test/kotlin/com/yourssu/scouter/ats/business/support/utils/AgeNormalizerTest.kt
+++ b/src/test/kotlin/com/yourssu/scouter/ats/business/support/utils/AgeNormalizerTest.kt
@@ -1,0 +1,60 @@
+package com.yourssu.scouter.ats.business.support.utils
+
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+
+class AgeNormalizerTest {
+
+    @Test
+    @DisplayName("00년생 -> 00년생")
+    fun alreadyTwoDigitsWithSuffix() {
+        assertEquals("00년생", AgeNormalizer.normalize("00년생"))
+    }
+
+    @Test
+    @DisplayName("02 -> 02년생")
+    fun twoDigitsOnly() {
+        assertEquals("02년생", AgeNormalizer.normalize("02"))
+    }
+
+    @Test
+    @DisplayName("2003년생 -> 03년생")
+    fun fourDigitsWithSuffix() {
+        assertEquals("03년생", AgeNormalizer.normalize("2003년생"))
+    }
+
+    @Test
+    @DisplayName("2000 -> 00년생")
+    fun fourDigitsOnly() {
+        assertEquals("00년생", AgeNormalizer.normalize("2000"))
+    }
+
+    @Test
+    @DisplayName("3 -> 03년생")
+    fun singleDigitPadded() {
+        assertEquals("03년생", AgeNormalizer.normalize("3"))
+    }
+
+    @Test
+    @DisplayName("null/blank -> 빈 문자열")
+    fun nullOrBlank() {
+        assertEquals("", AgeNormalizer.normalize(null))
+        assertEquals("", AgeNormalizer.normalize(""))
+        assertEquals("", AgeNormalizer.normalize("   "))
+    }
+
+    @Test
+    @DisplayName("숫자 없음 -> 빈 문자열")
+    fun noDigits() {
+        assertEquals("", AgeNormalizer.normalize("년생"))
+        assertEquals("", AgeNormalizer.normalize("abc"))
+    }
+
+    @Test
+    @DisplayName("전각 숫자 ０３ -> 03년생")
+    fun fullWidthDigits() {
+        assertEquals("03년생", AgeNormalizer.normalize("０３"))
+        assertEquals("03년생", AgeNormalizer.normalize("２００３년생"))
+    }
+}


### PR DESCRIPTION
## 📄 작업 내용 요약
- 지원자 구글폼 동기화 시 **나이(출생연도)** 를 "XX년생" 형식으로 통일
- **applicant_sync_mapping** 초기화를 merge 방식으로 변경해, yml에 새 학기만 추가하고 재기동하면 DB에 자동 반영

## 변경 내용
- **AgeNormalizer** 추가: 출생연도/나이 문자열 → "XX년생" 정규화 (전각 숫자 지원)
- **FormResponseToApplicantProcessor**: age 세팅 시 `AgeNormalizer.normalize()` 적용
- **ApplicantSyncMappingInitializer**: `existsByApplicationSemesterIdAndPartId`로 (학기, 파트) 존재 시 스킵, 없을 때만 INSERT

## 📎 Issue 번호
closed #279 
