### PR TITLE
[#281]; feat: 메일예약조회관련 권한 변경

### DIFF
--- a/scripts/sql/mail-reservation-queries.sql
+++ b/scripts/sql/mail-reservation-queries.sql
@@ -1,45 +1,66 @@
--- 메일 예약 DB 확인용 SQL (mail_reservation / mail 테이블)
-
--- 1. 예약 전체 목록 (예약 시각 기준 최신순)
 SELECT
     r.id AS reservation_id,
-    r.mail_id,
-    r.reservation_time,
+    r.status AS reservation_status,
+    r.reservation_time AS reservation_time,
+    m.id AS mail_id,
     m.sender_email_address,
     m.mail_subject,
-    m.body_format
-FROM mail_reservation r
-LEFT JOIN mail m ON m.id = r.mail_id
-ORDER BY r.reservation_time DESC;
-
--- 2. 예약 건수만 확인
-SELECT COUNT(*) AS reservation_count FROM mail_reservation;
-
--- 3. 아직 발송 시점이 안 된 예약 (미래 시각) — 스케줄러가 아직 안 건드림
-SELECT
+    m.mail_body,
+    m.body_format,
+    GROUP_CONCAT(
+        CASE
+            WHEN ra.type = 'TO' THEN ra.email_address
+        END
+        ORDER BY ra.id SEPARATOR ','
+    ) AS to_addresses,
+    GROUP_CONCAT(
+        CASE
+            WHEN ra.type = 'CC' THEN ra.email_address
+        END
+        ORDER BY ra.id SEPARATOR ','
+    ) AS cc_addresses,
+    GROUP_CONCAT(
+        CASE
+            WHEN ra.type = 'BCC' THEN ra.email_address
+        END
+        ORDER BY ra.id SEPARATOR ','
+    ) AS bcc_addresses
+FROM
+    mail_reservation r
+    JOIN mail m ON r.mail_id = m.id
+    LEFT JOIN mail_recipient_address ra ON ra.mail_id = m.id
+WHERE
+    m.sender_email_address = 'glen.urssu@gmail.com'
+    -- 예약(미발송)만 보고 싶으면 아래 주석 해제
+    AND r.status IN ('SCHEDULED', 'PENDING_SEND')
+GROUP BY
     r.id,
-    r.mail_id,
+    r.status,
     r.reservation_time,
-    m.mail_subject
-FROM mail_reservation r
-LEFT JOIN mail m ON m.id = r.mail_id
-WHERE r.reservation_time > NOW()
-ORDER BY r.reservation_time;
-
--- 4. 발송 대상이어야 하는데 남아 있는 예약 (과거 시각) — 스케줄러가 처리 못 한 것
-SELECT
-    r.id,
-    r.mail_id,
-    r.reservation_time,
+    m.id,
+    m.sender_email_address,
     m.mail_subject,
-    m.sender_email_address
-FROM mail_reservation r
-LEFT JOIN mail m ON m.id = r.mail_id
-WHERE r.reservation_time <= NOW()
-ORDER BY r.reservation_time;
+    m.mail_body,
+    m.body_format
+ORDER BY r.reservation_time;\G
 
--- 5. 예약은 있는데 메일이 삭제된 경우 (스케줄러에서 warn 나는 경우)
-SELECT r.id, r.mail_id, r.reservation_time
-FROM mail_reservation r
-LEFT JOIN mail m ON m.id = r.mail_id
-WHERE m.id IS NULL;
+
+SELECT
+    r.id AS reservation_id,
+    r.status AS reservation_status,
+    r.reservation_time AS reservation_time,
+    m.id AS mail_id,
+    m.sender_email_address,
+    m.mail_subject,
+    m.mail_body,
+    m.body_format,
+    ra.type AS recipient_type, -- TO / CC / BCC
+    ra.email_address AS recipient_address
+FROM
+    mail_reservation r
+    JOIN mail m ON r.mail_id = m.id
+    LEFT JOIN mail_recipient_address ra ON ra.mail_id = m.id
+WHERE
+    m.sender_email_address = 'glen.urssu@gmail.com'
+    AND r.status IN ('SCHEDULED', 'PENDING_SEND')  -- 필요 시 예약건만
+ORDER BY r.reservation_time, r.id, ra.type, ra.id;

--- a/src/main/kotlin/com/yourssu/scouter/ats/business/domain/applicant/FormResponseToApplicantProcessor.kt
+++ b/src/main/kotlin/com/yourssu/scouter/ats/business/domain/applicant/FormResponseToApplicantProcessor.kt
@@ -55,7 +55,10 @@ class FormResponseToApplicantProcessor(
             applicationDateTime = userResponse.createTime,
             applicationSemester = applicationSemester,
             academicSemester = userResponse.getAnswer(question.academicSemesterQuestion) ?: "",
-            availableTimes = availableTimeParser.parse(userResponse.getAll(question.availableTimeQuestion))
+            availableTimes = availableTimeParser.parse(
+                responseItems = userResponse.responseItems,
+                availableTimeQuestion = question.availableTimeQuestion,
+            ),
         )
 
         return ApplicantSyncInfo(applicant, formId, userResponse.responseId)
@@ -88,7 +91,10 @@ class FormResponseToApplicantProcessor(
             applicationDateTime = userResponse.createTime,
             applicationSemester = applicantSyncMapping.applicationSemester,
             academicSemester = userResponse.getAnswer(applicantSyncMapping.academicSemesterQuestion) ?: "",
-            availableTimes = availableTimeParser.parse(userResponse.getAll(applicantSyncMapping.availableTimeQuestion)),
+            availableTimes = availableTimeParser.parse(
+                responseItems = userResponse.responseItems,
+                availableTimeQuestion = applicantSyncMapping.availableTimeQuestion,
+            ),
         )
 
         return ApplicantSyncInfo(applicant, applicantSyncMapping.formId, userResponse.responseId)

--- a/src/main/kotlin/com/yourssu/scouter/common/application/domain/mail/MailReservationDetailResponse.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/application/domain/mail/MailReservationDetailResponse.kt
@@ -11,6 +11,8 @@ data class MailReservationDetailResponse(
     val reservationTime: Instant,
     @Schema(description = "예약 상태", example = "SCHEDULED", allowableValues = ["SCHEDULED", "PENDING_SEND", "SENT"])
     val status: MailReservationStatus,
+    @Schema(description = "발신자 이메일", example = "sender@example.com")
+    val senderEmailAddress: String,
     val mailSubject: String,
     val mailBody: String,
     val bodyFormat: String,
@@ -26,6 +28,7 @@ data class MailReservationDetailResponse(
                 mailId = detail.mailId,
                 reservationTime = detail.reservationTime,
                 status = detail.status,
+                senderEmailAddress = detail.senderEmailAddress,
                 mailSubject = detail.mailSubject,
                 mailBody = detail.mailBody,
                 bodyFormat = detail.bodyFormat.name,

--- a/src/main/kotlin/com/yourssu/scouter/common/application/domain/mail/MailReservationListResponse.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/application/domain/mail/MailReservationListResponse.kt
@@ -11,6 +11,8 @@ data class MailReservationListItem(
     val reservationTime: Instant,
     @Schema(description = "예약 상태", example = "SCHEDULED", allowableValues = ["SCHEDULED", "PENDING_SEND", "SENT"])
     val status: MailReservationStatus,
+    @Schema(description = "발신자 이메일", example = "sender@example.com")
+    val senderEmailAddress: String,
     val mailSubject: String,
     @Schema(description = "대표 수신자 이메일 (수신자가 없으면 null)", example = "receiver@example.com", nullable = true)
     val primaryReceiverEmailAddress: String?,
@@ -30,6 +32,7 @@ data class MailReservationListResponse(
                             mailId = detail.mailId,
                             reservationTime = detail.reservationTime,
                             status = detail.status,
+                            senderEmailAddress = detail.senderEmailAddress,
                             mailSubject = detail.mailSubject,
                             primaryReceiverEmailAddress = detail.receiverEmailAddresses.firstOrNull(),
                             hasAttachments = detail.hasAttachments,

--- a/src/main/kotlin/com/yourssu/scouter/common/business/domain/mail/MailService.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/business/domain/mail/MailService.kt
@@ -17,6 +17,7 @@ import com.yourssu.scouter.common.implement.domain.mail.MailWriter
 import com.yourssu.scouter.common.implement.domain.user.UserReader
 import com.yourssu.scouter.common.implement.support.exception.MailReservationAlreadyProcessedException
 import com.yourssu.scouter.common.implement.support.exception.MailReservationNotYetDueException
+import com.yourssu.scouter.hrms.business.domain.member.MemberPrivacyService
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import java.time.Instant
@@ -33,6 +34,7 @@ class MailService(
     private val mailRepository: MailRepository,
     private val oauth2Service: OAuth2Service,
     private val mailSender: MailSender,
+    private val memberPrivacyService: MemberPrivacyService,
 ) {
     companion object {
         private val log = LoggerFactory.getLogger(MailService::class.java)
@@ -65,8 +67,13 @@ class MailService(
     fun getPendingReservationStatuses(userId: Long): List<PendingMailReservationStatus> {
         val user = userReader.readById(userId)
         val now = Instant.now()
-        val senderEmail = user.getEmailAddress()
-        val reservations = mailReservationReader.readAllBeforeBySenderEmail(now, senderEmail)
+        val reservations =
+            if (memberPrivacyService.isPrivilegedUser(userId)) {
+                mailReservationReader.readAllBefore(now)
+            } else {
+                val senderEmails = memberPrivacyService.getActiveTeamMemberEmails(userId).toList()
+                mailReservationReader.readAllBeforeBySenderEmails(now, senderEmails)
+            }
         return reservations.map { reservation ->
             val mail = mailRepository.findById(reservation.mailId) ?: run {
                 log.warn("예약의 메일을 찾을 수 없음: reservationId={}, mailId={}", reservation.id, reservation.mailId)
@@ -195,9 +202,13 @@ class MailService(
     }
 
     fun getUserMailReservations(userId: Long): List<MailReservationDetail> {
-        val user = userReader.readById(userId)
-        val senderEmail = user.getEmailAddress()
-        val reservations = mailReservationReader.readAllBySenderEmail(senderEmail)
+        val reservations =
+            if (memberPrivacyService.isPrivilegedUser(userId)) {
+                mailReservationReader.readAll()
+            } else {
+                val senderEmails = memberPrivacyService.getActiveTeamMemberEmails(userId).toList()
+                mailReservationReader.readAllBySenderEmails(senderEmails)
+            }
         return reservations.map { reservation ->
             val mail =
                 mailRepository.findById(reservation.mailId)
@@ -212,7 +223,6 @@ class MailService(
         userId: Long,
         reservationId: Long,
     ): MailReservationDetail {
-        val user = userReader.readById(userId)
         val reservation =
             mailReservationReader.readById(reservationId)
                 ?: throw MailReservationNotFoundException("예약을 찾을 수 없습니다. reservationId=$reservationId")
@@ -221,8 +231,10 @@ class MailService(
             mailRepository.findById(reservation.mailId)
                 ?: throw MailReservationNotFoundException("예약 메일을 찾을 수 없습니다. reservationId=$reservationId, mailId=${reservation.mailId}")
 
-        val senderEmail = user.getEmailAddress()
-        if (mail.senderEmailAddress != senderEmail) {
+        val canAccess =
+            memberPrivacyService.isPrivilegedUser(userId) ||
+                memberPrivacyService.getActiveTeamMemberEmails(userId).contains(mail.senderEmailAddress)
+        if (!canAccess) {
             throw MailReservationAccessDeniedException("예약에 접근할 수 없습니다. reservationId=$reservationId")
         }
 

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/domain/mail/MailReservationReader.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/domain/mail/MailReservationReader.kt
@@ -10,6 +10,10 @@ class MailReservationReader(
     private val mailReservationRepository: MailReservationRepository,
 ) {
 
+    fun readAll(): List<MailReservation> {
+        return mailReservationRepository.findAll()
+    }
+
     fun readAllBefore(time: Instant): List<MailReservation> {
         return mailReservationRepository.findAllByReservationTimeLessThanEqual(time)
     }
@@ -23,8 +27,16 @@ class MailReservationReader(
         return mailReservationRepository.findAllByReservationTimeLessThanEqualAndSenderEmail(time, senderEmail)
     }
 
+    fun readAllBeforeBySenderEmails(time: Instant, senderEmails: List<String>): List<MailReservation> {
+        return mailReservationRepository.findAllByReservationTimeLessThanEqualAndSenderEmails(time, senderEmails)
+    }
+
     fun readAllBySenderEmail(senderEmail: String): List<MailReservation> {
         return mailReservationRepository.findAllBySenderEmail(senderEmail)
+    }
+
+    fun readAllBySenderEmails(senderEmails: List<String>): List<MailReservation> {
+        return mailReservationRepository.findAllBySenderEmails(senderEmails)
     }
 
     fun readAllBySenderEmailAndReservationTimeBetween(
@@ -33,6 +45,14 @@ class MailReservationReader(
         to: Instant,
     ): List<MailReservation> {
         return mailReservationRepository.findAllBySenderEmailAndReservationTimeBetween(senderEmail, from, to)
+    }
+
+    fun readAllBySenderEmailsAndReservationTimeBetween(
+        senderEmails: List<String>,
+        from: Instant,
+        to: Instant,
+    ): List<MailReservation> {
+        return mailReservationRepository.findAllBySenderEmailsAndReservationTimeBetween(senderEmails, from, to)
     }
 
     fun readById(id: Long): MailReservation? {

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/domain/mail/MailReservationRepository.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/domain/mail/MailReservationRepository.kt
@@ -6,6 +6,8 @@ interface MailReservationRepository {
 
     fun save(mailReservation: MailReservation): MailReservation
 
+    fun findAll(): List<MailReservation>
+
     fun findAllByReservationTimeLessThanEqual(reservationTime: Instant): List<MailReservation>
 
     fun findAllByReservationTimeLessThanEqualAndStatusNot(
@@ -15,10 +17,20 @@ interface MailReservationRepository {
 
     fun findAllByReservationTimeLessThanEqualAndSenderEmail(time: Instant, senderEmail: String): List<MailReservation>
 
+    fun findAllByReservationTimeLessThanEqualAndSenderEmails(time: Instant, senderEmails: List<String>): List<MailReservation>
+
     fun findAllBySenderEmail(senderEmail: String): List<MailReservation>
+
+    fun findAllBySenderEmails(senderEmails: List<String>): List<MailReservation>
 
     fun findAllBySenderEmailAndReservationTimeBetween(
         senderEmail: String,
+        from: Instant,
+        to: Instant,
+    ): List<MailReservation>
+
+    fun findAllBySenderEmailsAndReservationTimeBetween(
+        senderEmails: List<String>,
         from: Instant,
         to: Instant,
     ): List<MailReservation>

--- a/src/main/kotlin/com/yourssu/scouter/common/storage/domain/mail/JpaMailReservationRepository.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/storage/domain/mail/JpaMailReservationRepository.kt
@@ -26,10 +26,27 @@ interface JpaMailReservationRepository : JpaRepository<MailReservationEntity, Lo
 
     @Query(
         "SELECT r FROM MailReservationEntity r, MailEntity m WHERE r.mailId = m.id " +
+            "AND r.reservationTime <= :time AND m.senderEmailAddress IN :senderEmails",
+    )
+    fun findAllByReservationTimeLessThanEqualAndSenderEmails(
+        @Param("time") time: Instant,
+        @Param("senderEmails") senderEmails: List<String>,
+    ): List<MailReservationEntity>
+
+    @Query(
+        "SELECT r FROM MailReservationEntity r, MailEntity m WHERE r.mailId = m.id " +
             "AND m.senderEmailAddress = :senderEmail",
     )
     fun findAllBySenderEmail(
         @Param("senderEmail") senderEmail: String,
+    ): List<MailReservationEntity>
+
+    @Query(
+        "SELECT r FROM MailReservationEntity r, MailEntity m WHERE r.mailId = m.id " +
+            "AND m.senderEmailAddress IN :senderEmails",
+    )
+    fun findAllBySenderEmails(
+        @Param("senderEmails") senderEmails: List<String>,
     ): List<MailReservationEntity>
 
     @Query(
@@ -39,6 +56,17 @@ interface JpaMailReservationRepository : JpaRepository<MailReservationEntity, Lo
     )
     fun findAllBySenderEmailAndReservationTimeBetween(
         @Param("senderEmail") senderEmail: String,
+        @Param("from") from: Instant,
+        @Param("to") to: Instant,
+    ): List<MailReservationEntity>
+
+    @Query(
+        "SELECT r FROM MailReservationEntity r, MailEntity m WHERE r.mailId = m.id " +
+            "AND m.senderEmailAddress IN :senderEmails " +
+            "AND r.reservationTime BETWEEN :from AND :to",
+    )
+    fun findAllBySenderEmailsAndReservationTimeBetween(
+        @Param("senderEmails") senderEmails: List<String>,
         @Param("from") from: Instant,
         @Param("to") to: Instant,
     ): List<MailReservationEntity>

--- a/src/main/kotlin/com/yourssu/scouter/common/storage/domain/mail/MailReservationRepositoryImpl.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/storage/domain/mail/MailReservationRepositoryImpl.kt
@@ -15,6 +15,10 @@ class MailReservationRepositoryImpl(
         return jpaMailReservationRepository.save(MailReservationEntity.from(mailReservation)).toDomain()
     }
 
+    override fun findAll(): List<MailReservation> {
+        return jpaMailReservationRepository.findAll().map { it.toDomain() }
+    }
+
     override fun findAllByReservationTimeLessThanEqual(reservationTime: Instant): List<MailReservation> {
         return jpaMailReservationRepository.findAllByReservationTimeLessThanEqual(reservationTime).map { it.toDomain() }
     }
@@ -35,8 +39,21 @@ class MailReservationRepositoryImpl(
             .map { it.toDomain() }
     }
 
+    override fun findAllByReservationTimeLessThanEqualAndSenderEmails(
+        time: Instant,
+        senderEmails: List<String>,
+    ): List<MailReservation> {
+        return jpaMailReservationRepository.findAllByReservationTimeLessThanEqualAndSenderEmails(time, senderEmails)
+            .map { it.toDomain() }
+    }
+
     override fun findAllBySenderEmail(senderEmail: String): List<MailReservation> {
         return jpaMailReservationRepository.findAllBySenderEmail(senderEmail)
+            .map { it.toDomain() }
+    }
+
+    override fun findAllBySenderEmails(senderEmails: List<String>): List<MailReservation> {
+        return jpaMailReservationRepository.findAllBySenderEmails(senderEmails)
             .map { it.toDomain() }
     }
 
@@ -46,6 +63,15 @@ class MailReservationRepositoryImpl(
         to: Instant,
     ): List<MailReservation> {
         return jpaMailReservationRepository.findAllBySenderEmailAndReservationTimeBetween(senderEmail, from, to)
+            .map { it.toDomain() }
+    }
+
+    override fun findAllBySenderEmailsAndReservationTimeBetween(
+        senderEmails: List<String>,
+        from: Instant,
+        to: Instant,
+    ): List<MailReservation> {
+        return jpaMailReservationRepository.findAllBySenderEmailsAndReservationTimeBetween(senderEmails, from, to)
             .map { it.toDomain() }
     }
 

--- a/src/main/kotlin/com/yourssu/scouter/hrms/business/domain/member/MemberPrivacyService.kt
+++ b/src/main/kotlin/com/yourssu/scouter/hrms/business/domain/member/MemberPrivacyService.kt
@@ -35,6 +35,30 @@ class MemberPrivacyService(
         return member.parts.mapNotNull { it.id }.toSet()
     }
 
+    /**
+     * 본인과 같은 파트(팀)에 속한 Active 멤버들의 이메일 목록을 반환한다.
+     * - 사용자가 HRMS 멤버가 아니면(파트 정보를 알 수 없으면) 본인 이메일만 반환한다.
+     */
+    fun getActiveTeamMemberEmails(userId: Long): Set<String> {
+        val user = userReader.readById(userId)
+        val myEmail: String = user.getEmailAddress()
+        val myPartIds: Set<Long> = getMemberPartIds(userId)
+        if (myPartIds.isEmpty()) {
+            return setOf(myEmail)
+        }
+
+        val activeMembers = memberReader.readAllActive()
+        val teamEmails =
+            activeMembers
+                .asSequence()
+                .map { it.member }
+                .filter { member -> member.parts.any { part -> part.id != null && myPartIds.contains(part.id) } }
+                .map { it.email }
+                .toSet()
+
+        return teamEmails + myEmail
+    }
+
     fun isPrivilegedUser(userId: Long): Boolean {
         if (devPrivilegeTestHolder?.isMarkedAsNonPrivileged(userId) == true) {
             return false

--- a/src/test/kotlin/com/yourssu/scouter/common/business/domain/mail/MailServiceTest.kt
+++ b/src/test/kotlin/com/yourssu/scouter/common/business/domain/mail/MailServiceTest.kt
@@ -19,6 +19,7 @@ import com.yourssu.scouter.common.implement.support.exception.MailReservationAcc
 import com.yourssu.scouter.common.implement.support.exception.MailReservationAlreadyProcessedException
 import com.yourssu.scouter.common.implement.support.exception.MailReservationNotFoundException
 import com.yourssu.scouter.common.implement.support.exception.MailReservationNotYetDueException
+import com.yourssu.scouter.hrms.business.domain.member.MemberPrivacyService
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
@@ -40,6 +41,7 @@ class MailServiceTest {
     private val mailRepository = mock<MailRepository>()
     private val oauth2Service = mock<OAuth2Service>()
     private val mailSender = mock<MailSender>()
+    private val memberPrivacyService = mock<MemberPrivacyService>()
 
     private fun createService(): MailService {
         return MailService(
@@ -52,6 +54,7 @@ class MailServiceTest {
             mailRepository = mailRepository,
             oauth2Service = oauth2Service,
             mailSender = mailSender,
+            memberPrivacyService = memberPrivacyService,
         )
     }
 
@@ -86,6 +89,7 @@ class MailServiceTest {
         val senderEmail = "user@example.com"
         val user = createUser(userId, senderEmail)
         whenever(userReader.readById(userId)).thenReturn(user)
+        whenever(memberPrivacyService.getActiveTeamMemberEmails(userId)).thenReturn(setOf(senderEmail))
 
         val reservation =
             MailReservation(
@@ -93,7 +97,7 @@ class MailServiceTest {
                 mailId = 100L,
                 reservationTime = Instant.parse("2026-03-01T00:00:00Z"),
             )
-        whenever(mailReservationReader.readAllBySenderEmail(senderEmail)).thenReturn(listOf(reservation))
+        whenever(mailReservationReader.readAllBySenderEmails(any())).thenReturn(listOf(reservation))
 
         val mail =
             Mail(
@@ -114,6 +118,7 @@ class MailServiceTest {
         val results = service.getUserMailReservations(userId)
 
         // then
+        verify(mailReservationReader).readAllBySenderEmails(listOf(senderEmail))
         assertThat(results).hasSize(1)
         val detail = results[0]
         assertThat(detail.reservationId).isEqualTo(10L)
@@ -144,6 +149,7 @@ class MailServiceTest {
         val userId = 1L
         val user = createUser(userId, "user@example.com")
         whenever(userReader.readById(userId)).thenReturn(user)
+        whenever(memberPrivacyService.getActiveTeamMemberEmails(userId)).thenReturn(setOf("user@example.com"))
 
         val reservation =
             MailReservation(
@@ -584,5 +590,84 @@ class MailServiceTest {
         assertThatThrownBy { service.retryReservation(userId, 10L) }
             .isInstanceOf(MailFailedException::class.java)
             .hasMessageContaining("메일 발송에 실패했습니다")
+    }
+
+    @Test
+    fun `getUserMailReservation는 같은 팀(발신자 이메일이 팀 이메일 목록에 포함)이면 타인의 예약도 조회할 수 있다`() {
+        // given
+        val userId = 1L
+        val user = createUser(userId, "viewer@example.com")
+        whenever(userReader.readById(userId)).thenReturn(user)
+        whenever(memberPrivacyService.getActiveTeamMemberEmails(userId)).thenReturn(setOf("viewer@example.com", "teammate@example.com"))
+
+        val reservation =
+            MailReservation(
+                id = 10L,
+                mailId = 100L,
+                reservationTime = Instant.parse("2026-03-01T00:00:00Z"),
+            )
+        whenever(mailReservationReader.readById(10L)).thenReturn(reservation)
+
+        val mail =
+            Mail(
+                id = 100L,
+                senderEmailAddress = "teammate@example.com",
+                receiverEmailAddresses = listOf("to@example.com"),
+                ccEmailAddresses = emptyList(),
+                bccEmailAddresses = emptyList(),
+                mailSubject = "제목",
+                mailBody = "본문",
+                bodyFormat = MailBodyFormat.HTML,
+            )
+        whenever(mailRepository.findById(100L)).thenReturn(mail)
+
+        val service = createService()
+
+        // when
+        val detail = service.getUserMailReservation(userId, 10L)
+
+        // then
+        assertThat(detail.mailId).isEqualTo(100L)
+        assertThat(detail.senderEmailAddress).isEqualTo("teammate@example.com")
+    }
+
+    @Test
+    fun `특권 유저는 예약 목록 조회 시 전체를 조회한다`() {
+        // given
+        val userId = 1L
+        val user = createUser(userId, "privileged@example.com")
+        whenever(userReader.readById(userId)).thenReturn(user)
+        whenever(memberPrivacyService.isPrivilegedUser(userId)).thenReturn(true)
+
+        val reservation =
+            MailReservation(
+                id = 10L,
+                mailId = 100L,
+                reservationTime = Instant.parse("2026-03-01T00:00:00Z"),
+            )
+        whenever(mailReservationReader.readAll()).thenReturn(listOf(reservation))
+
+        val mail =
+            Mail(
+                id = 100L,
+                senderEmailAddress = "other@example.com",
+                receiverEmailAddresses = listOf("to@example.com"),
+                ccEmailAddresses = emptyList(),
+                bccEmailAddresses = emptyList(),
+                mailSubject = "제목",
+                mailBody = "본문",
+                bodyFormat = MailBodyFormat.HTML,
+            )
+        whenever(mailRepository.findById(100L)).thenReturn(mail)
+
+        val service = createService()
+
+        // when
+        val results = service.getUserMailReservations(userId)
+
+        // then
+        verify(mailReservationReader).readAll()
+        assertThat(results).hasSize(1)
+        assertThat(results.first().senderEmailAddress).isEqualTo("other@example.com")
     }
 }


### PR DESCRIPTION
## 개요
- 메일 예약 조회 API에서 **같은 팀원** 및 **특권 유저(화이트리스트+HR)** 의 조회 범위를 확장했습니다.
- 관리자/운영 관점에서 예약 메일 모니터링을 더 쉽게 하기 위한 변경입니다.

## 주요 변경 사항
- **권한/팀 로직 강화**
  - `MemberPrivacyService`에 `getActiveTeamMemberEmails(userId)` 추가
    - 로그인 사용자의 파트 ID를 기준으로, 같은 파트에 속한 **Active 멤버**들의 이메일 목록을 계산
    - 본인 이메일도 항상 포함되도록 처리

- **메일 예약 조회 범위 확장**
  - `MailService.getPendingReservationStatuses`
    - 특권 유저(`isPrivilegedUser == true`) → 전체 예약(`readAllBefore`)
    - 일반 유저 → `getActiveTeamMemberEmails` 기반 `senderEmail IN (...)` 조회
  - `MailService.getUserMailReservations`
    - 특권 유저 → 전체 예약(`readAll`)
    - 일반 유저 → 팀 이메일 목록 기반 `readAllBySenderEmails`
  - `MailService.getUserMailReservation`
    - 특권 유저이거나, 예약 메일의 `senderEmailAddress`가 팀 이메일 목록에 포함되면 접근 허용
    - 그 외에는 기존처럼 `MailReservationAccessDeniedException` 발생

- **저장소 계층 확장**
  - `JpaMailReservationRepository` / `MailReservationRepository` / `MailReservationReader`에
    - `senderEmails IN (...)` 기반 조회 메서드 추가
    - 시간 조건(`<= time`, `BETWEEN from AND to`)이 있는 버전까지 지원

- **테스트**
  - `MailServiceTest`에서 다음 케이스 추가/보완
    - 일반 유저: `getActiveTeamMemberEmails` 기반으로 자기 메일이 조회되는지 검증
    - 같은 팀 유저: 다른 팀원의 예약 단건을 조회할 수 있는지 검증
    - 특권 유저: 예약 목록 조회 시 전체 예약이 반환되는지 검증
  - 전체 테스트(`./gradlew test`) 통과 확인

## 변경 의도
- 운영자가 **팀 단위로 예약 메일을 쉽게 확인**할 수 있도록 하고,
- HR/화이트리스트 계정은 **조직 전체 예약 현황을 빠르게 파악**할 수 있게 하기 위함입니다.

## 📎 Issue 번호
closed #281
