### PR TITLE
[#305]; fix: 배포 환경에 메일 발송 환경변수 누락으로 인한 500 에러 수정

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -165,6 +165,9 @@ jobs:
           MAIL_STORAGE_S3_REGION: ${{ secrets.MAIL_STORAGE_S3_REGION }}
           MAIL_STORAGE_S3_KEY_PREFIX: ${{ secrets.MAIL_STORAGE_S3_KEY_PREFIX }}
 
+          MAIL_SENDER_EMAIL: ${{ secrets.MAIL_SENDER_EMAIL }}
+          MAIL_SENDER_APP_PASSWORD: ${{ secrets.MAIL_SENDER_APP_PASSWORD }}
+
           # 멤버 인포 엑셀 HTML 다운로드 (/members/upload 비밀번호). 비어 있으면 Bearer+특권만 허용.
           MEMBER_EXCEL_DOWNLOAD_PASSWORD: ${{ secrets.MEMBER_EXCEL_DOWNLOAD_PASSWORD }}
           INPUT_DEPLOY_TAG: ${{ github.event.inputs.tag }}
@@ -208,6 +211,8 @@ jobs:
           echo "MAIL_STORAGE_S3_BUCKET=$MAIL_STORAGE_S3_BUCKET" >> .env.dev
           echo "MAIL_STORAGE_S3_REGION=$MAIL_STORAGE_S3_REGION" >> .env.dev
           echo "MAIL_STORAGE_S3_KEY_PREFIX=$MAIL_STORAGE_S3_KEY_PREFIX" >> .env.dev
+          echo "MAIL_SENDER_EMAIL=$MAIL_SENDER_EMAIL" >> .env.dev
+          echo "MAIL_SENDER_APP_PASSWORD=$MAIL_SENDER_APP_PASSWORD" >> .env.dev
           echo "MEMBER_EXCEL_DOWNLOAD_PASSWORD=$MEMBER_EXCEL_DOWNLOAD_PASSWORD" >> .env.dev
           echo "IMAGE_TAG=$DEPLOY_TAG" >> .env.dev
 

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -152,6 +152,9 @@ jobs:
           MAIL_STORAGE_S3_REGION: ${{ secrets.MAIL_STORAGE_S3_REGION }}
           MAIL_STORAGE_S3_KEY_PREFIX: ${{ secrets.MAIL_STORAGE_S3_KEY_PREFIX }}
 
+          MAIL_SENDER_EMAIL: ${{ secrets.MAIL_SENDER_EMAIL }}
+          MAIL_SENDER_APP_PASSWORD: ${{ secrets.MAIL_SENDER_APP_PASSWORD }}
+
           MEMBER_EXCEL_DOWNLOAD_PASSWORD: ${{ secrets.MEMBER_EXCEL_DOWNLOAD_PASSWORD }}
           INPUT_DEPLOY_TAG: ${{ github.event.inputs.tag }}
 
@@ -193,6 +196,8 @@ jobs:
           echo "MAIL_STORAGE_S3_BUCKET=$MAIL_STORAGE_S3_BUCKET" >> .env.prod
           echo "MAIL_STORAGE_S3_REGION=$MAIL_STORAGE_S3_REGION" >> .env.prod
           echo "MAIL_STORAGE_S3_KEY_PREFIX=$MAIL_STORAGE_S3_KEY_PREFIX" >> .env.prod
+          echo "MAIL_SENDER_EMAIL=$MAIL_SENDER_EMAIL" >> .env.prod
+          echo "MAIL_SENDER_APP_PASSWORD=$MAIL_SENDER_APP_PASSWORD" >> .env.prod
           echo "MEMBER_EXCEL_DOWNLOAD_PASSWORD=$MEMBER_EXCEL_DOWNLOAD_PASSWORD" >> .env.prod
           echo "IMAGE_TAG=$DEPLOY_TAG" >> .env.prod
 

--- a/.gitignore
+++ b/.gitignore
@@ -144,3 +144,5 @@ build/
 /.nb-gradle/
 
 docs/
+
+.claude/

--- a/src/main/kotlin/com/yourssu/scouter/common/application/domain/mail/MailSendController.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/application/domain/mail/MailSendController.kt
@@ -9,6 +9,7 @@ import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.validation.Valid
 import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.PostMapping
@@ -52,7 +53,7 @@ class MailSendController(
     @PostMapping(consumes = [MediaType.APPLICATION_JSON_VALUE])
     fun sendMail(
         @AuthUser authUserInfo: AuthUserInfo,
-        @RequestBody request: MailSendRequest,
+        @Valid @RequestBody request: MailSendRequest,
     ): ResponseEntity<Unit> {
         val command = request.toCommand(authUserInfo.userId)
         mailService.sendMail(command)

--- a/src/main/kotlin/com/yourssu/scouter/common/application/domain/mail/MailSendRequest.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/application/domain/mail/MailSendRequest.kt
@@ -4,11 +4,15 @@ import com.yourssu.scouter.common.business.domain.mail.MailBodyFormat
 import com.yourssu.scouter.common.business.domain.mail.MailSendCommand
 import com.yourssu.scouter.common.implement.domain.mail.message.MailAttachmentReference
 import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.Valid
+import jakarta.validation.constraints.Email
+import jakarta.validation.constraints.NotBlank
 
 @Schema(description = "메일 즉시 발송 요청")
 data class MailSendRequest(
+    @field:Valid
     @field:Schema(description = "수신자 이메일 주소 목록", example = "[\"user@example.com\"]")
-    val receiverEmailAddresses: List<String>,
+    val receiverEmailAddresses: List<@Email(message = "올바른 이메일 형식이 아닙니다") @NotBlank String>,
     @field:Schema(description = "메일 제목", example = "면접 안내")
     val mailSubject: String,
     @field:Schema(description = "메일 본문", example = "<p>안녕하세요</p>")

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/domain/mail/mime/builder/MimeMessageCommonHeaderApplier.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/domain/mail/mime/builder/MimeMessageCommonHeaderApplier.kt
@@ -1,8 +1,10 @@
 package com.yourssu.scouter.common.implement.domain.mail.mime.builder
 
 import com.yourssu.scouter.common.business.domain.mail.MailData
+import com.yourssu.scouter.common.implement.support.exception.InvalidEmailAddressException
 import jakarta.mail.Address
 import jakarta.mail.Message
+import jakarta.mail.internet.AddressException
 import jakarta.mail.internet.InternetAddress
 import jakarta.mail.internet.MimeMessage
 import org.springframework.stereotype.Component
@@ -19,6 +21,12 @@ class MimeMessageCommonHeaderApplier {
     }
 
     private fun List<String>.toInternetAddresses(): Array<Address> {
-        return this.map { InternetAddress(it) }.toTypedArray()
+        return this.map { email ->
+            try {
+                InternetAddress(email).also { it.validate() }
+            } catch (e: AddressException) {
+                throw InvalidEmailAddressException(email)
+            }
+        }.toTypedArray()
     }
 }

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/support/exception/InvalidEmailAddressException.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/support/exception/InvalidEmailAddressException.kt
@@ -1,0 +1,11 @@
+package com.yourssu.scouter.common.implement.support.exception
+
+import org.springframework.http.HttpStatus
+
+class InvalidEmailAddressException(
+    email: String,
+) : CustomException(
+    message = "유효하지 않은 이메일 주소입니다: $email",
+    errorCode = "Mail-Invalid-Address",
+    status = HttpStatus.BAD_REQUEST,
+)


### PR DESCRIPTION
## 📄 작업 내용 요약

배포 워크플로우에 `MAIL_SENDER_EMAIL`, `MAIL_SENDER_APP_PASSWORD` 환경변수가 누락되어 서버에 빈 값이 주입되고, `InternetAddress("")` 파싱 실패로 500 에러가 발생하던 문제를 수정합니다.

**변경 사항**
- `deploy-dev.yml`, `deploy-prod.yml`: `MAIL_SENDER_EMAIL`, `MAIL_SENDER_APP_PASSWORD` 환경변수 추가 (근본 원인 수정)
- 유효하지 않은 이메일 주소로 인한 500 에러 방지 
  - `InvalidEmailAddressException` 신규 생성
  - `MimeMessageCommonHeaderApplier`: 잘못된 이메일 주소 파싱 시 `InvalidEmailAddressException`(400) throw (방어 코드)
  - `MailSendRequest`: `@Email`, `@NotBlank` 검증 추가 (방어 코드)
  - `MailSendController`: `@Valid` 추가

## 📎 Issue 번호
closed #305