### PR TITLE
[#307] fix: APPLICANT 변수 attributeKey null로 인한 템플릿 조회 500 에러 수정

### DIFF
--- a/src/main/resources/db/migration/V19__fix_applicant_variable_attribute_key.sql
+++ b/src/main/resources/db/migration/V19__fix_applicant_variable_attribute_key.sql
@@ -1,0 +1,6 @@
+-- APPLICANT 타입 변수 중 attribute_key 가 누락된 레코드를 applicant.name 으로 채움
+-- V16 마이그레이션에서 attribute_key 컬럼 추가 시 기존 데이터가 채워지지 않아 발생한 문제 수정
+UPDATE mail_template_variable
+SET attribute_key = 'applicant.name'
+WHERE variable_type = 'APPLICANT'
+  AND attribute_key IS NULL;


### PR DESCRIPTION
## 📄 작업 내용 요약
V16 마이그레이션에서 attribute_key 컬럼 추가 시 기존 APPLICANT 변수에 값을 채우지 않아 발생한 null 데이터를 V19 마이그레이션으로 applicant.name 으로 채움

## 📎 Issue 번호
closed #307