### PR TITLE
[#309]; feat: 매핑되지 않은 폼 응답 저장 및 지원자 서류 응답 조회 API 추가

### DIFF
--- a/src/main/kotlin/com/yourssu/scouter/ats/application/domain/applicant/ApplicantController.kt
+++ b/src/main/kotlin/com/yourssu/scouter/ats/application/domain/applicant/ApplicantController.kt
@@ -92,6 +92,25 @@ class ApplicantController(
         return ResponseEntity.ok(ReadApplicantResponse.from(accessible.first()))
     }
 
+    @Operation(
+        summary = "지원자 서류 응답 조회",
+        description = "지원자 필드로 매핑되지 않고 저장된 폼의 질문/응답 목록을 조회합니다."
+    )
+    @GetMapping("/applicants/{applicantId}/answers")
+    fun readAnswersById(
+        @AuthUser authUserInfo: AuthUserInfo,
+        @PathVariable applicantId: Long,
+    ): ResponseEntity<List<ReadApplicantAnswerResponse>> {
+        val applicantDto: ApplicantDto = applicantService.readById(applicantId)
+        val accessible = applicantPrivacyService.filterAccessibleApplicants(authUserInfo.userId, listOf(applicantDto))
+        if (accessible.isEmpty()) {
+            throw ApplicantAccessDeniedException("해당 지원자의 정보를 조회할 권한이 없습니다.")
+        }
+
+        val answers = applicantService.readAnswersByApplicantId(applicantId)
+        return ResponseEntity.ok(answers.map(ReadApplicantAnswerResponse::from))
+    }
+
     @Operation(summary = "지원자 삭제", description = "지원자 목록 조회에서 얻은 applicantId를 이용해 지원자를 삭제합니다.")
     @ApiResponse(description = "NO_CONTENT", responseCode = "204")
     @DeleteMapping("/applicants/{applicantId}")

--- a/src/main/kotlin/com/yourssu/scouter/ats/application/domain/applicant/ReadApplicantAnswerResponse.kt
+++ b/src/main/kotlin/com/yourssu/scouter/ats/application/domain/applicant/ReadApplicantAnswerResponse.kt
@@ -1,0 +1,18 @@
+package com.yourssu.scouter.ats.application.domain.applicant
+
+import com.yourssu.scouter.ats.business.domain.applicant.ApplicantAnswerDto
+
+data class ReadApplicantAnswerResponse(
+
+    val question: String,
+
+    val answer: String,
+) {
+
+    companion object {
+        fun from(applicantAnswerDto: ApplicantAnswerDto): ReadApplicantAnswerResponse = ReadApplicantAnswerResponse(
+            question = applicantAnswerDto.question,
+            answer = applicantAnswerDto.answer,
+        )
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/ats/business/domain/applicant/ApplicantAnswerDto.kt
+++ b/src/main/kotlin/com/yourssu/scouter/ats/business/domain/applicant/ApplicantAnswerDto.kt
@@ -1,0 +1,15 @@
+package com.yourssu.scouter.ats.business.domain.applicant
+
+import com.yourssu.scouter.ats.implement.domain.applicant.ApplicantAnswer
+
+data class ApplicantAnswerDto(
+    val question: String,
+    val answer: String,
+) {
+    companion object {
+        fun from(applicantAnswer: ApplicantAnswer): ApplicantAnswerDto = ApplicantAnswerDto(
+            question = applicantAnswer.question,
+            answer = applicantAnswer.answer,
+        )
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/ats/business/domain/applicant/ApplicantService.kt
+++ b/src/main/kotlin/com/yourssu/scouter/ats/business/domain/applicant/ApplicantService.kt
@@ -3,6 +3,7 @@ package com.yourssu.scouter.ats.business.domain.applicant
 import com.yourssu.scouter.ats.business.support.utils.ApplicantStateConverter
 import com.yourssu.scouter.ats.implement.domain.applicant.Applicant
 import java.time.ZoneOffset
+import com.yourssu.scouter.ats.implement.domain.applicant.ApplicantAnswerReader
 import com.yourssu.scouter.ats.implement.domain.applicant.ApplicantReader
 import com.yourssu.scouter.ats.implement.domain.applicant.ApplicantState
 import com.yourssu.scouter.ats.implement.domain.applicant.ApplicantWriter
@@ -18,6 +19,7 @@ import org.springframework.stereotype.Service
 class ApplicantService(
     private val applicantWriter: ApplicantWriter,
     private val applicantReader: ApplicantReader,
+    private val applicantAnswerReader: ApplicantAnswerReader,
     private val departmentReader: DepartmentReader,
     private val partReader: PartReader,
     private val semesterReader: SemesterReader,
@@ -38,6 +40,12 @@ class ApplicantService(
         val applicant: Applicant = applicantReader.readById(applicantId)
 
         return ApplicantDto.from(applicant)
+    }
+
+    fun readAnswersByApplicantId(applicantId: Long): List<ApplicantAnswerDto> {
+        applicantReader.readById(applicantId)
+
+        return applicantAnswerReader.readAllByApplicantId(applicantId).map(ApplicantAnswerDto::from)
     }
 
     fun readAllByFilters(

--- a/src/main/kotlin/com/yourssu/scouter/ats/business/domain/applicant/ApplicantSyncInfo.kt
+++ b/src/main/kotlin/com/yourssu/scouter/ats/business/domain/applicant/ApplicantSyncInfo.kt
@@ -1,9 +1,11 @@
 package com.yourssu.scouter.ats.business.domain.applicant
 
 import com.yourssu.scouter.ats.implement.domain.applicant.Applicant
+import com.yourssu.scouter.common.implement.support.google.ResponseItem
 
 data class ApplicantSyncInfo(
     val applicant: Applicant,
     val formId: String,
     val responseId: String,
+    val unmappedResponseItems: List<ResponseItem> = emptyList(),
 )

--- a/src/main/kotlin/com/yourssu/scouter/ats/business/domain/applicant/ApplicantSyncService.kt
+++ b/src/main/kotlin/com/yourssu/scouter/ats/business/domain/applicant/ApplicantSyncService.kt
@@ -13,6 +13,7 @@ import java.time.LocalDate
 class ApplicantSyncService(
     private val oauth2Service: OAuth2Service,
     private val applicantWriter: ApplicantWriter,
+    private val applicantAnswerWriter: ApplicantAnswerWriter,
     private val semesterReader: SemesterReader,
     private val applicantSyncLogReader: ApplicantSyncLogReader,
     private val applicantSyncLogWriter: ApplicantSyncLogWriter,
@@ -91,8 +92,26 @@ class ApplicantSyncService(
             )
         }
 
-        applicantWriter.writeAll(newApplicants)
+        val savedApplicants: List<Applicant> = applicantWriter.writeAll(newApplicants)
+        writeUnmappedAnswers(savedApplicants, newResults)
         applicantSyncLogWriter.writeAll(newSyncLogs)
+    }
+
+    private fun writeUnmappedAnswers(
+        savedApplicants: List<Applicant>,
+        syncResults: List<ApplicantSyncInfo>,
+    ) {
+        val newAnswers: List<ApplicantAnswer> = savedApplicants.zip(syncResults) { saved, syncResult ->
+            syncResult.unmappedResponseItems.map { item ->
+                ApplicantAnswer(
+                    applicantId = saved.id!!,
+                    question = item.question,
+                    answer = item.answer,
+                )
+            }
+        }.flatten()
+
+        applicantAnswerWriter.writeAll(newAnswers)
     }
 
     fun readLastUpdatedTime(): Instant? {

--- a/src/main/kotlin/com/yourssu/scouter/ats/business/domain/applicant/FormResponseToApplicantProcessor.kt
+++ b/src/main/kotlin/com/yourssu/scouter/ats/business/domain/applicant/FormResponseToApplicantProcessor.kt
@@ -8,6 +8,7 @@ import com.yourssu.scouter.ats.implement.domain.applicant.ApplicantSyncMapping
 import com.yourssu.scouter.common.implement.domain.part.Part
 import com.yourssu.scouter.common.implement.domain.semester.Semester
 import com.yourssu.scouter.common.implement.support.google.GoogleFormsReader
+import com.yourssu.scouter.common.implement.support.google.ResponseItem
 import com.yourssu.scouter.common.implement.support.google.UserResponse
 import org.springframework.stereotype.Component
 
@@ -97,7 +98,34 @@ class FormResponseToApplicantProcessor(
             ),
         )
 
-        return ApplicantSyncInfo(applicant, applicantSyncMapping.formId, userResponse.responseId)
+        return ApplicantSyncInfo(
+            applicant = applicant,
+            formId = applicantSyncMapping.formId,
+            responseId = userResponse.responseId,
+            unmappedResponseItems = extractUnmappedResponseItems(userResponse, applicantSyncMapping),
+        )
+    }
+
+    private fun extractUnmappedResponseItems(
+        userResponse: UserResponse,
+        applicantSyncMapping: ApplicantSyncMapping,
+    ): List<ResponseItem> {
+        // getAnswer/getAll과 동일하게 startsWith 기준으로 매핑 여부를 판단한다.
+        // availableTimeQuestion은 그룹 질문이라 "제목:행제목" 형태의 항목까지 함께 제외된다.
+        val mappedQuestions: List<String> = listOfNotNull(
+            applicantSyncMapping.nameQuestion,
+            applicantSyncMapping.emailQuestion,
+            applicantSyncMapping.phoneNumberQuestion,
+            applicantSyncMapping.ageQuestion,
+            applicantSyncMapping.departmentQuestion,
+            applicantSyncMapping.studentIdQuestion,
+            applicantSyncMapping.academicSemesterQuestion,
+            applicantSyncMapping.availableTimeQuestion,
+        )
+
+        return userResponse.responseItems.filter { item ->
+            item.answer.isNotBlank() && mappedQuestions.none { question -> item.question.startsWith(question) }
+        }
     }
 }
 

--- a/src/main/kotlin/com/yourssu/scouter/ats/business/support/utils/AvailableTimeParser.kt
+++ b/src/main/kotlin/com/yourssu/scouter/ats/business/support/utils/AvailableTimeParser.kt
@@ -16,6 +16,9 @@ class AvailableTimeParser(
     private val availableTimeMap: ApplicantAvailableTimeMap,
     private val nowProvider: () -> Instant = { Instant.now() },
 ) {
+    private val dayOfWeekInDaysRegex = Regex("""\s*[월화수목금토일]요일""")
+    private val dayOfWeekInFormatRegex = Regex("""\s*E+요일""")
+
     fun parse(
         responseItems: List<ResponseItem>,
         availableTimeQuestion: String? = null,
@@ -74,14 +77,43 @@ class AvailableTimeParser(
         days: String,
     ): List<Instant>? =
         parseWithConfiguredFormats(times, year, days)
+            ?: parseIgnoringDayOfWeek(times, year, days)
             ?: parseWithCurrentMonthFallback(times, year, currentMonth, days)
+
+    // 폼에는 연도 정보가 없어 현재 연도로 가정하는데, 실제 작성 연도가 다르면
+    // 날짜에 함께 적힌 요일이 현재 연도의 요일과 어긋나 파싱에 실패한다.
+    // 이 경우 날짜와 포맷 양쪽에서 요일을 제거하고 현재 연도 기준으로 파싱한다.
+    private fun parseIgnoringDayOfWeek(
+        times: List<String>,
+        year: Int,
+        days: String,
+    ): List<Instant>? {
+        val daysWithoutDayOfWeek = days.replace(dayOfWeekInDaysRegex, "").trim()
+        if (daysWithoutDayOfWeek == days) {
+            return null
+        }
+
+        val formatsWithoutDayOfWeek =
+            availableTimeMap.days
+                .map { format -> format.replace(dayOfWeekInFormatRegex, "").trim() }
+                .distinct()
+
+        return parseWithFormats(formatsWithoutDayOfWeek, times, year, daysWithoutDayOfWeek)
+    }
 
     private fun parseWithConfiguredFormats(
         times: List<String>,
         year: Int,
         days: String,
+    ): List<Instant>? = parseWithFormats(availableTimeMap.days, times, year, days)
+
+    private fun parseWithFormats(
+        formats: List<String>,
+        times: List<String>,
+        year: Int,
+        days: String,
     ): List<Instant>? =
-        availableTimeMap.days.firstNotNullOfOrNull { format ->
+        formats.firstNotNullOfOrNull { format ->
             val formatter = DateTimeFormatter.ofPattern(format).withLocale(Locale.KOREA)
             try {
                 times.map { time ->
@@ -106,6 +138,7 @@ class AvailableTimeParser(
 
         val dayWithCurrentMonth = "${currentMonth}월 $days"
         return parseWithConfiguredFormats(times, year, dayWithCurrentMonth)
+            ?: parseIgnoringDayOfWeek(times, year, dayWithCurrentMonth)
     }
 
     private fun containsMonthInfo(days: String): Boolean =

--- a/src/main/kotlin/com/yourssu/scouter/ats/implement/domain/applicant/ApplicantAnswer.kt
+++ b/src/main/kotlin/com/yourssu/scouter/ats/implement/domain/applicant/ApplicantAnswer.kt
@@ -1,0 +1,8 @@
+package com.yourssu.scouter.ats.implement.domain.applicant
+
+class ApplicantAnswer(
+    val id: Long? = null,
+    val applicantId: Long,
+    val question: String,
+    val answer: String,
+)

--- a/src/main/kotlin/com/yourssu/scouter/ats/implement/domain/applicant/ApplicantAnswerReader.kt
+++ b/src/main/kotlin/com/yourssu/scouter/ats/implement/domain/applicant/ApplicantAnswerReader.kt
@@ -1,0 +1,14 @@
+package com.yourssu.scouter.ats.implement.domain.applicant
+
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+
+@Component
+@Transactional(readOnly = true)
+class ApplicantAnswerReader(
+    private val applicantAnswerRepository: ApplicantAnswerRepository,
+) {
+    fun readAllByApplicantId(applicantId: Long): List<ApplicantAnswer> {
+        return applicantAnswerRepository.findAllByApplicantId(applicantId)
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/ats/implement/domain/applicant/ApplicantAnswerRepository.kt
+++ b/src/main/kotlin/com/yourssu/scouter/ats/implement/domain/applicant/ApplicantAnswerRepository.kt
@@ -1,0 +1,7 @@
+package com.yourssu.scouter.ats.implement.domain.applicant
+
+interface ApplicantAnswerRepository {
+    fun saveAll(answers: List<ApplicantAnswer>)
+
+    fun findAllByApplicantId(applicantId: Long): List<ApplicantAnswer>
+}

--- a/src/main/kotlin/com/yourssu/scouter/ats/implement/domain/applicant/ApplicantAnswerWriter.kt
+++ b/src/main/kotlin/com/yourssu/scouter/ats/implement/domain/applicant/ApplicantAnswerWriter.kt
@@ -1,0 +1,14 @@
+package com.yourssu.scouter.ats.implement.domain.applicant
+
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+
+@Component
+@Transactional
+class ApplicantAnswerWriter(
+    private val applicantAnswerRepository: ApplicantAnswerRepository,
+) {
+    fun writeAll(answers: List<ApplicantAnswer>) {
+        applicantAnswerRepository.saveAll(answers)
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/ats/implement/domain/applicant/ApplicantRepository.kt
+++ b/src/main/kotlin/com/yourssu/scouter/ats/implement/domain/applicant/ApplicantRepository.kt
@@ -3,7 +3,7 @@ package com.yourssu.scouter.ats.implement.domain.applicant
 interface ApplicantRepository {
     fun save(applicant: Applicant): Applicant
 
-    fun saveAll(applicants: List<Applicant>)
+    fun saveAll(applicants: List<Applicant>): List<Applicant>
 
     fun findById(applicantId: Long): Applicant?
 

--- a/src/main/kotlin/com/yourssu/scouter/ats/implement/domain/applicant/ApplicantWriter.kt
+++ b/src/main/kotlin/com/yourssu/scouter/ats/implement/domain/applicant/ApplicantWriter.kt
@@ -13,8 +13,8 @@ class ApplicantWriter(
         return applicantRepository.save(applicant)
     }
 
-    fun writeAll(applicants: List<Applicant>) {
-        applicantRepository.saveAll(applicants)
+    fun writeAll(applicants: List<Applicant>): List<Applicant> {
+        return applicantRepository.saveAll(applicants)
     }
 
     fun delete(applicant: Applicant) {

--- a/src/main/kotlin/com/yourssu/scouter/ats/storage/domain/applicant/ApplicantAnswerEntity.kt
+++ b/src/main/kotlin/com/yourssu/scouter/ats/storage/domain/applicant/ApplicantAnswerEntity.kt
@@ -1,0 +1,46 @@
+package com.yourssu.scouter.ats.storage.domain.applicant
+
+import com.yourssu.scouter.ats.implement.domain.applicant.ApplicantAnswer
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
+import jakarta.persistence.ForeignKey
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.Table
+import org.hibernate.annotations.OnDelete
+import org.hibernate.annotations.OnDeleteAction
+
+/**
+ * 지원자 필드로 매핑되지 않은 폼의 텍스트 기반 질문/응답을 담는 Entity Class
+ * @see ApplicantEntity
+ */
+@Entity
+@Table(name = "applicant_answer")
+class ApplicantAnswerEntity(
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long? = null,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "applicant_id", nullable = false, foreignKey = ForeignKey(name = "fk_applicant_answer_applicant"))
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    val applicant: ApplicantEntity,
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    val question: String,
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    val answer: String,
+) {
+    fun toDomain(): ApplicantAnswer = ApplicantAnswer(
+        id = id,
+        applicantId = applicant.id!!,
+        question = question,
+        answer = answer,
+    )
+}

--- a/src/main/kotlin/com/yourssu/scouter/ats/storage/domain/applicant/ApplicantAnswerRepositoryImpl.kt
+++ b/src/main/kotlin/com/yourssu/scouter/ats/storage/domain/applicant/ApplicantAnswerRepositoryImpl.kt
@@ -1,0 +1,28 @@
+package com.yourssu.scouter.ats.storage.domain.applicant
+
+import com.yourssu.scouter.ats.implement.domain.applicant.ApplicantAnswer
+import com.yourssu.scouter.ats.implement.domain.applicant.ApplicantAnswerRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+class ApplicantAnswerRepositoryImpl(
+    private val jpaApplicantAnswerRepository: JpaApplicantAnswerRepository,
+    private val jpaApplicantRepository: JpaApplicantRepository,
+) : ApplicantAnswerRepository {
+
+    override fun saveAll(answers: List<ApplicantAnswer>) {
+        val entities = answers.map { answer ->
+            ApplicantAnswerEntity(
+                applicant = jpaApplicantRepository.getReferenceById(answer.applicantId),
+                question = answer.question,
+                answer = answer.answer,
+            )
+        }
+
+        jpaApplicantAnswerRepository.saveAll(entities)
+    }
+
+    override fun findAllByApplicantId(applicantId: Long): List<ApplicantAnswer> {
+        return jpaApplicantAnswerRepository.findAllByApplicantId(applicantId).map { it.toDomain() }
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/ats/storage/domain/applicant/ApplicantRepositoryImpl.kt
+++ b/src/main/kotlin/com/yourssu/scouter/ats/storage/domain/applicant/ApplicantRepositoryImpl.kt
@@ -21,19 +21,16 @@ class ApplicantRepositoryImpl(
         return savedApplicant
     }
 
-    override fun saveAll(applicants: List<Applicant>) {
-        val savedApplicants =
-            jpaApplicantRepository
-                .saveAll(applicants.map { ApplicantEntity.from(it) })
-        val applicantMap = applicants.associateBy { "${it.name}_${it.email}" }
-        val availableTimeEntities =
-            savedApplicants.flatMap { saved ->
-                val originalTime = applicantMap["${saved.name}_${saved.email}"]?.availableTimes ?: emptyList()
-                ApplicantAvailableTimeEntity.from(saved.toDomain(originalTime))
-            }
+    override fun saveAll(applicants: List<Applicant>): List<Applicant> {
+        // JPA saveAll은 입력 순서를 보존하므로 zip으로 저장 전 도메인과 짝지어 복원한다.
+        val savedEntities = jpaApplicantRepository.saveAll(applicants.map { ApplicantEntity.from(it) })
+        val savedApplicants = savedEntities.zip(applicants) { entity, original ->
+            entity.toDomain(original.availableTimes)
+        }
 
-        jpaAvailableTimeRepository
-            .saveAll(availableTimeEntities)
+        jpaAvailableTimeRepository.saveAll(savedApplicants.flatMap(ApplicantAvailableTimeEntity::from))
+
+        return savedApplicants
     }
 
     override fun findById(applicantId: Long): Applicant? {

--- a/src/main/kotlin/com/yourssu/scouter/ats/storage/domain/applicant/JpaApplicantAnswerRepository.kt
+++ b/src/main/kotlin/com/yourssu/scouter/ats/storage/domain/applicant/JpaApplicantAnswerRepository.kt
@@ -1,0 +1,7 @@
+package com.yourssu.scouter.ats.storage.domain.applicant
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface JpaApplicantAnswerRepository : JpaRepository<ApplicantAnswerEntity, Long> {
+    fun findAllByApplicantId(applicantId: Long): List<ApplicantAnswerEntity>
+}

--- a/src/main/resources/db/migration/V19__create_applicant_answer_table.sql
+++ b/src/main/resources/db/migration/V19__create_applicant_answer_table.sql
@@ -1,0 +1,8 @@
+CREATE TABLE applicant_answer (
+    id           BIGINT AUTO_INCREMENT PRIMARY KEY,
+    applicant_id BIGINT NOT NULL,
+    question     TEXT   NOT NULL,
+    answer       TEXT   NOT NULL,
+    CONSTRAINT fk_applicant_answer_applicant
+        FOREIGN KEY (applicant_id) REFERENCES applicant (id) ON DELETE CASCADE
+);

--- a/src/test/kotlin/com/yourssu/scouter/ats/business/support/utils/AvailableTimeParserTest.kt
+++ b/src/test/kotlin/com/yourssu/scouter/ats/business/support/utils/AvailableTimeParserTest.kt
@@ -251,6 +251,73 @@ class AvailableTimeParserTest {
     }
 
     @Test
+    @DisplayName("요일이 현재 연도와 맞으면 요일을 포함한 형식으로 파싱한다.")
+    fun parseDayOfWeekMatchTest() {
+        // given: 2026년 9월 11일은 금요일
+        val item1 = ResponseItem("가능하신 시간대를 모두 선택해주세요.:9월 11일 금요일", answer = "14시~16시")
+        val responseItems = listOf(item1)
+        val expectedOutput =
+            listOf(
+                LocalDateTime.of(2026, 9, 11, 14, 0, 0).atZone(ZoneId.of("Asia/Seoul")).toInstant(),
+                LocalDateTime.of(2026, 9, 11, 15, 0, 0).atZone(ZoneId.of("Asia/Seoul")).toInstant(),
+            )
+
+        // when
+        val localDateTimes =
+            parserWithFixedNow.parse(responseItems, availableTimeQuestion = "가능하신 시간대를 모두 선택해주세요.")
+
+        // then
+        assertEquals(expectedOutput, localDateTimes)
+    }
+
+    @Test
+    @DisplayName("요일이 현재 연도와 맞지 않으면 요일을 무시하고 현재 연도로 파싱한다.")
+    fun parseDayOfWeekMismatchIgnoresDayOfWeekTest() {
+        // given: 2026년 9월 12일은 토요일이라 '금요일'과 불일치
+        val item1 = ResponseItem("가능하신 시간대를 모두 선택해주세요.:9월 12일 금요일", answer = "14시~16시")
+        val responseItems = listOf(item1)
+        val expectedOutput =
+            listOf(
+                LocalDateTime.of(2026, 9, 12, 14, 0, 0).atZone(ZoneId.of("Asia/Seoul")).toInstant(),
+                LocalDateTime.of(2026, 9, 12, 15, 0, 0).atZone(ZoneId.of("Asia/Seoul")).toInstant(),
+            )
+
+        // when
+        val localDateTimes =
+            parserWithFixedNow.parse(responseItems, availableTimeQuestion = "가능하신 시간대를 모두 선택해주세요.")
+
+        // then
+        assertEquals(expectedOutput, localDateTimes)
+    }
+
+    @Test
+    @DisplayName("요일 포맷만 설정돼 있어도 요일 불일치 시 요일을 무시하고 현재 연도로 파싱한다.")
+    fun parseDayOfWeekMismatchWithOnlyDayOfWeekFormatTest() {
+        // given: 운영 설정처럼 요일 포함 포맷만 존재, 2026년 1월 5일은 월요일이라 '화요일'과 불일치
+        val dayOfWeekOnlyMap =
+            ApplicantAvailableTimeMap(
+                time = listOf("(\\d+)시\\s*~\\s*(\\d+)시"),
+                days = listOf("yyyy M월 d일 E요일 HH:mm"),
+            )
+        val dayOfWeekOnlyParser = AvailableTimeParser(dayOfWeekOnlyMap) { fixedNow }
+
+        val item1 = ResponseItem("가능하신 시간대를 모두 선택해주세요.:1월 5일 화요일", answer = "14시~16시")
+        val responseItems = listOf(item1)
+        val expectedOutput =
+            listOf(
+                LocalDateTime.of(2026, 1, 5, 14, 0, 0).atZone(ZoneId.of("Asia/Seoul")).toInstant(),
+                LocalDateTime.of(2026, 1, 5, 15, 0, 0).atZone(ZoneId.of("Asia/Seoul")).toInstant(),
+            )
+
+        // when
+        val localDateTimes =
+            dayOfWeekOnlyParser.parse(responseItems, availableTimeQuestion = "가능하신 시간대를 모두 선택해주세요.")
+
+        // then
+        assertEquals(expectedOutput, localDateTimes)
+    }
+
+    @Test
     @DisplayName("days에 월 정보가 없으면 현재 월을 사용해 파싱한다.")
     fun parseDayWithoutMonthUsesCurrentMonthTest() {
         // given


### PR DESCRIPTION
## 📄 작업 내용 요약

- **매핑되지 않은 폼 응답 저장**: 지원자 동기화 시 지원자 필드로 매핑되지 않은 폼 질문/응답을 `ApplicantAnswer`로 저장합니다. (`applicant_answer` 테이블 신설, V19 마이그레이션)
- **지원자 서류 응답 조회 API**: `GET /applicants/{applicantId}/answers`로 저장된 질문/응답 목록을 조회합니다. 기존 지원자 조회와 동일하게 접근 권한을 검증합니다.
- **선행 리팩토링**: 저장된 지원자 ID를 답변 저장에 사용할 수 있도록 `ApplicantWriter.writeAll`이 저장된 `Applicant` 목록을 반환하도록 변경했습니다.
- **AvailableTimeParser 개선**: 폼 날짜에 적힌 요일이 현재 연도의 실제 요일과 불일치하면(작성 연도가 다른 경우) 요일을 무시하고 현재 연도 기준으로 파싱하도록 수정했습니다.

## 📎 Issue 번호
closed #309

🤖 Generated with [Claude Code](https://claude.com/claude-code)