### PR TITLE
[#312] fix: 메일 그룹 조회 엔드포인트 변경

### DIFF
--- a/src/main/kotlin/com/yourssu/scouter/common/application/domain/mail/MailGroupListResponse.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/application/domain/mail/MailGroupListResponse.kt
@@ -10,13 +10,25 @@ data class MailGroupListResponse(
 ) {
     data class MailGroupItem(
         val groupId: Long,
-        val senderEmail: String,
+        @field:Schema(description = "예약자 이름 (영문 닉네임)", example = "emin", nullable = true)
+        val reserverName: String?,
+        @field:Schema(description = "예약자 이메일", example = "emin.urssu@gmail.com", nullable = true)
+        val reserverEmail: String?,
         val templateId: Long?,
         val reservationTime: Instant,
         val status: MailReservationStatus,
         val createdAt: Instant,
-        @field:Schema(description = "그룹에 속한 예약 ID 목록")
-        val reservationIds: List<Long>,
+        @field:Schema(description = "그룹에 속한 메일 목록 (수신자별 1건)")
+        val mails: List<MailItem>,
+    )
+
+    data class MailItem(
+        @field:Schema(description = "예약 ID")
+        val reservationId: Long,
+        @field:Schema(description = "수신자 이메일", example = "alice@example.com")
+        val receiverEmail: String,
+        @field:Schema(description = "변수 렌더링이 완료된 메일 제목", example = "[유어슈] 홍길동님 서류 결과 안내")
+        val mailSubject: String,
     )
 
     companion object {
@@ -25,12 +37,19 @@ data class MailGroupListResponse(
                 groups = details.map { detail ->
                     MailGroupItem(
                         groupId = detail.groupId,
-                        senderEmail = detail.senderEmail,
+                        reserverName = detail.reserverName,
+                        reserverEmail = detail.reserverEmail,
                         templateId = detail.templateId,
                         reservationTime = detail.reservationTime,
                         status = detail.status,
                         createdAt = detail.createdAt,
-                        reservationIds = detail.reservationIds,
+                        mails = detail.mails.map { mail ->
+                            MailItem(
+                                reservationId = mail.reservationId,
+                                receiverEmail = mail.receiverEmail,
+                                mailSubject = mail.mailSubject,
+                            )
+                        },
                     )
                 },
             )

--- a/src/main/kotlin/com/yourssu/scouter/common/application/domain/mail/MailReservationController.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/application/domain/mail/MailReservationController.kt
@@ -78,7 +78,7 @@ class MailReservationController(
 
     @Operation(
         summary = "메일 그룹 목록 조회",
-        description = "메일 예약 그룹 메타데이터와 각 그룹에 속한 메일 ID 목록을 조회합니다. 1 예약 요청 = 1 그룹, 수신자 수만큼 메일 ID가 존재합니다.",
+        description = "메일 예약 그룹 메타데이터(예약자 포함)와 각 그룹에 속한 메일 목록(예약 ID, 수신자 이메일, 렌더링된 제목)을 조회합니다. 1 예약 요청 = 1 그룹, 수신자 수만큼 메일이 존재합니다.",
     )
     @ApiResponse(responseCode = "200", description = "조회 성공")
     @GetMapping("/groups")

--- a/src/main/kotlin/com/yourssu/scouter/common/application/domain/mail/MailReservationDetailResponse.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/application/domain/mail/MailReservationDetailResponse.kt
@@ -9,10 +9,10 @@ import java.time.Instant
 data class MailReservationDetailResponse(
     val reservationId: Long,
     val reservationTime: Instant,
-    @Schema(description = "예약 상태", example = "SCHEDULED", allowableValues = ["SCHEDULED", "PENDING_SEND", "SENT"])
+    @field:Schema(description = "예약 상태", example = "SCHEDULED", allowableValues = ["SCHEDULED", "PENDING_SEND", "SENT"])
     val status: MailReservationStatus,
-    @Schema(description = "발신자 이메일", example = "sender@example.com")
-    val senderEmailAddress: String,
+    @field:Schema(description = "예약자 이메일 (실제 발송은 공용 계정으로 나감)", example = "sender@example.com", nullable = true)
+    val senderEmailAddress: String?,
     val mailSubject: String,
     val mailBody: String,
     val bodyFormat: String,

--- a/src/main/kotlin/com/yourssu/scouter/common/application/domain/mail/MailReservationListResponse.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/application/domain/mail/MailReservationListResponse.kt
@@ -9,12 +9,12 @@ import java.time.Instant
 data class MailReservationListItem(
     val reservationId: Long,
     val reservationTime: Instant,
-    @Schema(description = "예약 상태", example = "SCHEDULED", allowableValues = ["SCHEDULED", "PENDING_SEND", "SENT"])
+    @field:Schema(description = "예약 상태", example = "SCHEDULED", allowableValues = ["SCHEDULED", "PENDING_SEND", "SENT"])
     val status: MailReservationStatus,
-    @Schema(description = "발신자 이메일", example = "sender@example.com")
-    val senderEmailAddress: String,
+    @field:Schema(description = "예약자 이메일 (실제 발송은 공용 계정으로 나감)", example = "sender@example.com", nullable = true)
+    val senderEmailAddress: String?,
     val mailSubject: String,
-    @Schema(description = "대표 수신자 이메일 (수신자가 없으면 null)", example = "receiver@example.com", nullable = true)
+    @field:Schema(description = "대표 수신자 이메일 (수신자가 없으면 null)", example = "receiver@example.com", nullable = true)
     val primaryReceiverEmailAddress: String?,
     @field:Schema(description = "첨부파일 참조 목록")
     val attachmentReferences: List<AttachmentReference>,

--- a/src/main/kotlin/com/yourssu/scouter/common/business/domain/mail/MailData.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/business/domain/mail/MailData.kt
@@ -1,6 +1,5 @@
 package com.yourssu.scouter.common.business.domain.mail
 
-import com.yourssu.scouter.common.implement.domain.mail.message.Mail
 import com.yourssu.scouter.common.implement.domain.mail.reservation.MailReservation
 import jakarta.mail.util.ByteArrayDataSource
 
@@ -15,22 +14,10 @@ data class MailData(
     val attachments: Map<String, ByteArrayDataSource> = emptyMap(),
 ) {
     companion object {
-        fun from(mail: Mail): MailData {
-            return MailData(
-                senderEmailAddress = mail.senderEmailAddress,
-                receiverEmailAddresses = listOf(mail.receiverEmailAddress),
-                ccEmailAddresses = mail.ccEmailAddresses,
-                bccEmailAddresses = mail.bccEmailAddresses,
-                mailSubject = mail.mailSubject,
-                mailBody = mail.mailBody,
-                bodyFormat = mail.bodyFormat,
-                attachments = mail.attachments,
-            )
-        }
-
         fun from(reservation: MailReservation): MailData {
             return MailData(
-                senderEmailAddress = reservation.senderEmailAddress,
+                // 실제 From은 GoogleMailSender가 공용 발송 계정으로 덮어쓴다
+                senderEmailAddress = "",
                 receiverEmailAddresses = listOf(reservation.receiverEmailAddress),
                 ccEmailAddresses = reservation.ccEmailAddresses,
                 bccEmailAddresses = reservation.bccEmailAddresses,

--- a/src/main/kotlin/com/yourssu/scouter/common/business/domain/mail/MailGroupDetail.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/business/domain/mail/MailGroupDetail.kt
@@ -5,10 +5,17 @@ import java.time.Instant
 
 data class MailGroupDetail(
     val groupId: Long,
-    val senderEmail: String,
+    val reserverName: String?,
+    val reserverEmail: String?,
     val templateId: Long?,
     val reservationTime: Instant,
     val status: MailReservationStatus,
     val createdAt: Instant,
-    val reservationIds: List<Long>,
-)
+    val mails: List<MailSummary>,
+) {
+    data class MailSummary(
+        val reservationId: Long,
+        val receiverEmail: String,
+        val mailSubject: String,
+    )
+}

--- a/src/main/kotlin/com/yourssu/scouter/common/business/domain/mail/MailReservationDetail.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/business/domain/mail/MailReservationDetail.kt
@@ -8,7 +8,7 @@ data class MailReservationDetail(
     val reservationId: Long,
     val reservationTime: Instant,
     val status: MailReservationStatus,
-    val senderEmailAddress: String,
+    val senderEmailAddress: String?,
     val receiverEmailAddresses: List<String>,
     val ccEmailAddresses: List<String>,
     val bccEmailAddresses: List<String>,

--- a/src/main/kotlin/com/yourssu/scouter/common/business/domain/mail/MailService.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/business/domain/mail/MailService.kt
@@ -12,6 +12,7 @@ import com.yourssu.scouter.common.implement.domain.mail.reservation.MailReservat
 import com.yourssu.scouter.common.implement.domain.mail.reservation.MailReservationWriter
 import com.yourssu.scouter.common.implement.domain.mail.template.MailRenderContext
 import com.yourssu.scouter.common.implement.domain.mail.template.MailTemplateRepository
+import com.yourssu.scouter.common.implement.domain.user.User
 import com.yourssu.scouter.common.implement.domain.user.UserReader
 import com.yourssu.scouter.common.implement.support.exception.InvalidMailRenderingException
 import com.yourssu.scouter.common.implement.support.exception.InvalidTemplateException
@@ -22,6 +23,7 @@ import com.yourssu.scouter.common.implement.support.exception.MailReservationGro
 import com.yourssu.scouter.common.implement.support.exception.MailReservationNotFoundException
 import com.yourssu.scouter.common.implement.support.exception.MailReservationNotYetDueException
 import com.yourssu.scouter.hrms.business.domain.member.MemberPrivacyService
+import com.yourssu.scouter.hrms.implement.domain.member.MemberReader
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -42,6 +44,7 @@ class MailService(
     private val mailReservationGroupReader: MailReservationGroupReader,
     private val applicantReader: ApplicantReader,
     private val mailReservationGroupWriter: MailReservationGroupWriter,
+    private val memberReader: MemberReader,
 ) {
     companion object {
         private val log = LoggerFactory.getLogger(MailService::class.java)
@@ -101,19 +104,19 @@ class MailService(
                 )
             }
 
-        val mails = template.createMailList(sender, contexts)
+        val mails = template.createMailList(contexts)
 
         val group =
             mailReservationGroupWriter.save(
                 MailReservationGroup(
-                    senderEmail = sender.getEmailAddress(),
+                    reservedByUserId = sender.id!!,
                     templateId = template.id,
                     reservationTime = command.reservationTime,
                 ),
             )
 
         mails.forEach { mail ->
-            mailWriter.reserve(mail, command.reservationTime, group.id!!)
+            mailWriter.reserve(mail, command.reservationTime, group.id!!, sender.id)
         }
         log.info("메일 예약 등록 완료: groupId={}, 수신자 수={}", group.id, command.recipients.size)
     }
@@ -124,8 +127,7 @@ class MailService(
             if (memberPrivacyService.isPrivilegedUser(userId)) {
                 mailReservationReader.readAllBefore(now)
             } else {
-                val senderEmails = memberPrivacyService.getActiveTeamMemberEmails(userId).toList()
-                mailReservationReader.readAllBeforeBySenderEmails(now, senderEmails)
+                mailReservationReader.readAllBeforeByReservedByUserIds(now, resolveTeamUserIds(userId))
             }
         return reservations.map { reservation ->
             PendingMailReservationStatus(
@@ -178,12 +180,11 @@ class MailService(
         userId: Long,
         reservationId: Long,
     ) {
-        val user = userReader.readById(userId)
         val reservation =
             mailReservationReader.readById(reservationId)
                 ?: throw MailReservationNotFoundException("예약을 찾을 수 없습니다. reservationId=$reservationId")
 
-        if (!canManageReservation(user.getEmailAddress(), userId, reservation.senderEmailAddress)) {
+        if (!canManageReservation(userId, reservation.reservedByUserId)) {
             throw MailReservationAccessDeniedException("예약에 접근할 수 없습니다. reservationId=$reservationId")
         }
 
@@ -270,19 +271,31 @@ class MailService(
             if (memberPrivacyService.isPrivilegedUser(userId)) {
                 mailReservationGroupReader.readAll()
             } else {
-                val senderEmails = memberPrivacyService.getActiveTeamMemberEmails(userId).toList()
-                mailReservationGroupReader.readAllBySenderEmails(senderEmails)
+                mailReservationGroupReader.readAllByReservedByUserIds(resolveTeamUserIds(userId))
             }
+        val reservers =
+            userReader.readAllByIds(groups.mapNotNull { it.reservedByUserId }.distinct())
+                .associateBy { it.id!! }
+        val reserverNames = reservers.mapValues { (_, user) -> resolveReserverName(user) }
         return groups.map { group ->
-            val reservationIds = mailReservationReader.readAllByGroupId(group.id!!).map { it.id!! }
+            val reserver = group.reservedByUserId?.let(reservers::get)
+            val mails =
+                mailReservationReader.readAllByGroupId(group.id!!).map { reservation ->
+                    MailGroupDetail.MailSummary(
+                        reservationId = reservation.id!!,
+                        receiverEmail = reservation.receiverEmailAddress,
+                        mailSubject = reservation.mailSubject,
+                    )
+                }
             MailGroupDetail(
                 groupId = group.id,
-                senderEmail = group.senderEmail,
+                reserverName = group.reservedByUserId?.let(reserverNames::get),
+                reserverEmail = reserver?.getEmailAddress(),
                 templateId = group.templateId,
                 reservationTime = group.reservationTime,
                 status = group.status,
                 createdAt = group.createdAt,
-                reservationIds = reservationIds,
+                mails = mails,
             )
         }
     }
@@ -292,10 +305,9 @@ class MailService(
             if (memberPrivacyService.isPrivilegedUser(userId)) {
                 mailReservationReader.readAll()
             } else {
-                val senderEmails = memberPrivacyService.getActiveTeamMemberEmails(userId).toList()
-                mailReservationReader.readAllBySenderEmails(senderEmails)
+                mailReservationReader.readAllByReservedByUserIds(resolveTeamUserIds(userId))
             }
-        return reservations.map(::toDetail)
+        return toDetails(reservations)
     }
 
     fun getUserMailReservation(
@@ -307,11 +319,11 @@ class MailService(
                 ?: throw MailReservationNotFoundException("예약을 찾을 수 없습니다. reservationId=$reservationId")
 
         val privileged = memberPrivacyService.isPrivilegedUser(userId)
-        if (!privileged && !memberPrivacyService.getActiveTeamMemberEmails(userId).contains(reservation.senderEmailAddress)) {
+        if (!privileged && reservation.reservedByUserId !in resolveTeamUserIds(userId)) {
             throw MailReservationAccessDeniedException("예약에 접근할 수 없습니다. reservationId=$reservationId")
         }
 
-        return toDetail(reservation)
+        return toDetails(listOf(reservation)).single()
     }
 
     fun updateMailReservation(
@@ -319,12 +331,11 @@ class MailService(
         reservationId: Long,
         command: MailReserveCommand,
     ) {
-        val user = userReader.readById(userId)
         val existingReservation =
             mailReservationReader.readById(reservationId)
                 ?: throw MailReservationNotFoundException("예약을 찾을 수 없습니다. reservationId=$reservationId")
 
-        if (!canManageReservation(user.getEmailAddress(), userId, existingReservation.senderEmailAddress)) {
+        if (!canManageReservation(userId, existingReservation.reservedByUserId)) {
             throw MailReservationAccessDeniedException("예약에 접근할 수 없습니다. reservationId=$reservationId")
         }
 
@@ -349,12 +360,11 @@ class MailService(
         userId: Long,
         reservationId: Long,
     ) {
-        val user = userReader.readById(userId)
         val reservation =
             mailReservationReader.readById(reservationId)
                 ?: throw MailReservationNotFoundException("예약을 찾을 수 없습니다. reservationId=$reservationId")
 
-        if (!canManageReservation(user.getEmailAddress(), userId, reservation.senderEmailAddress)) {
+        if (!canManageReservation(userId, reservation.reservedByUserId)) {
             throw MailReservationAccessDeniedException("예약에 접근할 수 없습니다. reservationId=$reservationId")
         }
 
@@ -380,12 +390,11 @@ class MailService(
         userId: Long,
         groupId: Long,
     ) {
-        val user = userReader.readById(userId)
         val group =
             mailReservationGroupReader.readById(groupId)
                 ?: throw MailReservationGroupNotFoundException("메일 그룹을 찾을 수 없습니다. groupId=$groupId")
 
-        if (!canManageReservation(user.getEmailAddress(), userId, group.senderEmail)) {
+        if (!canManageReservation(userId, group.reservedByUserId)) {
             throw MailReservationAccessDeniedException("메일 그룹에 접근할 수 없습니다. groupId=$groupId")
         }
 
@@ -403,26 +412,40 @@ class MailService(
     }
 
     private fun canManageReservation(
-        requesterEmail: String,
         requesterUserId: Long,
-        reservationSenderEmail: String,
+        reservedByUserId: Long?,
     ): Boolean {
-        return requesterEmail == reservationSenderEmail || memberPrivacyService.isScouterTeamMember(requesterUserId)
+        return requesterUserId == reservedByUserId || memberPrivacyService.isScouterTeamMember(requesterUserId)
     }
 
-    private fun toDetail(reservation: MailReservation): MailReservationDetail {
-        return MailReservationDetail(
-            reservationId = reservation.id!!,
-            reservationTime = reservation.reservationTime,
-            status = reservation.status,
-            senderEmailAddress = reservation.senderEmailAddress,
-            receiverEmailAddresses = listOf(reservation.receiverEmailAddress),
-            ccEmailAddresses = reservation.ccEmailAddresses,
-            bccEmailAddresses = reservation.bccEmailAddresses,
-            mailSubject = reservation.mailSubject,
-            mailBody = reservation.mailBody,
-            bodyFormat = reservation.bodyFormat,
-            attachmentReferences = reservation.attachmentReferences,
-        )
+    /** 같은 파트(팀) Active 멤버들의 users.id 목록. 로그인 이력이 없는 팀원은 예약도 없으므로 제외돼도 무방하다. */
+    private fun resolveTeamUserIds(userId: Long): List<Long> {
+        val teamEmails = memberPrivacyService.getActiveTeamMemberEmails(userId)
+        return userReader.readAllByEmails(teamEmails).map { it.id!! }
+    }
+
+    private fun resolveReserverName(user: User): String {
+        return memberReader.readByEmailOrNull(user.getEmailAddress())?.nicknameEnglish ?: user.userInfo.name
+    }
+
+    private fun toDetails(reservations: List<MailReservation>): List<MailReservationDetail> {
+        val reserverEmails =
+            userReader.readAllByIds(reservations.mapNotNull { it.reservedByUserId }.distinct())
+                .associate { it.id!! to it.getEmailAddress() }
+        return reservations.map { reservation ->
+            MailReservationDetail(
+                reservationId = reservation.id!!,
+                reservationTime = reservation.reservationTime,
+                status = reservation.status,
+                senderEmailAddress = reservation.reservedByUserId?.let(reserverEmails::get),
+                receiverEmailAddresses = listOf(reservation.receiverEmailAddress),
+                ccEmailAddresses = reservation.ccEmailAddresses,
+                bccEmailAddresses = reservation.bccEmailAddresses,
+                mailSubject = reservation.mailSubject,
+                mailBody = reservation.mailBody,
+                bodyFormat = reservation.bodyFormat,
+                attachmentReferences = reservation.attachmentReferences,
+            )
+        }
     }
 }

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/domain/mail/message/Mail.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/domain/mail/message/Mail.kt
@@ -1,7 +1,6 @@
 package com.yourssu.scouter.common.implement.domain.mail.message
 
 import com.yourssu.scouter.common.business.domain.mail.MailBodyFormat
-import jakarta.mail.util.ByteArrayDataSource
 
 class Mail(
     val receiverEmailAddress: String,

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/domain/mail/message/Mail.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/domain/mail/message/Mail.kt
@@ -4,7 +4,6 @@ import com.yourssu.scouter.common.business.domain.mail.MailBodyFormat
 import jakarta.mail.util.ByteArrayDataSource
 
 class Mail(
-    val senderEmailAddress: String,
     val receiverEmailAddress: String,
     val ccEmailAddresses: List<String> = emptyList(),
     val bccEmailAddresses: List<String> = emptyList(),
@@ -12,5 +11,4 @@ class Mail(
     val mailBody: String,
     val bodyFormat: MailBodyFormat,
     val attachmentReferences: List<MailAttachmentReference> = emptyList(),
-    val attachments: Map<String, ByteArrayDataSource> = emptyMap(),
 )

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/domain/mail/message/MailWriter.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/domain/mail/message/MailWriter.kt
@@ -20,10 +20,11 @@ class MailWriter(
         mail: Mail,
         reservationTime: Instant,
         groupId: Long,
+        reservedByUserId: Long,
     ) {
         val reservation =
             MailReservation(
-                senderEmailAddress = mail.senderEmailAddress,
+                reservedByUserId = reservedByUserId,
                 receiverEmailAddress = mail.receiverEmailAddress,
                 ccEmailAddresses = mail.ccEmailAddresses,
                 bccEmailAddresses = mail.bccEmailAddresses,

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/domain/mail/reservation/MailReservation.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/domain/mail/reservation/MailReservation.kt
@@ -6,7 +6,8 @@ import java.time.Instant
 
 data class MailReservation(
     val id: Long? = null,
-    val senderEmailAddress: String,
+    // 예약자 users.id (null: 레거시 backfill 실패 데이터)
+    val reservedByUserId: Long?,
     val receiverEmailAddress: String,
     val ccEmailAddresses: List<String> = emptyList(),
     val bccEmailAddresses: List<String> = emptyList(),

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/domain/mail/reservation/MailReservationGroup.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/domain/mail/reservation/MailReservationGroup.kt
@@ -4,7 +4,8 @@ import java.time.Instant
 
 data class MailReservationGroup(
     val id: Long? = null,
-    val senderEmail: String,
+    // 예약자 users.id (null: 레거시 backfill 실패 데이터)
+    val reservedByUserId: Long?,
     val templateId: Long?,
     val reservationTime: Instant,
     val status: MailReservationStatus = MailReservationStatus.SCHEDULED,

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/domain/mail/reservation/MailReservationGroupReader.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/domain/mail/reservation/MailReservationGroupReader.kt
@@ -15,9 +15,6 @@ class MailReservationGroupReader(
     fun readById(id: Long): MailReservationGroup? =
         mailReservationGroupRepository.findById(id)
 
-    fun readAllBySenderEmail(senderEmail: String): List<MailReservationGroup> =
-        mailReservationGroupRepository.findAllBySenderEmail(senderEmail)
-
-    fun readAllBySenderEmails(senderEmails: List<String>): List<MailReservationGroup> =
-        mailReservationGroupRepository.findAllBySenderEmails(senderEmails)
+    fun readAllByReservedByUserIds(reservedByUserIds: Collection<Long>): List<MailReservationGroup> =
+        mailReservationGroupRepository.findAllByReservedByUserIds(reservedByUserIds)
 }

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/domain/mail/reservation/MailReservationGroupRepository.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/domain/mail/reservation/MailReservationGroupRepository.kt
@@ -8,9 +8,7 @@ interface MailReservationGroupRepository {
 
     fun findById(id: Long): MailReservationGroup?
 
-    fun findAllBySenderEmail(senderEmail: String): List<MailReservationGroup>
-
-    fun findAllBySenderEmails(senderEmails: List<String>): List<MailReservationGroup>
+    fun findAllByReservedByUserIds(reservedByUserIds: Collection<Long>): List<MailReservationGroup>
 
     fun deleteById(id: Long)
 }

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/domain/mail/reservation/MailReservationReader.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/domain/mail/reservation/MailReservationReader.kt
@@ -26,36 +26,12 @@ class MailReservationReader(
         )
     }
 
-    fun readAllBeforeBySenderEmail(time: Instant, senderEmail: String): List<MailReservation> {
-        return mailReservationRepository.findAllByReservationTimeLessThanEqualAndSenderEmail(time, senderEmail)
+    fun readAllBeforeByReservedByUserIds(time: Instant, reservedByUserIds: Collection<Long>): List<MailReservation> {
+        return mailReservationRepository.findAllByReservationTimeLessThanEqualAndReservedByUserIds(time, reservedByUserIds)
     }
 
-    fun readAllBeforeBySenderEmails(time: Instant, senderEmails: List<String>): List<MailReservation> {
-        return mailReservationRepository.findAllByReservationTimeLessThanEqualAndSenderEmails(time, senderEmails)
-    }
-
-    fun readAllBySenderEmail(senderEmail: String): List<MailReservation> {
-        return mailReservationRepository.findAllBySenderEmail(senderEmail)
-    }
-
-    fun readAllBySenderEmails(senderEmails: List<String>): List<MailReservation> {
-        return mailReservationRepository.findAllBySenderEmails(senderEmails)
-    }
-
-    fun readAllBySenderEmailAndReservationTimeBetween(
-        senderEmail: String,
-        from: Instant,
-        to: Instant,
-    ): List<MailReservation> {
-        return mailReservationRepository.findAllBySenderEmailAndReservationTimeBetween(senderEmail, from, to)
-    }
-
-    fun readAllBySenderEmailsAndReservationTimeBetween(
-        senderEmails: List<String>,
-        from: Instant,
-        to: Instant,
-    ): List<MailReservation> {
-        return mailReservationRepository.findAllBySenderEmailsAndReservationTimeBetween(senderEmails, from, to)
+    fun readAllByReservedByUserIds(reservedByUserIds: Collection<Long>): List<MailReservation> {
+        return mailReservationRepository.findAllByReservedByUserIds(reservedByUserIds)
     }
 
     fun readById(id: Long): MailReservation? {

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/domain/mail/reservation/MailReservationRepository.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/domain/mail/reservation/MailReservationRepository.kt
@@ -32,31 +32,12 @@ interface MailReservationRepository {
 
     fun resetStuckSendingReservations(claimedBefore: Instant): Int
 
-    fun findAllByReservationTimeLessThanEqualAndSenderEmail(
+    fun findAllByReservationTimeLessThanEqualAndReservedByUserIds(
         time: Instant,
-        senderEmail: String,
+        reservedByUserIds: Collection<Long>,
     ): List<MailReservation>
 
-    fun findAllByReservationTimeLessThanEqualAndSenderEmails(
-        time: Instant,
-        senderEmails: List<String>,
-    ): List<MailReservation>
-
-    fun findAllBySenderEmail(senderEmail: String): List<MailReservation>
-
-    fun findAllBySenderEmails(senderEmails: List<String>): List<MailReservation>
-
-    fun findAllBySenderEmailAndReservationTimeBetween(
-        senderEmail: String,
-        from: Instant,
-        to: Instant,
-    ): List<MailReservation>
-
-    fun findAllBySenderEmailsAndReservationTimeBetween(
-        senderEmails: List<String>,
-        from: Instant,
-        to: Instant,
-    ): List<MailReservation>
+    fun findAllByReservedByUserIds(reservedByUserIds: Collection<Long>): List<MailReservation>
 
     fun findById(id: Long): MailReservation?
 

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/domain/mail/template/MailTemplate.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/domain/mail/template/MailTemplate.kt
@@ -1,10 +1,8 @@
 package com.yourssu.scouter.common.implement.domain.mail.template
 
-import com.yourssu.scouter.common.implement.domain.mail.template.MailRenderContext
 import com.yourssu.scouter.common.business.domain.mail.MailBodyFormat
 import com.yourssu.scouter.common.implement.domain.mail.message.Mail
 import com.yourssu.scouter.common.implement.domain.mail.message.MailAttachmentReference
-import com.yourssu.scouter.common.implement.domain.user.User
 import com.yourssu.scouter.common.implement.support.exception.InvalidMailRenderingException
 import java.time.Instant
 
@@ -19,12 +17,11 @@ class MailTemplate(
     val createdAt: Instant? = null,
     val updatedAt: Instant? = null,
 ) {
-    fun createMail(sender: User, mailRenderingContext: MailRenderContext): Mail {
+    fun createMail(mailRenderingContext: MailRenderContext): Mail {
         MailRenderer.validate(this, mailRenderingContext)
         val renderedMail = MailRenderer.render(this, mailRenderingContext)
 
         return Mail(
-            senderEmailAddress = sender.getEmailAddress(),
             receiverEmailAddress = mailRenderingContext.recipientEmail,
             ccEmailAddresses = mailRenderingContext.ccEmails,
             bccEmailAddresses = mailRenderingContext.bccEmails,
@@ -35,8 +32,8 @@ class MailTemplate(
         )
     }
 
-    fun createMailList(sender: User, mailRenderingContextList: List<MailRenderContext>): List<Mail> {
-        return mailRenderingContextList.map { createMail(sender, it) }
+    fun createMailList(mailRenderingContextList: List<MailRenderContext>): List<Mail> {
+        return mailRenderingContextList.map(::createMail)
     }
 
     fun validateAttachmentReferences() {

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/domain/user/UserReader.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/domain/user/UserReader.kt
@@ -28,4 +28,12 @@ class UserReader(
     fun readById(userId: Long): User {
         return userRepository.findById(userId) ?: throw UserNotFoundException("지정한 사용자를 찾을 수 없습니다.")
     }
+
+    fun readAllByIds(userIds: Collection<Long>): List<User> {
+        return userRepository.findAllByIds(userIds)
+    }
+
+    fun readAllByEmails(emails: Collection<String>): List<User> {
+        return userRepository.findAllByEmails(emails)
+    }
 }

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/domain/user/UserRepository.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/domain/user/UserRepository.kt
@@ -7,5 +7,7 @@ interface UserRepository {
     fun findById(userId: Long): User?
     fun findByOAuthId(oauthId: String): User?
     fun findByEmail(email: String): User?
+    fun findAllByIds(userIds: Collection<Long>): List<User>
+    fun findAllByEmails(emails: Collection<String>): List<User>
     fun deleteById(userId: Long)
 }

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/support/mail/GoogleMailSender.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/support/mail/GoogleMailSender.kt
@@ -40,7 +40,7 @@ class GoogleMailSender(
             put("mail.mime.charset", "UTF-8")
             put("mail.mime.allowutf8", "true")
         }
-        log.info("SMTP 인증 시도: email={}, appPassword={}", mailSenderProperties.email, mailSenderProperties.appPassword)
+        log.info("SMTP 인증 시도: email={}", mailSenderProperties.email)
         val authenticator = object : Authenticator() {
             override fun getPasswordAuthentication(): PasswordAuthentication =
                 PasswordAuthentication(mailSenderProperties.email, mailSenderProperties.appPassword)

--- a/src/main/kotlin/com/yourssu/scouter/common/storage/domain/mail/JpaMailRepository.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/storage/domain/mail/JpaMailRepository.kt
@@ -27,30 +27,11 @@ interface JpaMailRepository : JpaRepository<MailEntity, Long> {
         statuses: Collection<MailReservationStatus>,
     ): List<MailEntity>
 
-    fun findAllBySenderEmailAddress(senderEmailAddress: String): List<MailEntity>
+    fun findAllByReservedByUserIdIn(reservedByUserIds: Collection<Long>): List<MailEntity>
 
-    fun findAllBySenderEmailAddressIn(senderEmailAddresses: List<String>): List<MailEntity>
-
-    fun findAllByReservationTimeLessThanEqualAndSenderEmailAddress(
+    fun findAllByReservationTimeLessThanEqualAndReservedByUserIdIn(
         reservationTime: Instant,
-        senderEmailAddress: String,
-    ): List<MailEntity>
-
-    fun findAllByReservationTimeLessThanEqualAndSenderEmailAddressIn(
-        reservationTime: Instant,
-        senderEmailAddresses: List<String>,
-    ): List<MailEntity>
-
-    fun findAllBySenderEmailAddressAndReservationTimeBetween(
-        senderEmailAddress: String,
-        from: Instant,
-        to: Instant,
-    ): List<MailEntity>
-
-    fun findAllBySenderEmailAddressInAndReservationTimeBetween(
-        senderEmailAddresses: List<String>,
-        from: Instant,
-        to: Instant,
+        reservedByUserIds: Collection<Long>,
     ): List<MailEntity>
 
     @Modifying(clearAutomatically = true, flushAutomatically = true)

--- a/src/main/kotlin/com/yourssu/scouter/common/storage/domain/mail/JpaMailReservationGroupRepository.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/storage/domain/mail/JpaMailReservationGroupRepository.kt
@@ -4,7 +4,5 @@ import org.springframework.data.jpa.repository.JpaRepository
 
 interface JpaMailReservationGroupRepository : JpaRepository<MailReservationGroupEntity, Long> {
 
-    fun findAllBySenderEmail(senderEmail: String): List<MailReservationGroupEntity>
-
-    fun findAllBySenderEmailIn(senderEmails: List<String>): List<MailReservationGroupEntity>
+    fun findAllByReservedByUserIdIn(reservedByUserIds: Collection<Long>): List<MailReservationGroupEntity>
 }

--- a/src/main/kotlin/com/yourssu/scouter/common/storage/domain/mail/MailEntity.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/storage/domain/mail/MailEntity.kt
@@ -1,7 +1,6 @@
 package com.yourssu.scouter.common.storage.domain.mail
 
 import com.yourssu.scouter.common.business.domain.mail.MailBodyFormat
-import com.yourssu.scouter.common.implement.domain.mail.message.MailAttachmentReference
 import com.yourssu.scouter.common.implement.domain.mail.reservation.MailReservation
 import com.yourssu.scouter.common.implement.domain.mail.reservation.MailReservationStatus
 import jakarta.persistence.CascadeType
@@ -28,8 +27,9 @@ class MailEntity(
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     val id: Long? = null,
-    @Column(nullable = false)
-    val senderEmailAddress: String,
+    // 예약자 users.id (nullable: 레거시 데이터 backfill)
+    @Column
+    val reservedByUserId: Long?,
     @Column(nullable = false)
     val mailSubject: String,
     @Lob
@@ -99,7 +99,7 @@ class MailEntity(
     fun toDomain(): MailReservation =
         MailReservation(
             id = id,
-            senderEmailAddress = senderEmailAddress,
+            reservedByUserId = reservedByUserId,
             receiverEmailAddress = receiverEmailAddress?.emailAddress ?: "",
             ccEmailAddresses = ccEmailAddresses.map { it.emailAddress },
             bccEmailAddresses = bccEmailAddresses.map { it.emailAddress },

--- a/src/main/kotlin/com/yourssu/scouter/common/storage/domain/mail/MailEntityMapper.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/storage/domain/mail/MailEntityMapper.kt
@@ -9,7 +9,7 @@ class MailEntityMapper {
         val mailEntity =
             MailEntity(
                 id = reservation.id,
-                senderEmailAddress = reservation.senderEmailAddress,
+                reservedByUserId = reservation.reservedByUserId,
                 mailSubject = reservation.mailSubject,
                 mailBody = reservation.mailBody,
                 bodyFormat = reservation.bodyFormat,

--- a/src/main/kotlin/com/yourssu/scouter/common/storage/domain/mail/MailReservationGroupEntity.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/storage/domain/mail/MailReservationGroupEntity.kt
@@ -21,8 +21,9 @@ class MailReservationGroupEntity(
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     val id: Long? = null,
 
-    @Column(nullable = false)
-    val senderEmail: String,
+    // 예약자 users.id (nullable: 레거시 데이터 backfill)
+    @Column
+    val reservedByUserId: Long?,
 
     // 어떤 템플릿으로 발송했는지 추적용 (nullable: 레거시 데이터 backfill)
     @Column
@@ -43,7 +44,7 @@ class MailReservationGroupEntity(
         fun from(group: MailReservationGroup): MailReservationGroupEntity =
             MailReservationGroupEntity(
                 id = group.id,
-                senderEmail = group.senderEmail,
+                reservedByUserId = group.reservedByUserId,
                 templateId = group.templateId,
                 reservationTime = group.reservationTime,
                 status = group.status,
@@ -54,7 +55,7 @@ class MailReservationGroupEntity(
     fun toDomain(): MailReservationGroup =
         MailReservationGroup(
             id = id,
-            senderEmail = senderEmail,
+            reservedByUserId = reservedByUserId,
             templateId = templateId,
             reservationTime = reservationTime,
             status = status,

--- a/src/main/kotlin/com/yourssu/scouter/common/storage/domain/mail/MailReservationGroupRepositoryImpl.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/storage/domain/mail/MailReservationGroupRepositoryImpl.kt
@@ -18,11 +18,8 @@ class MailReservationGroupRepositoryImpl(
     override fun findById(id: Long): MailReservationGroup? =
         jpaMailReservationGroupRepository.findById(id).orElse(null)?.toDomain()
 
-    override fun findAllBySenderEmail(senderEmail: String): List<MailReservationGroup> =
-        jpaMailReservationGroupRepository.findAllBySenderEmail(senderEmail).map { it.toDomain() }
-
-    override fun findAllBySenderEmails(senderEmails: List<String>): List<MailReservationGroup> =
-        jpaMailReservationGroupRepository.findAllBySenderEmailIn(senderEmails).map { it.toDomain() }
+    override fun findAllByReservedByUserIds(reservedByUserIds: Collection<Long>): List<MailReservationGroup> =
+        jpaMailReservationGroupRepository.findAllByReservedByUserIdIn(reservedByUserIds).map { it.toDomain() }
 
     override fun deleteById(id: Long) =
         jpaMailReservationGroupRepository.deleteById(id)

--- a/src/main/kotlin/com/yourssu/scouter/common/storage/domain/mail/MailReservationRepositoryImpl.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/storage/domain/mail/MailReservationRepositoryImpl.kt
@@ -62,41 +62,15 @@ class MailReservationRepositoryImpl(
     override fun resetStuckSendingReservations(claimedBefore: Instant): Int =
         jpaMailRepository.resetStuckSendingReservationsNative(claimedBefore)
 
-    override fun findAllByReservationTimeLessThanEqualAndSenderEmail(
+    override fun findAllByReservationTimeLessThanEqualAndReservedByUserIds(
         time: Instant,
-        senderEmail: String,
+        reservedByUserIds: Collection<Long>,
     ): List<MailReservation> =
-        jpaMailRepository.findAllByReservationTimeLessThanEqualAndSenderEmailAddress(time, senderEmail)
+        jpaMailRepository.findAllByReservationTimeLessThanEqualAndReservedByUserIdIn(time, reservedByUserIds)
             .map { it.toDomain() }
 
-    override fun findAllByReservationTimeLessThanEqualAndSenderEmails(
-        time: Instant,
-        senderEmails: List<String>,
-    ): List<MailReservation> =
-        jpaMailRepository.findAllByReservationTimeLessThanEqualAndSenderEmailAddressIn(time, senderEmails)
-            .map { it.toDomain() }
-
-    override fun findAllBySenderEmail(senderEmail: String): List<MailReservation> =
-        jpaMailRepository.findAllBySenderEmailAddress(senderEmail).map { it.toDomain() }
-
-    override fun findAllBySenderEmails(senderEmails: List<String>): List<MailReservation> =
-        jpaMailRepository.findAllBySenderEmailAddressIn(senderEmails).map { it.toDomain() }
-
-    override fun findAllBySenderEmailAndReservationTimeBetween(
-        senderEmail: String,
-        from: Instant,
-        to: Instant,
-    ): List<MailReservation> =
-        jpaMailRepository.findAllBySenderEmailAddressAndReservationTimeBetween(senderEmail, from, to)
-            .map { it.toDomain() }
-
-    override fun findAllBySenderEmailsAndReservationTimeBetween(
-        senderEmails: List<String>,
-        from: Instant,
-        to: Instant,
-    ): List<MailReservation> =
-        jpaMailRepository.findAllBySenderEmailAddressInAndReservationTimeBetween(senderEmails, from, to)
-            .map { it.toDomain() }
+    override fun findAllByReservedByUserIds(reservedByUserIds: Collection<Long>): List<MailReservation> =
+        jpaMailRepository.findAllByReservedByUserIdIn(reservedByUserIds).map { it.toDomain() }
 
     override fun findById(id: Long): MailReservation? =
         jpaMailRepository.findById(id).orElse(null)?.toDomain()

--- a/src/main/kotlin/com/yourssu/scouter/common/storage/domain/user/JpaUserRepository.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/storage/domain/user/JpaUserRepository.kt
@@ -6,4 +6,5 @@ interface JpaUserRepository : JpaRepository<UserEntity, Long> {
 
     fun findByOauthId(oauthId: String): UserEntity?
     fun findByEmail(email: String): UserEntity?
+    fun findAllByEmailIn(emails: Collection<String>): List<UserEntity>
 }

--- a/src/main/kotlin/com/yourssu/scouter/common/storage/domain/user/UserRepositoryImpl.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/storage/domain/user/UserRepositoryImpl.kt
@@ -30,6 +30,14 @@ class UserRepositoryImpl(
         return jpaUserRepository.findByEmail(email)?.toDomain()
     }
 
+    override fun findAllByIds(userIds: Collection<Long>): List<User> {
+        return jpaUserRepository.findAllById(userIds).map { it.toDomain() }
+    }
+
+    override fun findAllByEmails(emails: Collection<String>): List<User> {
+        return jpaUserRepository.findAllByEmailIn(emails).map { it.toDomain() }
+    }
+
     override fun deleteById(userId: Long) {
         jpaUserRepository.deleteById(userId)
     }

--- a/src/main/resources/db/migration/V21__replace_sender_email_with_reserved_by_user_id.sql
+++ b/src/main/resources/db/migration/V21__replace_sender_email_with_reserved_by_user_id.sql
@@ -1,0 +1,21 @@
+-- 실제 발송은 공용 계정(mail.sender)으로 나가므로 sender_email 계열 컬럼은 발신 주소가 아니라
+-- "누가 예약했는지" 메타정보였음. 예약자 식별자(users.id)로 교체하고 이름/이메일은 조회 시점에 파생한다.
+ALTER TABLE mail_reservation_group
+    ADD COLUMN reserved_by_user_id BIGINT NULL;
+
+UPDATE mail_reservation_group g
+    JOIN users u ON u.email = g.sender_email
+SET g.reserved_by_user_id = u.id;
+
+ALTER TABLE mail_reservation_group
+    DROP COLUMN sender_email;
+
+ALTER TABLE mail
+    ADD COLUMN reserved_by_user_id BIGINT NULL;
+
+UPDATE mail m
+    JOIN users u ON u.email = m.sender_email_address
+SET m.reserved_by_user_id = u.id;
+
+ALTER TABLE mail
+    DROP COLUMN sender_email_address;

--- a/src/test/kotlin/com/yourssu/scouter/common/business/domain/mail/MailReservationClaimConcurrencyTest.kt
+++ b/src/test/kotlin/com/yourssu/scouter/common/business/domain/mail/MailReservationClaimConcurrencyTest.kt
@@ -1,6 +1,5 @@
 package com.yourssu.scouter.common.business.domain.mail
 
-import com.yourssu.scouter.common.business.domain.mail.MailBodyFormat
 import com.yourssu.scouter.common.implement.domain.mail.reservation.MailReservation
 import com.yourssu.scouter.common.implement.domain.mail.reservation.MailReservationRepository
 import com.yourssu.scouter.common.implement.domain.mail.reservation.MailReservationStatus
@@ -37,7 +36,7 @@ class MailReservationClaimConcurrencyTest {
             val reservation =
                 mailReservationRepository.save(
                     MailReservation(
-                        senderEmailAddress = "claim-concurrency@example.com",
+                        reservedByUserId = null,
                         receiverEmailAddress = "to@example.com",
                         mailSubject = "claim-test",
                         mailBody = "body",

--- a/src/test/kotlin/com/yourssu/scouter/common/business/domain/mail/MailServiceTest.kt
+++ b/src/test/kotlin/com/yourssu/scouter/common/business/domain/mail/MailServiceTest.kt
@@ -21,6 +21,7 @@ import com.yourssu.scouter.common.implement.support.exception.MailReservationAlr
 import com.yourssu.scouter.common.implement.support.exception.MailReservationNotFoundException
 import com.yourssu.scouter.common.implement.support.exception.MailReservationNotYetDueException
 import com.yourssu.scouter.hrms.business.domain.member.MemberPrivacyService
+import com.yourssu.scouter.hrms.implement.domain.member.MemberReader
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
@@ -46,6 +47,7 @@ class MailServiceTest {
     private val mailReservationGroupReader = mock<MailReservationGroupReader>()
     private val applicantReader = mock<ApplicantReader>()
     private val mailReservationGroupWriter = mock<MailReservationGroupWriter>()
+    private val memberReader = mock<MemberReader>()
 
     private fun createService(): MailService {
         return MailService(
@@ -61,6 +63,7 @@ class MailServiceTest {
             mailReservationGroupReader = mailReservationGroupReader,
             applicantReader = applicantReader,
             mailReservationGroupWriter = mailReservationGroupWriter,
+            memberReader = memberReader,
         )
     }
 
@@ -90,7 +93,7 @@ class MailServiceTest {
 
     private fun reservation(
         id: Long = 10L,
-        senderEmailAddress: String = "user@example.com",
+        reservedByUserId: Long? = 1L,
         receiverEmailAddress: String = "to@example.com",
         mailSubject: String = "제목",
         mailBody: String = "본문",
@@ -99,7 +102,7 @@ class MailServiceTest {
     ): MailReservation =
         MailReservation(
             id = id,
-            senderEmailAddress = senderEmailAddress,
+            reservedByUserId = reservedByUserId,
             receiverEmailAddress = receiverEmailAddress,
             mailSubject = mailSubject,
             mailBody = mailBody,
@@ -109,23 +112,26 @@ class MailServiceTest {
         )
 
     @Test
-    fun `getUserMailReservations는 로그인 사용자의 발신자 이메일 기준으로 예약 목록을 조회한다`() {
+    fun `getUserMailReservations는 로그인 사용자의 팀 예약자 기준으로 예약 목록을 조회한다`() {
         val userId = 1L
-        val senderEmail = "user@example.com"
-        whenever(memberPrivacyService.getActiveTeamMemberEmails(userId)).thenReturn(setOf(senderEmail))
+        val user = createUser(userId, "user@example.com")
+        whenever(memberPrivacyService.getActiveTeamMemberEmails(userId)).thenReturn(setOf("user@example.com"))
+        whenever(userReader.readAllByEmails(any())).thenReturn(listOf(user))
+        whenever(userReader.readAllByIds(any())).thenReturn(listOf(user))
 
-        val r = reservation(senderEmailAddress = senderEmail)
-        whenever(mailReservationReader.readAllBySenderEmails(any())).thenReturn(listOf(r))
+        val r = reservation(reservedByUserId = userId)
+        whenever(mailReservationReader.readAllByReservedByUserIds(any())).thenReturn(listOf(r))
 
         val service = createService()
         val results = service.getUserMailReservations(userId)
 
-        verify(mailReservationReader).readAllBySenderEmails(listOf(senderEmail))
+        verify(mailReservationReader).readAllByReservedByUserIds(listOf(userId))
         assertThat(results).hasSize(1)
         val detail = results[0]
         assertThat(detail.reservationId).isEqualTo(10L)
         assertThat(detail.mailSubject).isEqualTo("제목")
         assertThat(detail.receiverEmailAddresses).containsExactly("to@example.com")
+        assertThat(detail.senderEmailAddress).isEqualTo("user@example.com")
     }
 
     @Test
@@ -143,8 +149,9 @@ class MailServiceTest {
     fun `getUserMailReservation는 다른 사용자의 예약에 접근하면 예외를 던진다`() {
         val userId = 1L
         whenever(memberPrivacyService.getActiveTeamMemberEmails(userId)).thenReturn(setOf("user@example.com"))
+        whenever(userReader.readAllByEmails(any())).thenReturn(listOf(createUser(userId, "user@example.com")))
 
-        val r = reservation(senderEmailAddress = "other@example.com")
+        val r = reservation(reservedByUserId = 2L)
         whenever(mailReservationReader.readById(10L)).thenReturn(r)
 
         val service = createService()
@@ -157,11 +164,9 @@ class MailServiceTest {
     @Test
     fun `updateMailReservation는 메일 내용과 예약 시간을 전체 교체한다`() {
         val userId = 1L
-        val user = createUser(userId, "user@example.com")
-        whenever(userReader.readById(userId)).thenReturn(user)
         whenever(memberPrivacyService.isScouterTeamMember(userId)).thenReturn(false)
 
-        val r = reservation(reservationTime = Instant.now().plusSeconds(600))
+        val r = reservation(reservedByUserId = userId, reservationTime = Instant.now().plusSeconds(600))
         whenever(mailReservationReader.readById(10L)).thenReturn(r)
 
         val command =
@@ -186,11 +191,9 @@ class MailServiceTest {
     @Test
     fun `updateMailReservation는 화이트리스트 사용자면 타인의 예약도 수정할 수 있다`() {
         val userId = 1L
-        val user = createUser(userId, "umi.urssu@gmail.com")
-        whenever(userReader.readById(userId)).thenReturn(user)
         whenever(memberPrivacyService.isScouterTeamMember(userId)).thenReturn(true)
 
-        val r = reservation(senderEmailAddress = "other@example.com", reservationTime = Instant.now().plusSeconds(600))
+        val r = reservation(reservedByUserId = 2L, reservationTime = Instant.now().plusSeconds(600))
         whenever(mailReservationReader.readById(10L)).thenReturn(r)
 
         val command =
@@ -212,11 +215,9 @@ class MailServiceTest {
     @Test
     fun `updateMailReservation는 화이트리스트가 아니면 타인의 예약 수정 시 예외를 던진다`() {
         val userId = 1L
-        val user = createUser(userId, "user@example.com")
-        whenever(userReader.readById(userId)).thenReturn(user)
         whenever(memberPrivacyService.isScouterTeamMember(userId)).thenReturn(false)
 
-        val r = reservation(senderEmailAddress = "other@example.com", reservationTime = Instant.now().plusSeconds(600))
+        val r = reservation(reservedByUserId = 2L, reservationTime = Instant.now().plusSeconds(600))
         whenever(mailReservationReader.readById(10L)).thenReturn(r)
 
         val command =
@@ -240,11 +241,9 @@ class MailServiceTest {
     @Test
     fun `updateMailReservation는 예약 시간이 지난 경우 예외를 던지고 저장을 수행하지 않는다`() {
         val userId = 1L
-        val user = createUser(userId, "user@example.com")
-        whenever(userReader.readById(userId)).thenReturn(user)
         whenever(memberPrivacyService.isScouterTeamMember(userId)).thenReturn(false)
 
-        val r = reservation(reservationTime = Instant.now().minusSeconds(60))
+        val r = reservation(reservedByUserId = userId, reservationTime = Instant.now().minusSeconds(60))
         whenever(mailReservationReader.readById(10L)).thenReturn(r)
 
         val command =
@@ -268,11 +267,9 @@ class MailServiceTest {
     @Test
     fun `cancelMailReservation는 화이트리스트가 아니면 타인의 예약 삭제 시 예외를 던지고 삭제를 수행하지 않는다`() {
         val userId = 1L
-        val user = createUser(userId, "user@example.com")
-        whenever(userReader.readById(userId)).thenReturn(user)
         whenever(memberPrivacyService.isScouterTeamMember(userId)).thenReturn(false)
 
-        val r = reservation(senderEmailAddress = "other@example.com", reservationTime = Instant.now().plusSeconds(600))
+        val r = reservation(reservedByUserId = 2L, reservationTime = Instant.now().plusSeconds(600))
         whenever(mailReservationReader.readById(10L)).thenReturn(r)
 
         val service = createService()
@@ -286,11 +283,9 @@ class MailServiceTest {
     @Test
     fun `cancelMailReservation는 화이트리스트 사용자면 타인의 예약도 삭제할 수 있다`() {
         val userId = 1L
-        val user = createUser(userId, "umi.urssu@gmail.com")
-        whenever(userReader.readById(userId)).thenReturn(user)
         whenever(memberPrivacyService.isScouterTeamMember(userId)).thenReturn(true)
 
-        val r = reservation(senderEmailAddress = "other@example.com", reservationTime = Instant.now().plusSeconds(600))
+        val r = reservation(reservedByUserId = 2L, reservationTime = Instant.now().plusSeconds(600))
         whenever(mailReservationReader.readById(10L)).thenReturn(r)
 
         val service = createService()
@@ -302,11 +297,9 @@ class MailServiceTest {
     @Test
     fun `cancelMailReservation는 예약 시간이 지난 경우 예외를 던지고 삭제를 수행하지 않는다`() {
         val userId = 1L
-        val user = createUser(userId, "user@example.com")
-        whenever(userReader.readById(userId)).thenReturn(user)
         whenever(memberPrivacyService.isScouterTeamMember(userId)).thenReturn(false)
 
-        val r = reservation(reservationTime = Instant.now().minusSeconds(60))
+        val r = reservation(reservedByUserId = userId, reservationTime = Instant.now().minusSeconds(60))
         whenever(mailReservationReader.readById(10L)).thenReturn(r)
 
         val service = createService()
@@ -320,14 +313,11 @@ class MailServiceTest {
     @Test
     fun `retryReservation는 PENDING_SEND 상태이고 예약 시간이 지난 경우 발송을 시도하고 성공 시 SENT로 저장한다`() {
         val userId = 1L
-        val senderEmail = "user@example.com"
-        val user = createUser(userId, senderEmail)
-        whenever(userReader.readById(userId)).thenReturn(user)
         whenever(memberPrivacyService.isScouterTeamMember(userId)).thenReturn(false)
 
         val r =
             reservation(
-                senderEmailAddress = senderEmail,
+                reservedByUserId = userId,
                 reservationTime = Instant.now().minusSeconds(60),
                 status = MailReservationStatus.PENDING_SEND,
             )
@@ -346,12 +336,11 @@ class MailServiceTest {
     @Test
     fun `retryReservation는 이미 SENT인 경우 예외를 던진다`() {
         val userId = 1L
-        val user = createUser(userId, "user@example.com")
-        whenever(userReader.readById(userId)).thenReturn(user)
         whenever(memberPrivacyService.isScouterTeamMember(userId)).thenReturn(false)
 
         val r =
             reservation(
+                reservedByUserId = userId,
                 reservationTime = Instant.now().minusSeconds(60),
                 status = MailReservationStatus.SENT,
             )
@@ -369,12 +358,11 @@ class MailServiceTest {
     @Test
     fun `retryReservation는 예약 시간이 지나지 않은 경우 예외를 던진다`() {
         val userId = 1L
-        val user = createUser(userId, "user@example.com")
-        whenever(userReader.readById(userId)).thenReturn(user)
         whenever(memberPrivacyService.isScouterTeamMember(userId)).thenReturn(false)
 
         val r =
             reservation(
+                reservedByUserId = userId,
                 reservationTime = Instant.now().plusSeconds(600),
                 status = MailReservationStatus.PENDING_SEND,
             )
@@ -392,13 +380,11 @@ class MailServiceTest {
     @Test
     fun `retryReservation는 화이트리스트가 아니면 다른 사용자의 예약에 대해 예외를 던진다`() {
         val userId = 1L
-        val user = createUser(userId, "user@example.com")
-        whenever(userReader.readById(userId)).thenReturn(user)
         whenever(memberPrivacyService.isScouterTeamMember(userId)).thenReturn(false)
 
         val r =
             reservation(
-                senderEmailAddress = "other@example.com",
+                reservedByUserId = 2L,
                 reservationTime = Instant.now().minusSeconds(60),
                 status = MailReservationStatus.PENDING_SEND,
             )
@@ -416,13 +402,11 @@ class MailServiceTest {
     @Test
     fun `retryReservation는 화이트리스트 사용자면 다른 사용자의 예약도 재전송할 수 있다`() {
         val userId = 1L
-        val user = createUser(userId, "umi.urssu@gmail.com")
-        whenever(userReader.readById(userId)).thenReturn(user)
         whenever(memberPrivacyService.isScouterTeamMember(userId)).thenReturn(true)
 
         val r =
             reservation(
-                senderEmailAddress = "other@example.com",
+                reservedByUserId = 2L,
                 reservationTime = Instant.now().minusSeconds(60),
                 status = MailReservationStatus.PENDING_SEND,
             )
@@ -441,8 +425,6 @@ class MailServiceTest {
     @Test
     fun `retryReservation는 존재하지 않는 예약에 대해 예외를 던진다`() {
         val userId = 1L
-        val user = createUser(userId, "user@example.com")
-        whenever(userReader.readById(userId)).thenReturn(user)
         whenever(mailReservationReader.readById(999L)).thenReturn(null)
 
         val service = createService()
@@ -455,14 +437,11 @@ class MailServiceTest {
     @Test
     fun `retryReservation는 발송 실패 시 MailFailedException을 던진다`() {
         val userId = 1L
-        val senderEmail = "user@example.com"
-        val user = createUser(userId, senderEmail)
-        whenever(userReader.readById(userId)).thenReturn(user)
         whenever(memberPrivacyService.isScouterTeamMember(userId)).thenReturn(false)
 
         val r =
             reservation(
-                senderEmailAddress = senderEmail,
+                reservedByUserId = userId,
                 reservationTime = Instant.now().minusSeconds(60),
                 status = MailReservationStatus.PENDING_SEND,
             )
@@ -483,13 +462,18 @@ class MailServiceTest {
     }
 
     @Test
-    fun `getUserMailReservation는 같은 팀(발신자 이메일이 팀 이메일 목록에 포함)이면 타인의 예약도 조회할 수 있다`() {
+    fun `getUserMailReservation는 같은 팀(예약자가 팀원 목록에 포함)이면 타인의 예약도 조회할 수 있다`() {
         val userId = 1L
+        val teammate = createUser(2L, "teammate@example.com")
         whenever(memberPrivacyService.getActiveTeamMemberEmails(userId)).thenReturn(
             setOf("viewer@example.com", "teammate@example.com"),
         )
+        whenever(userReader.readAllByEmails(any())).thenReturn(
+            listOf(createUser(userId, "viewer@example.com"), teammate),
+        )
+        whenever(userReader.readAllByIds(any())).thenReturn(listOf(teammate))
 
-        val r = reservation(senderEmailAddress = "teammate@example.com")
+        val r = reservation(reservedByUserId = 2L)
         whenever(mailReservationReader.readById(10L)).thenReturn(r)
 
         val service = createService()
@@ -503,7 +487,10 @@ class MailServiceTest {
         val userId = 1L
         whenever(memberPrivacyService.isPrivilegedUser(userId)).thenReturn(true)
 
-        val r = reservation(senderEmailAddress = "other@example.com")
+        val other = createUser(2L, "other@example.com")
+        whenever(userReader.readAllByIds(any())).thenReturn(listOf(other))
+
+        val r = reservation(reservedByUserId = 2L)
         whenever(mailReservationReader.readAll()).thenReturn(listOf(r))
 
         val service = createService()

--- a/src/test/kotlin/com/yourssu/scouter/common/implement/domain/mail/reservation/MailReservationTest.kt
+++ b/src/test/kotlin/com/yourssu/scouter/common/implement/domain/mail/reservation/MailReservationTest.kt
@@ -15,7 +15,7 @@ class MailReservationTest {
     ): MailReservation {
         return MailReservation(
             id = 1L,
-            senderEmailAddress = "sender@example.com",
+            reservedByUserId = 1L,
             receiverEmailAddress = "receiver@example.com",
             mailSubject = "제목",
             mailBody = "본문",


### PR DESCRIPTION
## 📄 작업 내용 요약
메일 그룹 조회 엔드포인트에 예약자, 수신인, 메일제목을 추가합니다.

## 📎 Issue 번호
<!-- closed #번호 -->
closed #312