### PR TITLE
[#314]; feat: 서류평가 API 구현

### DIFF
--- a/src/main/kotlin/com/yourssu/scouter/ats/application/domain/applicant/ReadApplicantAnswerResponse.kt
+++ b/src/main/kotlin/com/yourssu/scouter/ats/application/domain/applicant/ReadApplicantAnswerResponse.kt
@@ -4,6 +4,8 @@ import com.yourssu.scouter.ats.business.domain.applicant.ApplicantAnswerDto
 
 data class ReadApplicantAnswerResponse(
 
+    val sectionId: Long?,
+
     val question: String,
 
     val answer: String,
@@ -11,6 +13,7 @@ data class ReadApplicantAnswerResponse(
 
     companion object {
         fun from(applicantAnswerDto: ApplicantAnswerDto): ReadApplicantAnswerResponse = ReadApplicantAnswerResponse(
+            sectionId = applicantAnswerDto.sectionId,
             question = applicantAnswerDto.question,
             answer = applicantAnswerDto.answer,
         )

--- a/src/main/kotlin/com/yourssu/scouter/ats/business/domain/applicant/ApplicantAnswerDto.kt
+++ b/src/main/kotlin/com/yourssu/scouter/ats/business/domain/applicant/ApplicantAnswerDto.kt
@@ -3,11 +3,13 @@ package com.yourssu.scouter.ats.business.domain.applicant
 import com.yourssu.scouter.ats.implement.domain.applicant.ApplicantAnswer
 
 data class ApplicantAnswerDto(
+    val sectionId: Long?,
     val question: String,
     val answer: String,
 ) {
     companion object {
         fun from(applicantAnswer: ApplicantAnswer): ApplicantAnswerDto = ApplicantAnswerDto(
+            sectionId = applicantAnswer.sectionId,
             question = applicantAnswer.question,
             answer = applicantAnswer.answer,
         )

--- a/src/main/kotlin/com/yourssu/scouter/ats/implement/domain/applicant/ApplicantAnswer.kt
+++ b/src/main/kotlin/com/yourssu/scouter/ats/implement/domain/applicant/ApplicantAnswer.kt
@@ -3,6 +3,7 @@ package com.yourssu.scouter.ats.implement.domain.applicant
 class ApplicantAnswer(
     val id: Long? = null,
     val applicantId: Long,
+    val sectionId: Long? = null,
     val question: String,
     val answer: String,
 )

--- a/src/main/kotlin/com/yourssu/scouter/ats/storage/domain/applicant/ApplicantAnswerEntity.kt
+++ b/src/main/kotlin/com/yourssu/scouter/ats/storage/domain/applicant/ApplicantAnswerEntity.kt
@@ -36,10 +36,14 @@ class ApplicantAnswerEntity(
 
     @Column(nullable = false, columnDefinition = "TEXT")
     val answer: String,
+
+    @Column(name = "section_id")
+    val sectionId: Long? = null,
 ) {
     fun toDomain(): ApplicantAnswer = ApplicantAnswer(
         id = id,
         applicantId = applicant.id!!,
+        sectionId = sectionId,
         question = question,
         answer = answer,
     )

--- a/src/main/kotlin/com/yourssu/scouter/ats/storage/domain/applicant/ApplicantAnswerRepositoryImpl.kt
+++ b/src/main/kotlin/com/yourssu/scouter/ats/storage/domain/applicant/ApplicantAnswerRepositoryImpl.kt
@@ -16,6 +16,7 @@ class ApplicantAnswerRepositoryImpl(
                 applicant = jpaApplicantRepository.getReferenceById(answer.applicantId),
                 question = answer.question,
                 answer = answer.answer,
+                sectionId = answer.sectionId,
             )
         }
 

--- a/src/main/kotlin/com/yourssu/scouter/document/application/domain/comment/CreateDocumentCommentRequest.kt
+++ b/src/main/kotlin/com/yourssu/scouter/document/application/domain/comment/CreateDocumentCommentRequest.kt
@@ -1,0 +1,21 @@
+package com.yourssu.scouter.document.application.domain.comment
+
+import com.yourssu.scouter.document.business.domain.comment.CreateDocumentCommentCommand
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotNull
+
+data class CreateDocumentCommentRequest(
+
+    @field:NotNull
+    val sectionId: Long?,
+
+    @field:NotBlank
+    val content: String?,
+) {
+    fun toCommand(applicantId: Long, authorUserId: Long): CreateDocumentCommentCommand = CreateDocumentCommentCommand(
+        applicantId = applicantId,
+        sectionId = sectionId!!,
+        authorUserId = authorUserId,
+        content = content!!,
+    )
+}

--- a/src/main/kotlin/com/yourssu/scouter/document/application/domain/comment/DocumentCommentController.kt
+++ b/src/main/kotlin/com/yourssu/scouter/document/application/domain/comment/DocumentCommentController.kt
@@ -1,0 +1,65 @@
+package com.yourssu.scouter.document.application.domain.comment
+
+import com.yourssu.scouter.common.application.support.authentication.AuthUser
+import com.yourssu.scouter.common.application.support.authentication.AuthUserInfo
+import com.yourssu.scouter.document.business.domain.comment.DocumentCommentDto
+import com.yourssu.scouter.document.business.domain.comment.DocumentCommentService
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.headers.Header
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.validation.Valid
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RestController
+import java.net.URI
+
+@Tag(name = "서류 코멘트")
+@RestController
+class DocumentCommentController(
+    private val documentCommentService: DocumentCommentService,
+) {
+
+    @Operation(summary = "인라인 코멘트 조회")
+    @GetMapping("/applicants/{applicantId}/documents/comments")
+    fun readAllByApplicantId(
+        @PathVariable applicantId: Long,
+    ): ResponseEntity<List<ReadDocumentCommentResponse>> {
+        val comments = documentCommentService.readAllByApplicantId(applicantId)
+
+        return ResponseEntity.ok(comments.map(ReadDocumentCommentResponse::from))
+    }
+
+    @Operation(summary = "인라인 코멘트 작성")
+    @ApiResponse(
+        description = "CREATED", responseCode = "201", headers = [
+            Header(name = "Location", description = "/applicants/{applicantId}/documents/comments/{commentId}"),
+        ],
+    )
+    @PostMapping("/applicants/{applicantId}/documents/comments")
+    fun create(
+        @AuthUser authUserInfo: AuthUserInfo,
+        @PathVariable applicantId: Long,
+        @RequestBody @Valid request: CreateDocumentCommentRequest,
+    ): ResponseEntity<Unit> {
+        val dto: DocumentCommentDto = documentCommentService.create(request.toCommand(applicantId, authUserInfo.userId))
+
+        return ResponseEntity.created(URI.create("/applicants/$applicantId/documents/comments/${dto.commentId}")).build()
+    }
+
+    @Operation(summary = "인라인 코멘트 삭제", description = "본인이 작성한 코멘트만 삭제 가능합니다.")
+    @DeleteMapping("/applicants/{applicantId}/documents/comments/{commentId}")
+    fun deleteById(
+        @AuthUser authUserInfo: AuthUserInfo,
+        @PathVariable applicantId: Long,
+        @PathVariable commentId: Long,
+    ): ResponseEntity<Unit> {
+        documentCommentService.deleteById(commentId, authUserInfo.userId)
+
+        return ResponseEntity.ok().build()
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/document/application/domain/comment/ReadDocumentCommentResponse.kt
+++ b/src/main/kotlin/com/yourssu/scouter/document/application/domain/comment/ReadDocumentCommentResponse.kt
@@ -1,0 +1,34 @@
+package com.yourssu.scouter.document.application.domain.comment
+
+import com.yourssu.scouter.document.business.domain.comment.DocumentCommentAuthorDto
+import com.yourssu.scouter.document.business.domain.comment.DocumentCommentDto
+import java.time.Instant
+
+data class ReadDocumentCommentAuthorResponse(
+    val userId: Long,
+    val nickname: String,
+    val part: String,
+) {
+    companion object {
+        fun from(dto: DocumentCommentAuthorDto): ReadDocumentCommentAuthorResponse =
+            ReadDocumentCommentAuthorResponse(dto.userId, dto.nickname, dto.part)
+    }
+}
+
+data class ReadDocumentCommentResponse(
+    val commentId: Long,
+    val sectionId: Long,
+    val content: String,
+    val author: ReadDocumentCommentAuthorResponse,
+    val createdAt: Instant?,
+) {
+    companion object {
+        fun from(dto: DocumentCommentDto): ReadDocumentCommentResponse = ReadDocumentCommentResponse(
+            commentId = dto.commentId,
+            sectionId = dto.sectionId,
+            content = dto.content,
+            author = ReadDocumentCommentAuthorResponse.from(dto.author),
+            createdAt = dto.createdAt,
+        )
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/document/application/domain/deadline/PartDocumentDeadlineController.kt
+++ b/src/main/kotlin/com/yourssu/scouter/document/application/domain/deadline/PartDocumentDeadlineController.kt
@@ -1,0 +1,38 @@
+package com.yourssu.scouter.document.application.domain.deadline
+
+import com.yourssu.scouter.document.business.domain.deadline.PartDocumentDeadlineService
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.validation.Valid
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RestController
+
+@Tag(name = "서류 평가 마감일")
+@RestController
+class PartDocumentDeadlineController(
+    private val partDocumentDeadlineService: PartDocumentDeadlineService,
+) {
+
+    @Operation(summary = "마감일 조회")
+    @GetMapping("/parts/{partId}/documents/deadline")
+    fun readByPartId(
+        @PathVariable partId: Long,
+    ): ResponseEntity<ReadDeadlineResponse> {
+        return ResponseEntity.ok(ReadDeadlineResponse.from(partDocumentDeadlineService.readByPartId(partId)))
+    }
+
+    @Operation(summary = "마감일 설정")
+    @PutMapping("/parts/{partId}/documents/deadline")
+    fun upsert(
+        @PathVariable partId: Long,
+        @RequestBody @Valid request: UpdateDeadlineRequest,
+    ): ResponseEntity<Unit> {
+        partDocumentDeadlineService.upsert(partId, request.deadline!!)
+
+        return ResponseEntity.ok().build()
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/document/application/domain/deadline/ReadDeadlineResponse.kt
+++ b/src/main/kotlin/com/yourssu/scouter/document/application/domain/deadline/ReadDeadlineResponse.kt
@@ -1,0 +1,12 @@
+package com.yourssu.scouter.document.application.domain.deadline
+
+import com.yourssu.scouter.document.business.domain.deadline.PartDocumentDeadlineDto
+import java.time.Instant
+
+data class ReadDeadlineResponse(
+    val deadline: Instant?,
+) {
+    companion object {
+        fun from(dto: PartDocumentDeadlineDto): ReadDeadlineResponse = ReadDeadlineResponse(dto.deadline)
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/document/application/domain/deadline/UpdateDeadlineRequest.kt
+++ b/src/main/kotlin/com/yourssu/scouter/document/application/domain/deadline/UpdateDeadlineRequest.kt
@@ -1,0 +1,10 @@
+package com.yourssu.scouter.document.application.domain.deadline
+
+import jakarta.validation.constraints.NotNull
+import java.time.Instant
+
+data class UpdateDeadlineRequest(
+
+    @field:NotNull
+    val deadline: Instant?,
+)

--- a/src/main/kotlin/com/yourssu/scouter/document/application/domain/evaluation/DocumentEvaluationController.kt
+++ b/src/main/kotlin/com/yourssu/scouter/document/application/domain/evaluation/DocumentEvaluationController.kt
@@ -1,0 +1,97 @@
+package com.yourssu.scouter.document.application.domain.evaluation
+
+import com.yourssu.scouter.ats.business.domain.applicant.ApplicantDto
+import com.yourssu.scouter.ats.business.domain.applicant.ApplicantPrivacyService
+import com.yourssu.scouter.ats.business.domain.applicant.ApplicantService
+import com.yourssu.scouter.ats.business.support.exception.ApplicantAccessDeniedException
+import com.yourssu.scouter.common.application.support.authentication.AuthUser
+import com.yourssu.scouter.common.application.support.authentication.AuthUserInfo
+import com.yourssu.scouter.document.business.domain.evaluation.DocumentEvaluationService
+import com.yourssu.scouter.document.business.domain.evaluation.DocumentEvaluationViewService
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.validation.Valid
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RestController
+
+@Tag(name = "서류 평가")
+@RestController
+class DocumentEvaluationController(
+    private val documentEvaluationService: DocumentEvaluationService,
+    private val documentEvaluationViewService: DocumentEvaluationViewService,
+    private val applicantService: ApplicantService,
+    private val applicantPrivacyService: ApplicantPrivacyService,
+) {
+
+    @Operation(summary = "서류 평가 조회 (본인)")
+    @GetMapping("/applicants/{applicantId}/documents/evaluations")
+    fun readMy(
+        @AuthUser authUserInfo: AuthUserInfo,
+        @PathVariable applicantId: Long,
+    ): ResponseEntity<ReadDocumentEvaluationResponse> {
+        requireAccessible(applicantId, authUserInfo.userId)
+
+        return ResponseEntity.ok(ReadDocumentEvaluationResponse.from(documentEvaluationService.readMy(applicantId, authUserInfo.userId)))
+    }
+
+    @Operation(summary = "서류 평가 저장/수정")
+    @PutMapping("/applicants/{applicantId}/documents/evaluations")
+    fun save(
+        @AuthUser authUserInfo: AuthUserInfo,
+        @PathVariable applicantId: Long,
+        @RequestBody @Valid request: SaveDocumentEvaluationRequest,
+    ): ResponseEntity<Unit> {
+        requireAccessible(applicantId, authUserInfo.userId)
+        documentEvaluationService.save(request.toCommand(applicantId, authUserInfo.userId))
+
+        return ResponseEntity.ok().build()
+    }
+
+    @Operation(summary = "다른 평가자 서류 평가 조회")
+    @GetMapping("/applicants/{applicantId}/documents/evaluations/others")
+    fun readOthers(
+        @AuthUser authUserInfo: AuthUserInfo,
+        @PathVariable applicantId: Long,
+    ): ResponseEntity<List<ReadOtherDocumentEvaluationResponse>> {
+        requireAccessible(applicantId, authUserInfo.userId)
+        val others = documentEvaluationService.readOthers(applicantId, authUserInfo.userId)
+
+        return ResponseEntity.ok(others.map(ReadOtherDocumentEvaluationResponse::from))
+    }
+
+    @Operation(summary = "서류 평가자 상태 목록 조회")
+    @GetMapping("/applicants/{applicantId}/documents/evaluations/status")
+    fun readStatuses(
+        @AuthUser authUserInfo: AuthUserInfo,
+        @PathVariable applicantId: Long,
+    ): ResponseEntity<List<ReadEvaluatorStatusResponse>> {
+        requireAccessible(applicantId, authUserInfo.userId)
+        val statuses = documentEvaluationService.readStatuses(applicantId)
+
+        return ResponseEntity.ok(statuses.map(ReadEvaluatorStatusResponse::from))
+    }
+
+    @Operation(summary = "서류 평가 화면 통합 조회")
+    @GetMapping("/applicants/{applicantId}/documents/evaluation-view")
+    fun readEvaluationView(
+        @AuthUser authUserInfo: AuthUserInfo,
+        @PathVariable applicantId: Long,
+    ): ResponseEntity<ReadEvaluationViewResponse> {
+        requireAccessible(applicantId, authUserInfo.userId)
+        val view = documentEvaluationViewService.read(applicantId, authUserInfo.userId)
+
+        return ResponseEntity.ok(ReadEvaluationViewResponse.from(view))
+    }
+
+    private fun requireAccessible(applicantId: Long, userId: Long) {
+        val applicantDto: ApplicantDto = applicantService.readById(applicantId)
+        val accessible = applicantPrivacyService.filterAccessibleApplicants(userId, listOf(applicantDto))
+        if (accessible.isEmpty()) {
+            throw ApplicantAccessDeniedException("해당 지원자의 정보를 조회할 권한이 없습니다.")
+        }
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/document/application/domain/evaluation/ReadDocumentEvaluationResponse.kt
+++ b/src/main/kotlin/com/yourssu/scouter/document/application/domain/evaluation/ReadDocumentEvaluationResponse.kt
@@ -1,0 +1,42 @@
+package com.yourssu.scouter.document.application.domain.evaluation
+
+import com.yourssu.scouter.document.business.domain.evaluation.DocumentEvaluationDto
+import com.yourssu.scouter.document.business.domain.evaluation.DocumentEvaluationItemDto
+import com.yourssu.scouter.document.implement.domain.evaluation.DocumentResult
+import java.time.Instant
+
+data class ReadDocumentEvaluationItemResponse(
+    val sectionId: Long,
+    val question: String,
+    val maxScore: Int,
+    val score: Int,
+    val memo: String,
+) {
+    companion object {
+        fun from(dto: DocumentEvaluationItemDto): ReadDocumentEvaluationItemResponse = ReadDocumentEvaluationItemResponse(
+            sectionId = dto.sectionId,
+            question = dto.question,
+            maxScore = dto.maxScore,
+            score = dto.score,
+            memo = dto.memo,
+        )
+    }
+}
+
+data class ReadDocumentEvaluationResponse(
+    val totalScore: Int,
+    val items: List<ReadDocumentEvaluationItemResponse>,
+    val overallComment: String,
+    val result: DocumentResult,
+    val submittedAt: Instant?,
+) {
+    companion object {
+        fun from(dto: DocumentEvaluationDto): ReadDocumentEvaluationResponse = ReadDocumentEvaluationResponse(
+            totalScore = dto.totalScore,
+            items = dto.items.map(ReadDocumentEvaluationItemResponse::from),
+            overallComment = dto.overallComment,
+            result = dto.result,
+            submittedAt = dto.submittedAt,
+        )
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/document/application/domain/evaluation/ReadEvaluationViewResponse.kt
+++ b/src/main/kotlin/com/yourssu/scouter/document/application/domain/evaluation/ReadEvaluationViewResponse.kt
@@ -1,0 +1,23 @@
+package com.yourssu.scouter.document.application.domain.evaluation
+
+import com.yourssu.scouter.ats.application.domain.applicant.ReadApplicantAnswerResponse
+import com.yourssu.scouter.document.application.domain.comment.ReadDocumentCommentResponse
+import com.yourssu.scouter.document.business.domain.evaluation.DocumentEvaluationViewDto
+
+data class ReadEvaluationViewResponse(
+    val answers: List<ReadApplicantAnswerResponse>,
+    val myEvaluation: ReadDocumentEvaluationResponse,
+    val others: List<ReadOtherDocumentEvaluationResponse>,
+    val comments: List<ReadDocumentCommentResponse>,
+    val evaluatorStatuses: List<ReadEvaluatorStatusResponse>,
+) {
+    companion object {
+        fun from(dto: DocumentEvaluationViewDto): ReadEvaluationViewResponse = ReadEvaluationViewResponse(
+            answers = dto.answers.map(ReadApplicantAnswerResponse::from),
+            myEvaluation = ReadDocumentEvaluationResponse.from(dto.myEvaluation),
+            others = dto.others.map(ReadOtherDocumentEvaluationResponse::from),
+            comments = dto.comments.map(ReadDocumentCommentResponse::from),
+            evaluatorStatuses = dto.evaluatorStatuses.map(ReadEvaluatorStatusResponse::from),
+        )
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/document/application/domain/evaluation/ReadEvaluatorStatusResponse.kt
+++ b/src/main/kotlin/com/yourssu/scouter/document/application/domain/evaluation/ReadEvaluatorStatusResponse.kt
@@ -1,0 +1,15 @@
+package com.yourssu.scouter.document.application.domain.evaluation
+
+import com.yourssu.scouter.document.business.domain.evaluation.EvaluatorStatusDto
+import com.yourssu.scouter.document.implement.domain.evaluation.EvaluationStatus
+
+data class ReadEvaluatorStatusResponse(
+    val userId: Long,
+    val name: String,
+    val status: EvaluationStatus,
+) {
+    companion object {
+        fun from(dto: EvaluatorStatusDto): ReadEvaluatorStatusResponse =
+            ReadEvaluatorStatusResponse(dto.userId, dto.name, dto.status)
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/document/application/domain/evaluation/ReadOtherDocumentEvaluationResponse.kt
+++ b/src/main/kotlin/com/yourssu/scouter/document/application/domain/evaluation/ReadOtherDocumentEvaluationResponse.kt
@@ -1,0 +1,36 @@
+package com.yourssu.scouter.document.application.domain.evaluation
+
+import com.yourssu.scouter.document.business.domain.evaluation.OtherDocumentEvaluationDto
+import com.yourssu.scouter.document.business.domain.evaluation.OtherDocumentEvaluationItemDto
+import com.yourssu.scouter.document.implement.domain.evaluation.DocumentResult
+
+data class ReadOtherDocumentEvaluationItemResponse(
+    val sectionId: Long,
+    val score: Int,
+    val memo: String,
+) {
+    companion object {
+        fun from(dto: OtherDocumentEvaluationItemDto): ReadOtherDocumentEvaluationItemResponse =
+            ReadOtherDocumentEvaluationItemResponse(dto.sectionId, dto.score, dto.memo)
+    }
+}
+
+data class ReadOtherDocumentEvaluationResponse(
+    val evaluatorId: Long,
+    val evaluatorName: String,
+    val totalScore: Int,
+    val result: DocumentResult,
+    val overallComment: String,
+    val items: List<ReadOtherDocumentEvaluationItemResponse>,
+) {
+    companion object {
+        fun from(dto: OtherDocumentEvaluationDto): ReadOtherDocumentEvaluationResponse = ReadOtherDocumentEvaluationResponse(
+            evaluatorId = dto.evaluatorId,
+            evaluatorName = dto.evaluatorName,
+            totalScore = dto.totalScore,
+            result = dto.result,
+            overallComment = dto.overallComment,
+            items = dto.items.map(ReadOtherDocumentEvaluationItemResponse::from),
+        )
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/document/application/domain/evaluation/SaveDocumentEvaluationRequest.kt
+++ b/src/main/kotlin/com/yourssu/scouter/document/application/domain/evaluation/SaveDocumentEvaluationRequest.kt
@@ -1,0 +1,45 @@
+package com.yourssu.scouter.document.application.domain.evaluation
+
+import com.yourssu.scouter.document.business.domain.evaluation.SaveDocumentEvaluationCommand
+import com.yourssu.scouter.document.business.domain.evaluation.SaveDocumentEvaluationItemCommand
+import com.yourssu.scouter.document.implement.domain.evaluation.DocumentResult
+import jakarta.validation.constraints.NotNull
+
+data class SaveDocumentEvaluationItemRequest(
+
+    @field:NotNull
+    val sectionId: Long?,
+
+    @field:NotNull
+    val score: Int?,
+
+    val memo: String = "",
+) {
+    fun toCommand(): SaveDocumentEvaluationItemCommand = SaveDocumentEvaluationItemCommand(
+        sectionId = sectionId!!,
+        score = score!!,
+        memo = memo,
+    )
+}
+
+data class SaveDocumentEvaluationRequest(
+
+    val items: List<SaveDocumentEvaluationItemRequest> = emptyList(),
+
+    val overallComment: String = "",
+
+    @field:NotNull
+    val result: DocumentResult?,
+
+    @field:NotNull
+    val submit: Boolean?,
+) {
+    fun toCommand(applicantId: Long, evaluatorUserId: Long): SaveDocumentEvaluationCommand = SaveDocumentEvaluationCommand(
+        applicantId = applicantId,
+        evaluatorUserId = evaluatorUserId,
+        items = items.map { it.toCommand() },
+        overallComment = overallComment,
+        result = result!!,
+        submit = submit!!,
+    )
+}

--- a/src/main/kotlin/com/yourssu/scouter/document/application/domain/rubric/DocumentRubricController.kt
+++ b/src/main/kotlin/com/yourssu/scouter/document/application/domain/rubric/DocumentRubricController.kt
@@ -1,0 +1,40 @@
+package com.yourssu.scouter.document.application.domain.rubric
+
+import com.yourssu.scouter.document.business.domain.rubric.DocumentSectionService
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.validation.Valid
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RestController
+
+@Tag(name = "서류 평가 문항")
+@RestController
+class DocumentRubricController(
+    private val documentSectionService: DocumentSectionService,
+) {
+
+    @Operation(summary = "서류 평가 문항 조회")
+    @GetMapping("/parts/{partId}/documents/rubrics")
+    fun readByPartId(
+        @PathVariable partId: Long,
+    ): ResponseEntity<List<ReadRubricResponse>> {
+        val sections = documentSectionService.readByPartId(partId)
+
+        return ResponseEntity.ok(sections.map(ReadRubricResponse::from))
+    }
+
+    @Operation(summary = "서류 평가 문항 수정", description = "배점과 평가 지표만 수정합니다. 배점 합계는 100이어야 합니다.")
+    @PutMapping("/parts/{partId}/documents/rubrics")
+    fun updateRubrics(
+        @PathVariable partId: Long,
+        @RequestBody @Valid requests: List<UpdateRubricRequest>,
+    ): ResponseEntity<Unit> {
+        documentSectionService.updateRubrics(partId, requests.map { it.toCommand() })
+
+        return ResponseEntity.ok().build()
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/document/application/domain/rubric/ReadRubricResponse.kt
+++ b/src/main/kotlin/com/yourssu/scouter/document/application/domain/rubric/ReadRubricResponse.kt
@@ -1,0 +1,19 @@
+package com.yourssu.scouter.document.application.domain.rubric
+
+import com.yourssu.scouter.document.business.domain.rubric.DocumentSectionDto
+
+data class ReadRubricResponse(
+    val sectionId: Long,
+    val question: String,
+    val maxScore: Int,
+    val criterionDetail: String,
+) {
+    companion object {
+        fun from(dto: DocumentSectionDto): ReadRubricResponse = ReadRubricResponse(
+            sectionId = dto.sectionId,
+            question = dto.question,
+            maxScore = dto.maxScore,
+            criterionDetail = dto.criterionDetail,
+        )
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/document/application/domain/rubric/UpdateRubricRequest.kt
+++ b/src/main/kotlin/com/yourssu/scouter/document/application/domain/rubric/UpdateRubricRequest.kt
@@ -1,0 +1,22 @@
+package com.yourssu.scouter.document.application.domain.rubric
+
+import com.yourssu.scouter.document.business.domain.rubric.UpdateRubricItemCommand
+import jakarta.validation.constraints.NotNull
+
+data class UpdateRubricRequest(
+
+    @field:NotNull
+    val sectionId: Long?,
+
+    @field:NotNull
+    val maxScore: Int?,
+
+    @field:NotNull
+    val criterionDetail: String?,
+) {
+    fun toCommand(): UpdateRubricItemCommand = UpdateRubricItemCommand(
+        sectionId = sectionId!!,
+        maxScore = maxScore!!,
+        criterionDetail = criterionDetail!!,
+    )
+}

--- a/src/main/kotlin/com/yourssu/scouter/document/business/domain/comment/CreateDocumentCommentCommand.kt
+++ b/src/main/kotlin/com/yourssu/scouter/document/business/domain/comment/CreateDocumentCommentCommand.kt
@@ -1,0 +1,8 @@
+package com.yourssu.scouter.document.business.domain.comment
+
+data class CreateDocumentCommentCommand(
+    val applicantId: Long,
+    val sectionId: Long,
+    val authorUserId: Long,
+    val content: String,
+)

--- a/src/main/kotlin/com/yourssu/scouter/document/business/domain/comment/DocumentCommentDto.kt
+++ b/src/main/kotlin/com/yourssu/scouter/document/business/domain/comment/DocumentCommentDto.kt
@@ -1,0 +1,28 @@
+package com.yourssu.scouter.document.business.domain.comment
+
+import com.yourssu.scouter.document.implement.domain.comment.DocumentComment
+import java.time.Instant
+
+data class DocumentCommentAuthorDto(
+    val userId: Long,
+    val nickname: String,
+    val part: String,
+)
+
+data class DocumentCommentDto(
+    val commentId: Long,
+    val sectionId: Long,
+    val content: String,
+    val author: DocumentCommentAuthorDto,
+    val createdAt: Instant?,
+) {
+    companion object {
+        fun of(comment: DocumentComment, author: DocumentCommentAuthorDto): DocumentCommentDto = DocumentCommentDto(
+            commentId = comment.id!!,
+            sectionId = comment.sectionId,
+            content = comment.content,
+            author = author,
+            createdAt = comment.createdAt,
+        )
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/document/business/domain/comment/DocumentCommentService.kt
+++ b/src/main/kotlin/com/yourssu/scouter/document/business/domain/comment/DocumentCommentService.kt
@@ -1,0 +1,78 @@
+package com.yourssu.scouter.document.business.domain.comment
+
+import com.yourssu.scouter.ats.implement.domain.applicant.ApplicantReader
+import com.yourssu.scouter.common.implement.domain.user.User
+import com.yourssu.scouter.common.implement.domain.user.UserReader
+import com.yourssu.scouter.document.implement.domain.comment.DocumentComment
+import com.yourssu.scouter.document.implement.domain.comment.DocumentCommentReader
+import com.yourssu.scouter.document.implement.domain.comment.DocumentCommentWriter
+import com.yourssu.scouter.document.implement.domain.rubric.DocumentSectionReader
+import com.yourssu.scouter.document.implement.support.exception.DocumentCommentAccessDeniedException
+import com.yourssu.scouter.document.implement.support.exception.DocumentSectionNotFoundException
+import com.yourssu.scouter.hrms.implement.domain.member.MemberReader
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class DocumentCommentService(
+    private val documentCommentReader: DocumentCommentReader,
+    private val documentCommentWriter: DocumentCommentWriter,
+    private val documentSectionReader: DocumentSectionReader,
+    private val applicantReader: ApplicantReader,
+    private val userReader: UserReader,
+    private val memberReader: MemberReader,
+) {
+
+    @Transactional
+    fun create(command: CreateDocumentCommentCommand): DocumentCommentDto {
+        require(command.content.isNotBlank()) { "코멘트 내용은 비어있을 수 없습니다." }
+
+        val applicant = applicantReader.readById(command.applicantId)
+        val sectionExists = documentSectionReader.readAllByPartId(applicant.part.id!!)
+            .any { it.id == command.sectionId }
+        if (!sectionExists) {
+            throw DocumentSectionNotFoundException("해당 파트에 존재하지 않는 문항입니다: ${command.sectionId}")
+        }
+
+        val saved = documentCommentWriter.write(
+            DocumentComment(
+                applicantId = command.applicantId,
+                sectionId = command.sectionId,
+                authorUserId = command.authorUserId,
+                content = command.content,
+            ),
+        )
+
+        return DocumentCommentDto.of(saved, toAuthorDto(command.authorUserId))
+    }
+
+    fun readAllByApplicantId(applicantId: Long): List<DocumentCommentDto> {
+        applicantReader.readById(applicantId)
+
+        val comments = documentCommentReader.readAllByApplicantId(applicantId)
+        val authors = comments.map { it.authorUserId }.distinct().associateWith { toAuthorDto(it) }
+
+        return comments.map { comment -> DocumentCommentDto.of(comment, authors.getValue(comment.authorUserId)) }
+    }
+
+    @Transactional
+    fun deleteById(commentId: Long, requesterUserId: Long) {
+        val comment = documentCommentReader.readById(commentId)
+        if (comment.authorUserId != requesterUserId) {
+            throw DocumentCommentAccessDeniedException("본인이 작성한 코멘트만 삭제할 수 있습니다.")
+        }
+
+        documentCommentWriter.delete(commentId)
+    }
+
+    private fun toAuthorDto(userId: Long): DocumentCommentAuthorDto {
+        val user: User = userReader.readById(userId)
+        val member = memberReader.readAllActive().find { it.member.email == user.userInfo.email }
+
+        return DocumentCommentAuthorDto(
+            userId = userId,
+            nickname = member?.member?.nicknameEnglish ?: user.userInfo.name,
+            part = member?.member?.parts?.firstOrNull()?.name ?: "",
+        )
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/document/business/domain/deadline/PartDocumentDeadlineDto.kt
+++ b/src/main/kotlin/com/yourssu/scouter/document/business/domain/deadline/PartDocumentDeadlineDto.kt
@@ -1,0 +1,12 @@
+package com.yourssu.scouter.document.business.domain.deadline
+
+import com.yourssu.scouter.document.implement.domain.deadline.PartDocumentDeadline
+import java.time.Instant
+
+data class PartDocumentDeadlineDto(
+    val deadline: Instant?,
+) {
+    companion object {
+        fun from(deadline: PartDocumentDeadline?): PartDocumentDeadlineDto = PartDocumentDeadlineDto(deadline?.deadline)
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/document/business/domain/deadline/PartDocumentDeadlineService.kt
+++ b/src/main/kotlin/com/yourssu/scouter/document/business/domain/deadline/PartDocumentDeadlineService.kt
@@ -1,0 +1,30 @@
+package com.yourssu.scouter.document.business.domain.deadline
+
+import com.yourssu.scouter.common.implement.domain.part.PartReader
+import com.yourssu.scouter.document.implement.domain.deadline.PartDocumentDeadline
+import com.yourssu.scouter.document.implement.domain.deadline.PartDocumentDeadlineReader
+import com.yourssu.scouter.document.implement.domain.deadline.PartDocumentDeadlineWriter
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.Instant
+
+@Service
+class PartDocumentDeadlineService(
+    private val partDocumentDeadlineReader: PartDocumentDeadlineReader,
+    private val partDocumentDeadlineWriter: PartDocumentDeadlineWriter,
+    private val partReader: PartReader,
+) {
+
+    fun readByPartId(partId: Long): PartDocumentDeadlineDto {
+        partReader.readById(partId)
+
+        return PartDocumentDeadlineDto.from(partDocumentDeadlineReader.readByPartId(partId))
+    }
+
+    @Transactional
+    fun upsert(partId: Long, deadline: Instant) {
+        partReader.readById(partId)
+
+        partDocumentDeadlineWriter.upsert(PartDocumentDeadline(partId, deadline))
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/document/business/domain/evaluation/DocumentEvaluationDto.kt
+++ b/src/main/kotlin/com/yourssu/scouter/document/business/domain/evaluation/DocumentEvaluationDto.kt
@@ -1,0 +1,12 @@
+package com.yourssu.scouter.document.business.domain.evaluation
+
+import com.yourssu.scouter.document.implement.domain.evaluation.DocumentResult
+import java.time.Instant
+
+data class DocumentEvaluationDto(
+    val totalScore: Int,
+    val items: List<DocumentEvaluationItemDto>,
+    val overallComment: String,
+    val result: DocumentResult,
+    val submittedAt: Instant?,
+)

--- a/src/main/kotlin/com/yourssu/scouter/document/business/domain/evaluation/DocumentEvaluationItemDto.kt
+++ b/src/main/kotlin/com/yourssu/scouter/document/business/domain/evaluation/DocumentEvaluationItemDto.kt
@@ -1,0 +1,9 @@
+package com.yourssu.scouter.document.business.domain.evaluation
+
+data class DocumentEvaluationItemDto(
+    val sectionId: Long,
+    val question: String,
+    val maxScore: Int,
+    val score: Int,
+    val memo: String,
+)

--- a/src/main/kotlin/com/yourssu/scouter/document/business/domain/evaluation/DocumentEvaluationService.kt
+++ b/src/main/kotlin/com/yourssu/scouter/document/business/domain/evaluation/DocumentEvaluationService.kt
@@ -1,0 +1,149 @@
+package com.yourssu.scouter.document.business.domain.evaluation
+
+import com.yourssu.scouter.ats.implement.domain.applicant.Applicant
+import com.yourssu.scouter.ats.implement.domain.applicant.ApplicantReader
+import com.yourssu.scouter.common.implement.domain.user.User
+import com.yourssu.scouter.common.implement.domain.user.UserReader
+import com.yourssu.scouter.document.implement.domain.evaluation.DocumentEvaluation
+import com.yourssu.scouter.document.implement.domain.evaluation.DocumentEvaluationItem
+import com.yourssu.scouter.document.implement.domain.evaluation.DocumentEvaluationReader
+import com.yourssu.scouter.document.implement.domain.evaluation.DocumentEvaluationWriter
+import com.yourssu.scouter.document.implement.domain.evaluation.DocumentResult
+import com.yourssu.scouter.document.implement.domain.evaluation.EvaluationStatus
+import com.yourssu.scouter.document.implement.domain.rubric.DocumentSection
+import com.yourssu.scouter.document.implement.domain.rubric.DocumentSectionReader
+import com.yourssu.scouter.document.implement.support.exception.DocumentEvaluationInvalidScoreException
+import com.yourssu.scouter.document.implement.support.exception.DocumentSectionNotFoundException
+import com.yourssu.scouter.hrms.implement.domain.member.ActiveMember
+import com.yourssu.scouter.hrms.implement.domain.member.MemberReader
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.Instant
+
+@Service
+class DocumentEvaluationService(
+    private val documentEvaluationReader: DocumentEvaluationReader,
+    private val documentEvaluationWriter: DocumentEvaluationWriter,
+    private val documentSectionReader: DocumentSectionReader,
+    private val applicantReader: ApplicantReader,
+    private val userReader: UserReader,
+    private val memberReader: MemberReader,
+) {
+
+    fun readMy(applicantId: Long, evaluatorUserId: Long): DocumentEvaluationDto {
+        val applicant = applicantReader.readById(applicantId)
+        val sections = documentSectionReader.readAllByPartId(applicant.part.id!!).associateBy { it.id }
+        val evaluation = documentEvaluationReader.readByApplicantIdAndEvaluatorUserId(applicantId, evaluatorUserId)
+            ?: return DocumentEvaluationDto(
+                totalScore = 0,
+                items = emptyList(),
+                overallComment = "",
+                result = DocumentResult.PENDING,
+                submittedAt = null,
+            )
+
+        return toDto(evaluation, sections)
+    }
+
+    @Transactional
+    fun save(command: SaveDocumentEvaluationCommand) {
+        val applicant: Applicant = applicantReader.readById(command.applicantId)
+        val sections = documentSectionReader.readAllByPartId(applicant.part.id!!).associateBy { it.id }
+
+        val items = command.items.map { item ->
+            val section = sections[item.sectionId]
+                ?: throw DocumentSectionNotFoundException("해당 파트에 존재하지 않는 문항입니다: ${item.sectionId}")
+            if (item.score > section.maxScore) {
+                throw DocumentEvaluationInvalidScoreException("점수는 배점(${section.maxScore})을 초과할 수 없습니다.")
+            }
+
+            DocumentEvaluationItem(sectionId = item.sectionId, score = item.score, memo = item.memo)
+        }
+
+        val existing = documentEvaluationReader
+            .readByApplicantIdAndEvaluatorUserId(command.applicantId, command.evaluatorUserId)
+
+        val evaluation = DocumentEvaluation(
+            id = existing?.id,
+            applicantId = command.applicantId,
+            evaluatorUserId = command.evaluatorUserId,
+            items = items,
+            overallComment = command.overallComment,
+            result = command.result,
+            submittedAt = if (command.submit) Instant.now() else existing?.submittedAt,
+        )
+
+        documentEvaluationWriter.write(evaluation)
+    }
+
+    fun readOthers(applicantId: Long, viewerUserId: Long): List<OtherDocumentEvaluationDto> {
+        val applicant = applicantReader.readById(applicantId)
+        val evaluations = documentEvaluationReader.readAllByApplicantId(applicantId)
+            .filter { it.isSubmitted() && it.evaluatorUserId != viewerUserId }
+
+        val viewerHasSubmitted = documentEvaluationReader
+            .readByApplicantIdAndEvaluatorUserId(applicantId, viewerUserId)?.isSubmitted() ?: false
+
+        val evaluators = userReader.readAllByIds(evaluations.map { it.evaluatorUserId }).associateBy { it.id }
+
+        return evaluations.map { evaluation ->
+            val masked = evaluation.maskedFor(viewerHasSubmitted)
+            val evaluator: User? = evaluators[evaluation.evaluatorUserId]
+            OtherDocumentEvaluationDto(
+                evaluatorId = evaluation.evaluatorUserId,
+                evaluatorName = evaluator?.userInfo?.name ?: "",
+                totalScore = evaluation.totalScore(),
+                result = evaluation.result,
+                overallComment = masked.overallComment,
+                items = masked.items.map { OtherDocumentEvaluationItemDto(it.sectionId, it.score, it.memo) },
+            )
+        }
+    }
+
+    fun readStatuses(applicantId: Long): List<EvaluatorStatusDto> {
+        val applicant = applicantReader.readById(applicantId)
+        val partId = applicant.part.id!!
+
+        val activeMembers: List<ActiveMember> = memberReader.readAllActive()
+            .filter { activeMember -> activeMember.member.parts.any { it.id == partId } }
+        val usersByEmail: Map<String, User> = userReader
+            .readAllByEmails(activeMembers.map { it.member.email })
+            .associateBy { it.userInfo.email }
+
+        val evaluationsByEvaluator = documentEvaluationReader.readAllByApplicantId(applicantId)
+            .associateBy { it.evaluatorUserId }
+
+        return activeMembers.mapNotNull { activeMember ->
+            val user = usersByEmail[activeMember.member.email] ?: return@mapNotNull null
+            val evaluation = evaluationsByEvaluator[user.id]
+            val status = when {
+                evaluation == null -> EvaluationStatus.NOT_STARTED
+                evaluation.isSubmitted() -> EvaluationStatus.SUBMITTED
+                else -> EvaluationStatus.IN_PROGRESS
+            }
+
+            EvaluatorStatusDto(userId = user.id!!, name = activeMember.member.name, status = status)
+        }
+    }
+
+    private fun toDto(evaluation: DocumentEvaluation, sections: Map<Long?, DocumentSection>): DocumentEvaluationDto {
+        val items = evaluation.items.map { item ->
+            val section = sections[item.sectionId]
+            DocumentEvaluationItemDto(
+                sectionId = item.sectionId,
+                question = section?.question ?: "",
+                maxScore = section?.maxScore ?: 0,
+                score = item.score,
+                memo = item.memo,
+            )
+        }
+
+        return DocumentEvaluationDto(
+            totalScore = evaluation.totalScore(),
+            items = items,
+            overallComment = evaluation.overallComment,
+            result = evaluation.result,
+            submittedAt = evaluation.submittedAt,
+        )
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/document/business/domain/evaluation/DocumentEvaluationViewDto.kt
+++ b/src/main/kotlin/com/yourssu/scouter/document/business/domain/evaluation/DocumentEvaluationViewDto.kt
@@ -1,0 +1,12 @@
+package com.yourssu.scouter.document.business.domain.evaluation
+
+import com.yourssu.scouter.ats.business.domain.applicant.ApplicantAnswerDto
+import com.yourssu.scouter.document.business.domain.comment.DocumentCommentDto
+
+data class DocumentEvaluationViewDto(
+    val answers: List<ApplicantAnswerDto>,
+    val myEvaluation: DocumentEvaluationDto,
+    val others: List<OtherDocumentEvaluationDto>,
+    val comments: List<DocumentCommentDto>,
+    val evaluatorStatuses: List<EvaluatorStatusDto>,
+)

--- a/src/main/kotlin/com/yourssu/scouter/document/business/domain/evaluation/DocumentEvaluationViewService.kt
+++ b/src/main/kotlin/com/yourssu/scouter/document/business/domain/evaluation/DocumentEvaluationViewService.kt
@@ -1,0 +1,23 @@
+package com.yourssu.scouter.document.business.domain.evaluation
+
+import com.yourssu.scouter.ats.business.domain.applicant.ApplicantService
+import com.yourssu.scouter.document.business.domain.comment.DocumentCommentService
+import org.springframework.stereotype.Service
+
+@Service
+class DocumentEvaluationViewService(
+    private val applicantService: ApplicantService,
+    private val documentEvaluationService: DocumentEvaluationService,
+    private val documentCommentService: DocumentCommentService,
+) {
+
+    fun read(applicantId: Long, viewerUserId: Long): DocumentEvaluationViewDto {
+        return DocumentEvaluationViewDto(
+            answers = applicantService.readAnswersByApplicantId(applicantId),
+            myEvaluation = documentEvaluationService.readMy(applicantId, viewerUserId),
+            others = documentEvaluationService.readOthers(applicantId, viewerUserId),
+            comments = documentCommentService.readAllByApplicantId(applicantId),
+            evaluatorStatuses = documentEvaluationService.readStatuses(applicantId),
+        )
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/document/business/domain/evaluation/EvaluatorStatusDto.kt
+++ b/src/main/kotlin/com/yourssu/scouter/document/business/domain/evaluation/EvaluatorStatusDto.kt
@@ -1,0 +1,9 @@
+package com.yourssu.scouter.document.business.domain.evaluation
+
+import com.yourssu.scouter.document.implement.domain.evaluation.EvaluationStatus
+
+data class EvaluatorStatusDto(
+    val userId: Long,
+    val name: String,
+    val status: EvaluationStatus,
+)

--- a/src/main/kotlin/com/yourssu/scouter/document/business/domain/evaluation/OtherDocumentEvaluationDto.kt
+++ b/src/main/kotlin/com/yourssu/scouter/document/business/domain/evaluation/OtherDocumentEvaluationDto.kt
@@ -1,0 +1,18 @@
+package com.yourssu.scouter.document.business.domain.evaluation
+
+import com.yourssu.scouter.document.implement.domain.evaluation.DocumentResult
+
+data class OtherDocumentEvaluationItemDto(
+    val sectionId: Long,
+    val score: Int,
+    val memo: String,
+)
+
+data class OtherDocumentEvaluationDto(
+    val evaluatorId: Long,
+    val evaluatorName: String,
+    val totalScore: Int,
+    val result: DocumentResult,
+    val overallComment: String,
+    val items: List<OtherDocumentEvaluationItemDto>,
+)

--- a/src/main/kotlin/com/yourssu/scouter/document/business/domain/evaluation/SaveDocumentEvaluationCommand.kt
+++ b/src/main/kotlin/com/yourssu/scouter/document/business/domain/evaluation/SaveDocumentEvaluationCommand.kt
@@ -1,0 +1,12 @@
+package com.yourssu.scouter.document.business.domain.evaluation
+
+import com.yourssu.scouter.document.implement.domain.evaluation.DocumentResult
+
+data class SaveDocumentEvaluationCommand(
+    val applicantId: Long,
+    val evaluatorUserId: Long,
+    val items: List<SaveDocumentEvaluationItemCommand>,
+    val overallComment: String,
+    val result: DocumentResult,
+    val submit: Boolean,
+)

--- a/src/main/kotlin/com/yourssu/scouter/document/business/domain/evaluation/SaveDocumentEvaluationItemCommand.kt
+++ b/src/main/kotlin/com/yourssu/scouter/document/business/domain/evaluation/SaveDocumentEvaluationItemCommand.kt
@@ -1,0 +1,7 @@
+package com.yourssu.scouter.document.business.domain.evaluation
+
+data class SaveDocumentEvaluationItemCommand(
+    val sectionId: Long,
+    val score: Int,
+    val memo: String,
+)

--- a/src/main/kotlin/com/yourssu/scouter/document/business/domain/rubric/DocumentSectionDto.kt
+++ b/src/main/kotlin/com/yourssu/scouter/document/business/domain/rubric/DocumentSectionDto.kt
@@ -1,0 +1,19 @@
+package com.yourssu.scouter.document.business.domain.rubric
+
+import com.yourssu.scouter.document.implement.domain.rubric.DocumentSection
+
+data class DocumentSectionDto(
+    val sectionId: Long,
+    val question: String,
+    val maxScore: Int,
+    val criterionDetail: String,
+) {
+    companion object {
+        fun from(documentSection: DocumentSection): DocumentSectionDto = DocumentSectionDto(
+            sectionId = documentSection.id!!,
+            question = documentSection.question,
+            maxScore = documentSection.maxScore,
+            criterionDetail = documentSection.criterionDetail,
+        )
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/document/business/domain/rubric/DocumentSectionService.kt
+++ b/src/main/kotlin/com/yourssu/scouter/document/business/domain/rubric/DocumentSectionService.kt
@@ -1,0 +1,56 @@
+package com.yourssu.scouter.document.business.domain.rubric
+
+import com.yourssu.scouter.common.implement.domain.part.PartReader
+import com.yourssu.scouter.document.implement.domain.evaluation.DocumentEvaluationReader
+import com.yourssu.scouter.document.implement.domain.rubric.DocumentSection
+import com.yourssu.scouter.document.implement.domain.rubric.DocumentSectionReader
+import com.yourssu.scouter.document.implement.domain.rubric.DocumentSectionWriter
+import com.yourssu.scouter.document.implement.support.exception.DocumentSectionNotFoundException
+import com.yourssu.scouter.document.implement.support.exception.RubricLockedException
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class DocumentSectionService(
+    private val documentSectionReader: DocumentSectionReader,
+    private val documentSectionWriter: DocumentSectionWriter,
+    private val documentEvaluationReader: DocumentEvaluationReader,
+    private val partReader: PartReader,
+) {
+
+    fun readByPartId(partId: Long): List<DocumentSectionDto> {
+        partReader.readById(partId)
+
+        return documentSectionReader.readAllByPartId(partId).map(DocumentSectionDto::from)
+    }
+
+    @Transactional
+    fun updateRubrics(partId: Long, items: List<UpdateRubricItemCommand>) {
+        partReader.readById(partId)
+        require(items.sumOf { it.maxScore } == 100) { "배점 합계는 100이어야 합니다." }
+
+        val partSections = documentSectionReader.readAllByPartId(partId).associateBy { it.id }
+        val sectionIds = items.map { it.sectionId }
+        sectionIds.forEach { sectionId ->
+            if (sectionId !in partSections) {
+                throw DocumentSectionNotFoundException("해당 파트에 존재하지 않는 문항입니다: $sectionId")
+            }
+        }
+
+        if (documentEvaluationReader.existsBySectionIdIn(sectionIds)) {
+            throw RubricLockedException("해당 문항을 참조하는 서류 평가가 존재해 수정할 수 없습니다.")
+        }
+
+        val updated = items.map { item ->
+            val section: DocumentSection = partSections.getValue(item.sectionId)
+            DocumentSection(
+                id = section.id,
+                partId = section.partId,
+                question = section.question,
+                maxScore = item.maxScore,
+                criterionDetail = item.criterionDetail,
+            )
+        }
+        documentSectionWriter.writeAll(updated)
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/document/business/domain/rubric/UpdateRubricItemCommand.kt
+++ b/src/main/kotlin/com/yourssu/scouter/document/business/domain/rubric/UpdateRubricItemCommand.kt
@@ -1,0 +1,7 @@
+package com.yourssu.scouter.document.business.domain.rubric
+
+data class UpdateRubricItemCommand(
+    val sectionId: Long,
+    val maxScore: Int,
+    val criterionDetail: String,
+)

--- a/src/main/kotlin/com/yourssu/scouter/document/implement/domain/comment/DocumentComment.kt
+++ b/src/main/kotlin/com/yourssu/scouter/document/implement/domain/comment/DocumentComment.kt
@@ -1,0 +1,26 @@
+package com.yourssu.scouter.document.implement.domain.comment
+
+import java.time.Instant
+
+class DocumentComment(
+    val id: Long? = null,
+    val applicantId: Long,
+    val sectionId: Long,
+    val authorUserId: Long,
+    val content: String,
+    val createdAt: Instant? = null,
+) {
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as DocumentComment
+
+        return id == other.id
+    }
+
+    override fun hashCode(): Int {
+        return id?.hashCode() ?: 0
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/document/implement/domain/comment/DocumentCommentReader.kt
+++ b/src/main/kotlin/com/yourssu/scouter/document/implement/domain/comment/DocumentCommentReader.kt
@@ -1,0 +1,21 @@
+package com.yourssu.scouter.document.implement.domain.comment
+
+import com.yourssu.scouter.document.implement.support.exception.DocumentCommentNotFoundException
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+
+@Component
+@Transactional(readOnly = true)
+class DocumentCommentReader(
+    private val documentCommentRepository: DocumentCommentRepository,
+) {
+
+    fun readAllByApplicantId(applicantId: Long): List<DocumentComment> {
+        return documentCommentRepository.findAllByApplicantId(applicantId)
+    }
+
+    fun readById(commentId: Long): DocumentComment {
+        return documentCommentRepository.findById(commentId)
+            ?: throw DocumentCommentNotFoundException("지정한 코멘트를 찾을 수 없습니다.")
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/document/implement/domain/comment/DocumentCommentRepository.kt
+++ b/src/main/kotlin/com/yourssu/scouter/document/implement/domain/comment/DocumentCommentRepository.kt
@@ -1,0 +1,12 @@
+package com.yourssu.scouter.document.implement.domain.comment
+
+interface DocumentCommentRepository {
+
+    fun save(comment: DocumentComment): DocumentComment
+
+    fun findAllByApplicantId(applicantId: Long): List<DocumentComment>
+
+    fun findById(commentId: Long): DocumentComment?
+
+    fun deleteById(commentId: Long)
+}

--- a/src/main/kotlin/com/yourssu/scouter/document/implement/domain/comment/DocumentCommentWriter.kt
+++ b/src/main/kotlin/com/yourssu/scouter/document/implement/domain/comment/DocumentCommentWriter.kt
@@ -1,0 +1,19 @@
+package com.yourssu.scouter.document.implement.domain.comment
+
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+
+@Component
+@Transactional
+class DocumentCommentWriter(
+    private val documentCommentRepository: DocumentCommentRepository,
+) {
+
+    fun write(comment: DocumentComment): DocumentComment {
+        return documentCommentRepository.save(comment)
+    }
+
+    fun delete(commentId: Long) {
+        documentCommentRepository.deleteById(commentId)
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/document/implement/domain/deadline/PartDocumentDeadline.kt
+++ b/src/main/kotlin/com/yourssu/scouter/document/implement/domain/deadline/PartDocumentDeadline.kt
@@ -1,0 +1,8 @@
+package com.yourssu.scouter.document.implement.domain.deadline
+
+import java.time.Instant
+
+class PartDocumentDeadline(
+    val partId: Long,
+    val deadline: Instant,
+)

--- a/src/main/kotlin/com/yourssu/scouter/document/implement/domain/deadline/PartDocumentDeadlineReader.kt
+++ b/src/main/kotlin/com/yourssu/scouter/document/implement/domain/deadline/PartDocumentDeadlineReader.kt
@@ -1,0 +1,15 @@
+package com.yourssu.scouter.document.implement.domain.deadline
+
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+
+@Component
+@Transactional(readOnly = true)
+class PartDocumentDeadlineReader(
+    private val partDocumentDeadlineRepository: PartDocumentDeadlineRepository,
+) {
+
+    fun readByPartId(partId: Long): PartDocumentDeadline? {
+        return partDocumentDeadlineRepository.findByPartId(partId)
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/document/implement/domain/deadline/PartDocumentDeadlineRepository.kt
+++ b/src/main/kotlin/com/yourssu/scouter/document/implement/domain/deadline/PartDocumentDeadlineRepository.kt
@@ -1,0 +1,8 @@
+package com.yourssu.scouter.document.implement.domain.deadline
+
+interface PartDocumentDeadlineRepository {
+
+    fun findByPartId(partId: Long): PartDocumentDeadline?
+
+    fun upsert(deadline: PartDocumentDeadline): PartDocumentDeadline
+}

--- a/src/main/kotlin/com/yourssu/scouter/document/implement/domain/deadline/PartDocumentDeadlineWriter.kt
+++ b/src/main/kotlin/com/yourssu/scouter/document/implement/domain/deadline/PartDocumentDeadlineWriter.kt
@@ -1,0 +1,15 @@
+package com.yourssu.scouter.document.implement.domain.deadline
+
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+
+@Component
+@Transactional
+class PartDocumentDeadlineWriter(
+    private val partDocumentDeadlineRepository: PartDocumentDeadlineRepository,
+) {
+
+    fun upsert(deadline: PartDocumentDeadline): PartDocumentDeadline {
+        return partDocumentDeadlineRepository.upsert(deadline)
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/document/implement/domain/evaluation/DocumentEvaluation.kt
+++ b/src/main/kotlin/com/yourssu/scouter/document/implement/domain/evaluation/DocumentEvaluation.kt
@@ -1,0 +1,48 @@
+package com.yourssu.scouter.document.implement.domain.evaluation
+
+import java.time.Instant
+
+class DocumentEvaluation(
+    val id: Long? = null,
+    val applicantId: Long,
+    val evaluatorUserId: Long,
+    val items: List<DocumentEvaluationItem>,
+    val overallComment: String,
+    val result: DocumentResult,
+    val submittedAt: Instant?,
+) {
+
+    fun totalScore(): Int = items.sumOf { it.score }
+
+    fun isSubmitted(): Boolean = submittedAt != null
+
+    // 조회자가 본인 평가를 제출하기 전이면 overallComment/items[].memo를 마스킹한다 [A5]
+    fun maskedFor(viewerHasSubmitted: Boolean): DocumentEvaluation {
+        if (viewerHasSubmitted) {
+            return this
+        }
+
+        return DocumentEvaluation(
+            id = id,
+            applicantId = applicantId,
+            evaluatorUserId = evaluatorUserId,
+            items = items.map { DocumentEvaluationItem(it.sectionId, it.score, "") },
+            overallComment = "",
+            result = result,
+            submittedAt = submittedAt,
+        )
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as DocumentEvaluation
+
+        return id == other.id
+    }
+
+    override fun hashCode(): Int {
+        return id?.hashCode() ?: 0
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/document/implement/domain/evaluation/DocumentEvaluationItem.kt
+++ b/src/main/kotlin/com/yourssu/scouter/document/implement/domain/evaluation/DocumentEvaluationItem.kt
@@ -1,0 +1,7 @@
+package com.yourssu.scouter.document.implement.domain.evaluation
+
+class DocumentEvaluationItem(
+    val sectionId: Long,
+    val score: Int,
+    val memo: String,
+)

--- a/src/main/kotlin/com/yourssu/scouter/document/implement/domain/evaluation/DocumentEvaluationReader.kt
+++ b/src/main/kotlin/com/yourssu/scouter/document/implement/domain/evaluation/DocumentEvaluationReader.kt
@@ -1,0 +1,23 @@
+package com.yourssu.scouter.document.implement.domain.evaluation
+
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+
+@Component
+@Transactional(readOnly = true)
+class DocumentEvaluationReader(
+    private val documentEvaluationRepository: DocumentEvaluationRepository,
+) {
+
+    fun readByApplicantIdAndEvaluatorUserId(applicantId: Long, evaluatorUserId: Long): DocumentEvaluation? {
+        return documentEvaluationRepository.findByApplicantIdAndEvaluatorUserId(applicantId, evaluatorUserId)
+    }
+
+    fun readAllByApplicantId(applicantId: Long): List<DocumentEvaluation> {
+        return documentEvaluationRepository.findAllByApplicantId(applicantId)
+    }
+
+    fun existsBySectionIdIn(sectionIds: List<Long>): Boolean {
+        return documentEvaluationRepository.existsBySectionIdIn(sectionIds)
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/document/implement/domain/evaluation/DocumentEvaluationRepository.kt
+++ b/src/main/kotlin/com/yourssu/scouter/document/implement/domain/evaluation/DocumentEvaluationRepository.kt
@@ -1,0 +1,12 @@
+package com.yourssu.scouter.document.implement.domain.evaluation
+
+interface DocumentEvaluationRepository {
+
+    fun save(evaluation: DocumentEvaluation): DocumentEvaluation
+
+    fun findByApplicantIdAndEvaluatorUserId(applicantId: Long, evaluatorUserId: Long): DocumentEvaluation?
+
+    fun findAllByApplicantId(applicantId: Long): List<DocumentEvaluation>
+
+    fun existsBySectionIdIn(sectionIds: List<Long>): Boolean
+}

--- a/src/main/kotlin/com/yourssu/scouter/document/implement/domain/evaluation/DocumentEvaluationWriter.kt
+++ b/src/main/kotlin/com/yourssu/scouter/document/implement/domain/evaluation/DocumentEvaluationWriter.kt
@@ -1,0 +1,15 @@
+package com.yourssu.scouter.document.implement.domain.evaluation
+
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+
+@Component
+@Transactional
+class DocumentEvaluationWriter(
+    private val documentEvaluationRepository: DocumentEvaluationRepository,
+) {
+
+    fun write(evaluation: DocumentEvaluation): DocumentEvaluation {
+        return documentEvaluationRepository.save(evaluation)
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/document/implement/domain/evaluation/DocumentResult.kt
+++ b/src/main/kotlin/com/yourssu/scouter/document/implement/domain/evaluation/DocumentResult.kt
@@ -1,0 +1,7 @@
+package com.yourssu.scouter.document.implement.domain.evaluation
+
+enum class DocumentResult {
+    PENDING,
+    DOCUMENT_PASS,
+    DOCUMENT_FAIL,
+}

--- a/src/main/kotlin/com/yourssu/scouter/document/implement/domain/evaluation/EvaluationStatus.kt
+++ b/src/main/kotlin/com/yourssu/scouter/document/implement/domain/evaluation/EvaluationStatus.kt
@@ -1,0 +1,7 @@
+package com.yourssu.scouter.document.implement.domain.evaluation
+
+enum class EvaluationStatus {
+    NOT_STARTED,
+    IN_PROGRESS,
+    SUBMITTED,
+}

--- a/src/main/kotlin/com/yourssu/scouter/document/implement/domain/rubric/DocumentSection.kt
+++ b/src/main/kotlin/com/yourssu/scouter/document/implement/domain/rubric/DocumentSection.kt
@@ -1,0 +1,23 @@
+package com.yourssu.scouter.document.implement.domain.rubric
+
+class DocumentSection(
+    val id: Long? = null,
+    val partId: Long,
+    val question: String,
+    val maxScore: Int,
+    val criterionDetail: String,
+) {
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as DocumentSection
+
+        return id == other.id
+    }
+
+    override fun hashCode(): Int {
+        return id?.hashCode() ?: 0
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/document/implement/domain/rubric/DocumentSectionReader.kt
+++ b/src/main/kotlin/com/yourssu/scouter/document/implement/domain/rubric/DocumentSectionReader.kt
@@ -1,0 +1,19 @@
+package com.yourssu.scouter.document.implement.domain.rubric
+
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+
+@Component
+@Transactional(readOnly = true)
+class DocumentSectionReader(
+    private val documentSectionRepository: DocumentSectionRepository,
+) {
+
+    fun readAllByPartId(partId: Long): List<DocumentSection> {
+        return documentSectionRepository.findAllByPartId(partId)
+    }
+
+    fun readAllByIdIn(sectionIds: List<Long>): List<DocumentSection> {
+        return documentSectionRepository.findAllByIdIn(sectionIds)
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/document/implement/domain/rubric/DocumentSectionRepository.kt
+++ b/src/main/kotlin/com/yourssu/scouter/document/implement/domain/rubric/DocumentSectionRepository.kt
@@ -1,0 +1,10 @@
+package com.yourssu.scouter.document.implement.domain.rubric
+
+interface DocumentSectionRepository {
+
+    fun findAllByPartId(partId: Long): List<DocumentSection>
+
+    fun findAllByIdIn(sectionIds: List<Long>): List<DocumentSection>
+
+    fun saveAll(sections: List<DocumentSection>): List<DocumentSection>
+}

--- a/src/main/kotlin/com/yourssu/scouter/document/implement/domain/rubric/DocumentSectionWriter.kt
+++ b/src/main/kotlin/com/yourssu/scouter/document/implement/domain/rubric/DocumentSectionWriter.kt
@@ -1,0 +1,15 @@
+package com.yourssu.scouter.document.implement.domain.rubric
+
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+
+@Component
+@Transactional
+class DocumentSectionWriter(
+    private val documentSectionRepository: DocumentSectionRepository,
+) {
+
+    fun writeAll(sections: List<DocumentSection>): List<DocumentSection> {
+        return documentSectionRepository.saveAll(sections)
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/document/implement/support/exception/DocumentCommentAccessDeniedException.kt
+++ b/src/main/kotlin/com/yourssu/scouter/document/implement/support/exception/DocumentCommentAccessDeniedException.kt
@@ -1,0 +1,8 @@
+package com.yourssu.scouter.document.implement.support.exception
+
+import com.yourssu.scouter.common.implement.support.exception.CustomException
+import org.springframework.http.HttpStatus
+
+class DocumentCommentAccessDeniedException(
+    message: String,
+) : CustomException(message, "DocumentComment-002", HttpStatus.FORBIDDEN)

--- a/src/main/kotlin/com/yourssu/scouter/document/implement/support/exception/DocumentCommentNotFoundException.kt
+++ b/src/main/kotlin/com/yourssu/scouter/document/implement/support/exception/DocumentCommentNotFoundException.kt
@@ -1,0 +1,8 @@
+package com.yourssu.scouter.document.implement.support.exception
+
+import com.yourssu.scouter.common.implement.support.exception.CustomException
+import org.springframework.http.HttpStatus
+
+class DocumentCommentNotFoundException(
+    message: String,
+) : CustomException(message, "DocumentComment-001", HttpStatus.NOT_FOUND)

--- a/src/main/kotlin/com/yourssu/scouter/document/implement/support/exception/DocumentEvaluationInvalidScoreException.kt
+++ b/src/main/kotlin/com/yourssu/scouter/document/implement/support/exception/DocumentEvaluationInvalidScoreException.kt
@@ -1,0 +1,8 @@
+package com.yourssu.scouter.document.implement.support.exception
+
+import com.yourssu.scouter.common.implement.support.exception.CustomException
+import org.springframework.http.HttpStatus
+
+class DocumentEvaluationInvalidScoreException(
+    message: String,
+) : CustomException(message, "DocumentEvaluation-001", HttpStatus.BAD_REQUEST)

--- a/src/main/kotlin/com/yourssu/scouter/document/implement/support/exception/DocumentSectionNotFoundException.kt
+++ b/src/main/kotlin/com/yourssu/scouter/document/implement/support/exception/DocumentSectionNotFoundException.kt
@@ -1,0 +1,8 @@
+package com.yourssu.scouter.document.implement.support.exception
+
+import com.yourssu.scouter.common.implement.support.exception.CustomException
+import org.springframework.http.HttpStatus
+
+class DocumentSectionNotFoundException(
+    message: String,
+) : CustomException(message, "DocumentSection-001", HttpStatus.NOT_FOUND)

--- a/src/main/kotlin/com/yourssu/scouter/document/implement/support/exception/RubricLockedException.kt
+++ b/src/main/kotlin/com/yourssu/scouter/document/implement/support/exception/RubricLockedException.kt
@@ -1,0 +1,8 @@
+package com.yourssu.scouter.document.implement.support.exception
+
+import com.yourssu.scouter.common.implement.support.exception.CustomException
+import org.springframework.http.HttpStatus
+
+class RubricLockedException(
+    message: String,
+) : CustomException(message, "DocumentSection-002", HttpStatus.CONFLICT)

--- a/src/main/kotlin/com/yourssu/scouter/document/storage/domain/comment/DocumentCommentEntity.kt
+++ b/src/main/kotlin/com/yourssu/scouter/document/storage/domain/comment/DocumentCommentEntity.kt
@@ -1,0 +1,63 @@
+package com.yourssu.scouter.document.storage.domain.comment
+
+import com.yourssu.scouter.document.implement.domain.comment.DocumentComment
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import org.springframework.data.annotation.CreatedDate
+import org.springframework.data.jpa.domain.support.AuditingEntityListener
+import jakarta.persistence.EntityListeners
+import java.time.Instant
+
+@Entity
+@Table(name = "document_comment")
+@EntityListeners(AuditingEntityListener::class)
+class DocumentCommentEntity(
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long? = null,
+
+    @Column(name = "applicant_id", nullable = false)
+    val applicantId: Long,
+
+    @Column(name = "section_id", nullable = false)
+    val sectionId: Long,
+
+    @Column(name = "author_user_id", nullable = false)
+    val authorUserId: Long,
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    val content: String,
+) {
+
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    var createdAt: Instant? = null
+        protected set
+
+    fun toDomain(): DocumentComment = DocumentComment(
+        id = id,
+        applicantId = applicantId,
+        sectionId = sectionId,
+        authorUserId = authorUserId,
+        content = content,
+        createdAt = createdAt,
+    )
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as DocumentCommentEntity
+
+        return id == other.id
+    }
+
+    override fun hashCode(): Int {
+        return id?.hashCode() ?: 0
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/document/storage/domain/comment/DocumentCommentRepositoryImpl.kt
+++ b/src/main/kotlin/com/yourssu/scouter/document/storage/domain/comment/DocumentCommentRepositoryImpl.kt
@@ -1,0 +1,36 @@
+package com.yourssu.scouter.document.storage.domain.comment
+
+import com.yourssu.scouter.document.implement.domain.comment.DocumentComment
+import com.yourssu.scouter.document.implement.domain.comment.DocumentCommentRepository
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Repository
+
+@Repository
+class DocumentCommentRepositoryImpl(
+    private val jpaDocumentCommentRepository: JpaDocumentCommentRepository,
+) : DocumentCommentRepository {
+
+    override fun save(comment: DocumentComment): DocumentComment {
+        val entity = DocumentCommentEntity(
+            id = comment.id,
+            applicantId = comment.applicantId,
+            sectionId = comment.sectionId,
+            authorUserId = comment.authorUserId,
+            content = comment.content,
+        )
+
+        return jpaDocumentCommentRepository.save(entity).toDomain()
+    }
+
+    override fun findAllByApplicantId(applicantId: Long): List<DocumentComment> {
+        return jpaDocumentCommentRepository.findAllByApplicantId(applicantId).map { it.toDomain() }
+    }
+
+    override fun findById(commentId: Long): DocumentComment? {
+        return jpaDocumentCommentRepository.findByIdOrNull(commentId)?.toDomain()
+    }
+
+    override fun deleteById(commentId: Long) {
+        jpaDocumentCommentRepository.deleteById(commentId)
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/document/storage/domain/comment/JpaDocumentCommentRepository.kt
+++ b/src/main/kotlin/com/yourssu/scouter/document/storage/domain/comment/JpaDocumentCommentRepository.kt
@@ -1,0 +1,8 @@
+package com.yourssu.scouter.document.storage.domain.comment
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface JpaDocumentCommentRepository : JpaRepository<DocumentCommentEntity, Long> {
+
+    fun findAllByApplicantId(applicantId: Long): List<DocumentCommentEntity>
+}

--- a/src/main/kotlin/com/yourssu/scouter/document/storage/domain/deadline/JpaPartDocumentDeadlineRepository.kt
+++ b/src/main/kotlin/com/yourssu/scouter/document/storage/domain/deadline/JpaPartDocumentDeadlineRepository.kt
@@ -1,0 +1,5 @@
+package com.yourssu.scouter.document.storage.domain.deadline
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface JpaPartDocumentDeadlineRepository : JpaRepository<PartDocumentDeadlineEntity, Long>

--- a/src/main/kotlin/com/yourssu/scouter/document/storage/domain/deadline/PartDocumentDeadlineEntity.kt
+++ b/src/main/kotlin/com/yourssu/scouter/document/storage/domain/deadline/PartDocumentDeadlineEntity.kt
@@ -1,0 +1,26 @@
+package com.yourssu.scouter.document.storage.domain.deadline
+
+import com.yourssu.scouter.document.implement.domain.deadline.PartDocumentDeadline
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import java.time.Instant
+
+@Entity
+@Table(name = "part_document_deadline")
+class PartDocumentDeadlineEntity(
+
+    @Id
+    @Column(name = "part_id")
+    val partId: Long,
+
+    @Column(nullable = false)
+    val deadline: Instant,
+) {
+
+    fun toDomain(): PartDocumentDeadline = PartDocumentDeadline(
+        partId = partId,
+        deadline = deadline,
+    )
+}

--- a/src/main/kotlin/com/yourssu/scouter/document/storage/domain/deadline/PartDocumentDeadlineRepositoryImpl.kt
+++ b/src/main/kotlin/com/yourssu/scouter/document/storage/domain/deadline/PartDocumentDeadlineRepositoryImpl.kt
@@ -1,0 +1,22 @@
+package com.yourssu.scouter.document.storage.domain.deadline
+
+import com.yourssu.scouter.document.implement.domain.deadline.PartDocumentDeadline
+import com.yourssu.scouter.document.implement.domain.deadline.PartDocumentDeadlineRepository
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Repository
+
+@Repository
+class PartDocumentDeadlineRepositoryImpl(
+    private val jpaPartDocumentDeadlineRepository: JpaPartDocumentDeadlineRepository,
+) : PartDocumentDeadlineRepository {
+
+    override fun findByPartId(partId: Long): PartDocumentDeadline? {
+        return jpaPartDocumentDeadlineRepository.findByIdOrNull(partId)?.toDomain()
+    }
+
+    override fun upsert(deadline: PartDocumentDeadline): PartDocumentDeadline {
+        val entity = PartDocumentDeadlineEntity(partId = deadline.partId, deadline = deadline.deadline)
+
+        return jpaPartDocumentDeadlineRepository.save(entity).toDomain()
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/document/storage/domain/evaluation/DocumentEvaluationEntity.kt
+++ b/src/main/kotlin/com/yourssu/scouter/document/storage/domain/evaluation/DocumentEvaluationEntity.kt
@@ -1,0 +1,71 @@
+package com.yourssu.scouter.document.storage.domain.evaluation
+
+import com.yourssu.scouter.document.implement.domain.evaluation.DocumentEvaluation
+import com.yourssu.scouter.document.implement.domain.evaluation.DocumentEvaluationItem
+import com.yourssu.scouter.document.implement.domain.evaluation.DocumentResult
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import jakarta.persistence.UniqueConstraint
+import java.time.Instant
+
+@Entity
+@Table(
+    name = "document_evaluation",
+    uniqueConstraints = [
+        UniqueConstraint(
+            name = "uk_document_evaluation_applicant_evaluator",
+            columnNames = ["applicant_id", "evaluator_user_id"],
+        ),
+    ],
+)
+class DocumentEvaluationEntity(
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long? = null,
+
+    @Column(name = "applicant_id", nullable = false)
+    val applicantId: Long,
+
+    @Column(name = "evaluator_user_id", nullable = false)
+    val evaluatorUserId: Long,
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    val overallComment: String,
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    val result: DocumentResult,
+
+    val submittedAt: Instant? = null,
+) {
+
+    fun toDomain(items: List<DocumentEvaluationItem>): DocumentEvaluation = DocumentEvaluation(
+        id = id,
+        applicantId = applicantId,
+        evaluatorUserId = evaluatorUserId,
+        items = items,
+        overallComment = overallComment,
+        result = result,
+        submittedAt = submittedAt,
+    )
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as DocumentEvaluationEntity
+
+        return id == other.id
+    }
+
+    override fun hashCode(): Int {
+        return id?.hashCode() ?: 0
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/document/storage/domain/evaluation/DocumentEvaluationItemEntity.kt
+++ b/src/main/kotlin/com/yourssu/scouter/document/storage/domain/evaluation/DocumentEvaluationItemEntity.kt
@@ -1,0 +1,45 @@
+package com.yourssu.scouter.document.storage.domain.evaluation
+
+import com.yourssu.scouter.document.implement.domain.evaluation.DocumentEvaluationItem
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
+import jakarta.persistence.ForeignKey
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.Table
+import org.hibernate.annotations.OnDelete
+import org.hibernate.annotations.OnDeleteAction
+
+@Entity
+@Table(name = "document_evaluation_item")
+class DocumentEvaluationItemEntity(
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long? = null,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "evaluation_id", nullable = false, foreignKey = ForeignKey(name = "fk_document_evaluation_item_evaluation"))
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    val evaluation: DocumentEvaluationEntity,
+
+    @Column(name = "section_id", nullable = false)
+    val sectionId: Long,
+
+    @Column(nullable = false)
+    val score: Int,
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    val memo: String,
+) {
+
+    fun toDomain(): DocumentEvaluationItem = DocumentEvaluationItem(
+        sectionId = sectionId,
+        score = score,
+        memo = memo,
+    )
+}

--- a/src/main/kotlin/com/yourssu/scouter/document/storage/domain/evaluation/DocumentEvaluationRepositoryImpl.kt
+++ b/src/main/kotlin/com/yourssu/scouter/document/storage/domain/evaluation/DocumentEvaluationRepositoryImpl.kt
@@ -1,0 +1,67 @@
+package com.yourssu.scouter.document.storage.domain.evaluation
+
+import com.yourssu.scouter.document.implement.domain.evaluation.DocumentEvaluation
+import com.yourssu.scouter.document.implement.domain.evaluation.DocumentEvaluationRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+class DocumentEvaluationRepositoryImpl(
+    private val jpaDocumentEvaluationRepository: JpaDocumentEvaluationRepository,
+    private val jpaDocumentEvaluationItemRepository: JpaDocumentEvaluationItemRepository,
+) : DocumentEvaluationRepository {
+
+    override fun save(evaluation: DocumentEvaluation): DocumentEvaluation {
+        val existingId = evaluation.id
+            ?: jpaDocumentEvaluationRepository
+                .findByApplicantIdAndEvaluatorUserId(evaluation.applicantId, evaluation.evaluatorUserId)?.id
+
+        val entity = DocumentEvaluationEntity(
+            id = existingId,
+            applicantId = evaluation.applicantId,
+            evaluatorUserId = evaluation.evaluatorUserId,
+            overallComment = evaluation.overallComment,
+            result = evaluation.result,
+            submittedAt = evaluation.submittedAt,
+        )
+        val savedEntity = jpaDocumentEvaluationRepository.save(entity)
+
+        if (existingId != null) {
+            jpaDocumentEvaluationItemRepository.deleteAllByEvaluationId(existingId)
+        }
+
+        val itemEntities = evaluation.items.map { item ->
+            DocumentEvaluationItemEntity(
+                evaluation = savedEntity,
+                sectionId = item.sectionId,
+                score = item.score,
+                memo = item.memo,
+            )
+        }
+        val savedItems = jpaDocumentEvaluationItemRepository.saveAll(itemEntities)
+
+        return savedEntity.toDomain(savedItems.map { it.toDomain() })
+    }
+
+    override fun findByApplicantIdAndEvaluatorUserId(applicantId: Long, evaluatorUserId: Long): DocumentEvaluation? {
+        val entity = jpaDocumentEvaluationRepository
+            .findByApplicantIdAndEvaluatorUserId(applicantId, evaluatorUserId) ?: return null
+        val items = jpaDocumentEvaluationItemRepository.findAllByEvaluationId(entity.id!!)
+
+        return entity.toDomain(items.map { it.toDomain() })
+    }
+
+    override fun findAllByApplicantId(applicantId: Long): List<DocumentEvaluation> {
+        val entities = jpaDocumentEvaluationRepository.findAllByApplicantId(applicantId)
+        val itemsByEvaluationId = jpaDocumentEvaluationItemRepository
+            .findAllByEvaluationIdIn(entities.mapNotNull { it.id })
+            .groupBy { it.evaluation.id }
+
+        return entities.map { entity ->
+            entity.toDomain((itemsByEvaluationId[entity.id] ?: emptyList()).map { it.toDomain() })
+        }
+    }
+
+    override fun existsBySectionIdIn(sectionIds: List<Long>): Boolean {
+        return jpaDocumentEvaluationItemRepository.existsBySectionIdIn(sectionIds)
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/document/storage/domain/evaluation/JpaDocumentEvaluationItemRepository.kt
+++ b/src/main/kotlin/com/yourssu/scouter/document/storage/domain/evaluation/JpaDocumentEvaluationItemRepository.kt
@@ -1,0 +1,17 @@
+package com.yourssu.scouter.document.storage.domain.evaluation
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
+import org.springframework.data.jpa.repository.Query
+
+interface JpaDocumentEvaluationItemRepository : JpaRepository<DocumentEvaluationItemEntity, Long> {
+    @Modifying
+    @Query("DELETE FROM DocumentEvaluationItemEntity i WHERE i.evaluation.id = :evaluationId")
+    fun deleteAllByEvaluationId(evaluationId: Long)
+
+    fun findAllByEvaluationId(evaluationId: Long): List<DocumentEvaluationItemEntity>
+
+    fun findAllByEvaluationIdIn(evaluationIds: List<Long>): List<DocumentEvaluationItemEntity>
+
+    fun existsBySectionIdIn(sectionIds: List<Long>): Boolean
+}

--- a/src/main/kotlin/com/yourssu/scouter/document/storage/domain/evaluation/JpaDocumentEvaluationRepository.kt
+++ b/src/main/kotlin/com/yourssu/scouter/document/storage/domain/evaluation/JpaDocumentEvaluationRepository.kt
@@ -1,0 +1,10 @@
+package com.yourssu.scouter.document.storage.domain.evaluation
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface JpaDocumentEvaluationRepository : JpaRepository<DocumentEvaluationEntity, Long> {
+
+    fun findByApplicantIdAndEvaluatorUserId(applicantId: Long, evaluatorUserId: Long): DocumentEvaluationEntity?
+
+    fun findAllByApplicantId(applicantId: Long): List<DocumentEvaluationEntity>
+}

--- a/src/main/kotlin/com/yourssu/scouter/document/storage/domain/rubric/DocumentSectionEntity.kt
+++ b/src/main/kotlin/com/yourssu/scouter/document/storage/domain/rubric/DocumentSectionEntity.kt
@@ -1,0 +1,58 @@
+package com.yourssu.scouter.document.storage.domain.rubric
+
+import com.yourssu.scouter.common.storage.domain.part.PartEntity
+import com.yourssu.scouter.document.implement.domain.rubric.DocumentSection
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
+import jakarta.persistence.ForeignKey
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.Table
+
+@Entity
+@Table(name = "document_section")
+class DocumentSectionEntity(
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long? = null,
+
+    @ManyToOne(fetch = FetchType.EAGER)
+    @JoinColumn(name = "part_id", nullable = false, foreignKey = ForeignKey(name = "fk_document_section_part"))
+    val part: PartEntity,
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    val question: String,
+
+    @Column(nullable = false)
+    val maxScore: Int,
+
+    @Column(nullable = false)
+    val criterionDetail: String,
+) {
+
+    fun toDomain(): DocumentSection = DocumentSection(
+        id = id,
+        partId = part.id!!,
+        question = question,
+        maxScore = maxScore,
+        criterionDetail = criterionDetail,
+    )
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as DocumentSectionEntity
+
+        return id == other.id
+    }
+
+    override fun hashCode(): Int {
+        return id?.hashCode() ?: 0
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/document/storage/domain/rubric/DocumentSectionRepositoryImpl.kt
+++ b/src/main/kotlin/com/yourssu/scouter/document/storage/domain/rubric/DocumentSectionRepositoryImpl.kt
@@ -1,0 +1,35 @@
+package com.yourssu.scouter.document.storage.domain.rubric
+
+import com.yourssu.scouter.common.storage.domain.part.JpaPartRepository
+import com.yourssu.scouter.document.implement.domain.rubric.DocumentSection
+import com.yourssu.scouter.document.implement.domain.rubric.DocumentSectionRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+class DocumentSectionRepositoryImpl(
+    private val jpaDocumentSectionRepository: JpaDocumentSectionRepository,
+    private val jpaPartRepository: JpaPartRepository,
+) : DocumentSectionRepository {
+
+    override fun findAllByPartId(partId: Long): List<DocumentSection> {
+        return jpaDocumentSectionRepository.findAllByPartId(partId).map { it.toDomain() }
+    }
+
+    override fun findAllByIdIn(sectionIds: List<Long>): List<DocumentSection> {
+        return jpaDocumentSectionRepository.findAllByIdIn(sectionIds).map { it.toDomain() }
+    }
+
+    override fun saveAll(sections: List<DocumentSection>): List<DocumentSection> {
+        val entities = sections.map { section ->
+            DocumentSectionEntity(
+                id = section.id,
+                part = jpaPartRepository.getReferenceById(section.partId),
+                question = section.question,
+                maxScore = section.maxScore,
+                criterionDetail = section.criterionDetail,
+            )
+        }
+
+        return jpaDocumentSectionRepository.saveAll(entities).map { it.toDomain() }
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/document/storage/domain/rubric/JpaDocumentSectionRepository.kt
+++ b/src/main/kotlin/com/yourssu/scouter/document/storage/domain/rubric/JpaDocumentSectionRepository.kt
@@ -1,0 +1,10 @@
+package com.yourssu.scouter.document.storage.domain.rubric
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface JpaDocumentSectionRepository : JpaRepository<DocumentSectionEntity, Long> {
+
+    fun findAllByPartId(partId: Long): List<DocumentSectionEntity>
+
+    fun findAllByIdIn(sectionIds: List<Long>): List<DocumentSectionEntity>
+}

--- a/src/main/resources/db/migration/V22__create_document_tables.sql
+++ b/src/main/resources/db/migration/V22__create_document_tables.sql
@@ -1,0 +1,47 @@
+ALTER TABLE applicant_answer
+    ADD COLUMN section_id BIGINT NULL;
+
+CREATE TABLE document_section (
+    id               BIGINT AUTO_INCREMENT PRIMARY KEY,
+    part_id          BIGINT NOT NULL,
+    question         TEXT   NOT NULL,
+    max_score        INT    NOT NULL,
+    criterion_detail VARCHAR(255) NOT NULL,
+    CONSTRAINT fk_document_section_part
+        FOREIGN KEY (part_id) REFERENCES part (id)
+);
+
+CREATE TABLE document_evaluation (
+    id                 BIGINT AUTO_INCREMENT PRIMARY KEY,
+    applicant_id       BIGINT NOT NULL,
+    evaluator_user_id  BIGINT NOT NULL,
+    overall_comment    TEXT   NOT NULL,
+    result             VARCHAR(20) NOT NULL,
+    submitted_at       DATETIME NULL,
+    CONSTRAINT uk_document_evaluation_applicant_evaluator
+        UNIQUE (applicant_id, evaluator_user_id)
+);
+
+CREATE TABLE document_evaluation_item (
+    id             BIGINT AUTO_INCREMENT PRIMARY KEY,
+    evaluation_id  BIGINT NOT NULL,
+    section_id     BIGINT NOT NULL,
+    score          INT    NOT NULL,
+    memo           TEXT   NOT NULL,
+    CONSTRAINT fk_document_evaluation_item_evaluation
+        FOREIGN KEY (evaluation_id) REFERENCES document_evaluation (id) ON DELETE CASCADE
+);
+
+CREATE TABLE document_comment (
+    id               BIGINT AUTO_INCREMENT PRIMARY KEY,
+    applicant_id     BIGINT NOT NULL,
+    section_id       BIGINT NOT NULL,
+    author_user_id   BIGINT NOT NULL,
+    content          TEXT   NOT NULL,
+    created_at       DATETIME NOT NULL
+);
+
+CREATE TABLE part_document_deadline (
+    part_id  BIGINT PRIMARY KEY,
+    deadline DATETIME NOT NULL
+);

--- a/src/test/kotlin/com/yourssu/scouter/document/storage/domain/deadline/PartDocumentDeadlineRepositoryImplTest.kt
+++ b/src/test/kotlin/com/yourssu/scouter/document/storage/domain/deadline/PartDocumentDeadlineRepositoryImplTest.kt
@@ -1,0 +1,81 @@
+package com.yourssu.scouter.document.storage.domain.deadline
+
+import com.yourssu.scouter.document.implement.domain.deadline.PartDocumentDeadline
+import com.yourssu.scouter.common.storage.domain.division.DivisionEntity
+import com.yourssu.scouter.common.storage.domain.part.PartEntity
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatCode
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager
+import org.springframework.context.annotation.Import
+import java.time.Instant
+
+@DataJpaTest
+@Import(PartDocumentDeadlineRepositoryImpl::class)
+@Suppress("NonAsciiCharacters")
+class PartDocumentDeadlineRepositoryImplTest {
+
+    @Autowired
+    lateinit var partDocumentDeadlineRepositoryImpl: PartDocumentDeadlineRepositoryImpl
+
+    @Autowired
+    lateinit var entityManager: TestEntityManager
+
+    private var partId: Long = 0
+
+    @BeforeEach
+    fun setUp() {
+        val division = entityManager.persist(DivisionEntity(null, "개발", 1))
+        val part = entityManager.persist(PartEntity(null, division, "PM", 1))
+        partId = part.id!!
+
+        entityManager.flush()
+        entityManager.clear()
+    }
+
+    @Test
+    fun `설정된 마감일이 없으면 null을 반환한다`() {
+        // when
+        val result = partDocumentDeadlineRepositoryImpl.findByPartId(partId)
+
+        // then
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `마감일이 없는 파트에 처음 설정하면 저장된다`() {
+        // given
+        val deadline = Instant.parse("2025-11-22T14:59:00Z")
+
+        // when
+        assertThatCode {
+            partDocumentDeadlineRepositoryImpl.upsert(PartDocumentDeadline(partId, deadline))
+        }.doesNotThrowAnyException()
+
+        // then
+        val found = partDocumentDeadlineRepositoryImpl.findByPartId(partId)
+        assertThat(found).isNotNull
+        assertThat(found!!.deadline).isEqualTo(deadline)
+    }
+
+    @Test
+    fun `이미 설정된 마감일을 다시 저장해도 예외 없이 갱신된다`() {
+        // given: 최초 설정
+        val firstDeadline = Instant.parse("2025-11-22T14:59:00Z")
+        partDocumentDeadlineRepositoryImpl.upsert(PartDocumentDeadline(partId, firstDeadline))
+
+        // when: 같은 파트에 재설정
+        val secondDeadline = Instant.parse("2025-12-01T00:00:00Z")
+        assertThatCode {
+            partDocumentDeadlineRepositoryImpl.upsert(PartDocumentDeadline(partId, secondDeadline))
+        }.doesNotThrowAnyException()
+
+        // then
+        val found = partDocumentDeadlineRepositoryImpl.findByPartId(partId)
+        assertThat(found).isNotNull
+        assertThat(found!!.deadline).isEqualTo(secondDeadline)
+    }
+}

--- a/src/test/kotlin/com/yourssu/scouter/document/storage/domain/evaluation/DocumentEvaluationRepositoryImplTest.kt
+++ b/src/test/kotlin/com/yourssu/scouter/document/storage/domain/evaluation/DocumentEvaluationRepositoryImplTest.kt
@@ -1,0 +1,187 @@
+package com.yourssu.scouter.document.storage.domain.evaluation
+
+import com.yourssu.scouter.ats.implement.domain.applicant.ApplicantState
+import com.yourssu.scouter.document.implement.domain.evaluation.DocumentEvaluation
+import com.yourssu.scouter.document.implement.domain.evaluation.DocumentEvaluationItem
+import com.yourssu.scouter.document.implement.domain.evaluation.DocumentResult
+import com.yourssu.scouter.ats.storage.domain.applicant.ApplicantEntity
+import com.yourssu.scouter.ats.storage.domain.applicant.JpaApplicantRepository
+import com.yourssu.scouter.common.implement.domain.authentication.OAuth2Type
+import com.yourssu.scouter.common.implement.domain.semester.Term
+import com.yourssu.scouter.common.storage.domain.division.DivisionEntity
+import com.yourssu.scouter.common.storage.domain.part.PartEntity
+import com.yourssu.scouter.common.storage.domain.semester.SemesterEntity
+import com.yourssu.scouter.common.storage.domain.user.JpaUserRepository
+import com.yourssu.scouter.common.storage.domain.user.UserEntity
+import com.yourssu.scouter.document.storage.domain.rubric.DocumentSectionEntity
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatCode
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager
+import org.springframework.context.annotation.Import
+import java.time.Instant
+import java.time.Year
+
+@DataJpaTest
+@Import(DocumentEvaluationRepositoryImpl::class)
+@Suppress("NonAsciiCharacters")
+class DocumentEvaluationRepositoryImplTest {
+
+    @Autowired
+    lateinit var documentEvaluationRepositoryImpl: DocumentEvaluationRepositoryImpl
+
+    @Autowired
+    lateinit var jpaApplicantRepository: JpaApplicantRepository
+
+    @Autowired
+    lateinit var jpaUserRepository: JpaUserRepository
+
+    @Autowired
+    lateinit var entityManager: TestEntityManager
+
+    private lateinit var savedApplicant: ApplicantEntity
+    private lateinit var savedEvaluator: UserEntity
+    private var sectionId1: Long = 0
+    private var sectionId2: Long = 0
+
+    @BeforeEach
+    fun setUp() {
+        val division = entityManager.persist(DivisionEntity(null, "개발", 1))
+        val part = entityManager.persist(PartEntity(null, division, "PM", 1))
+        val semester = entityManager.persist(SemesterEntity(null, Year.of(2025), Term.FALL))
+        savedApplicant = entityManager.persist(
+            ApplicantEntity(
+                id = null,
+                name = "오태민",
+                email = "applicant@example.com",
+                phoneNumber = "010-0000-0000",
+                age = "22",
+                department = "컴퓨터학부",
+                studentId = "202401002",
+                part = part,
+                state = ApplicantState.UNDER_REVIEW,
+                applicationDateTime = Instant.parse("2025-11-13T00:00:00Z"),
+                applicationSemester = semester,
+                academicSemester = "3-2",
+            ),
+        )
+        savedEvaluator = entityManager.persist(
+            UserEntity(
+                id = null,
+                name = "오리",
+                email = "ori@example.com",
+                profileImageUrl = "",
+                oauthId = "oauth-ori",
+                oauth2Type = OAuth2Type.GOOGLE,
+                tokenPrefix = "Bearer",
+                accessToken = "dummy",
+                refreshToken = "dummy",
+                accessTokenExpirationDateTime = Instant.now().plusSeconds(3600),
+            ),
+        )
+        val section1 = entityManager.persist(DocumentSectionEntity(null, part, "지원 동기", 60, "지원 동기"))
+        val section2 = entityManager.persist(DocumentSectionEntity(null, part, "문제 해결 경험", 40, "문제 해결"))
+        sectionId1 = section1.id!!
+        sectionId2 = section2.id!!
+
+        flushAndClear()
+    }
+
+    @Test
+    fun `평가를 처음 저장하면 문항 점수와 함께 조회할 수 있다`() {
+        // given
+        val evaluation = DocumentEvaluation(
+            applicantId = savedApplicant.id!!,
+            evaluatorUserId = savedEvaluator.id!!,
+            items = listOf(
+                DocumentEvaluationItem(sectionId1, 50, "지원 동기가 분명합니다."),
+                DocumentEvaluationItem(sectionId2, 30, "문제 해결 사례가 구체적입니다."),
+            ),
+            overallComment = "종합 의견",
+            result = DocumentResult.PENDING,
+            submittedAt = null,
+        )
+
+        // when
+        val saved = documentEvaluationRepositoryImpl.save(evaluation)
+
+        // then
+        assertThat(saved.id).isNotNull
+        assertThat(saved.items).hasSize(2)
+        assertThat(saved.totalScore()).isEqualTo(80)
+    }
+
+    @Test
+    fun `임시저장 후 다시 저장해도 유니크 제약 위반 없이 최신 값으로 갱신된다`() {
+        // given: 임시저장 (submit=false에 해당)
+        val tempSaved = documentEvaluationRepositoryImpl.save(
+            DocumentEvaluation(
+                applicantId = savedApplicant.id!!,
+                evaluatorUserId = savedEvaluator.id!!,
+                items = listOf(
+                    DocumentEvaluationItem(sectionId1, 50, "지원 동기가 분명합니다."),
+                    DocumentEvaluationItem(sectionId2, 30, "문제 해결 사례가 구체적입니다."),
+                ),
+                overallComment = "임시저장 코멘트",
+                result = DocumentResult.PENDING,
+                submittedAt = null,
+            ),
+        )
+
+        // when: 같은 section들을 다시 참조하며 제출 완료로 재저장
+        val submittedAt = Instant.now()
+        assertThatCode {
+            documentEvaluationRepositoryImpl.save(
+                DocumentEvaluation(
+                    id = tempSaved.id,
+                    applicantId = savedApplicant.id!!,
+                    evaluatorUserId = savedEvaluator.id!!,
+                    items = listOf(
+                        DocumentEvaluationItem(sectionId1, 55, "지원 동기가 분명하고 구체적입니다."),
+                        DocumentEvaluationItem(sectionId2, 35, "문제 해결 사례가 좋습니다."),
+                    ),
+                    overallComment = "제출 완료 코멘트",
+                    result = DocumentResult.DOCUMENT_PASS,
+                    submittedAt = submittedAt,
+                ),
+            )
+        }.doesNotThrowAnyException()
+
+        // then
+        val found = documentEvaluationRepositoryImpl.findByApplicantIdAndEvaluatorUserId(savedApplicant.id!!, savedEvaluator.id!!)
+        assertThat(found).isNotNull
+        assertThat(found!!.items).hasSize(2)
+        assertThat(found.totalScore()).isEqualTo(90)
+        assertThat(found.overallComment).isEqualTo("제출 완료 코멘트")
+        assertThat(found.result).isEqualTo(DocumentResult.DOCUMENT_PASS)
+        assertThat(found.submittedAt).isNotNull
+        assertThat(found.items.map { it.score }).containsExactlyInAnyOrder(55, 35)
+    }
+
+    @Test
+    fun `existsBySectionIdIn은 해당 section을 참조하는 평가 항목이 있으면 true를 반환한다`() {
+        // given
+        documentEvaluationRepositoryImpl.save(
+            DocumentEvaluation(
+                applicantId = savedApplicant.id!!,
+                evaluatorUserId = savedEvaluator.id!!,
+                items = listOf(DocumentEvaluationItem(sectionId1, 50, "메모")),
+                overallComment = "",
+                result = DocumentResult.PENDING,
+                submittedAt = null,
+            ),
+        )
+
+        // when and then
+        assertThat(documentEvaluationRepositoryImpl.existsBySectionIdIn(listOf(sectionId1))).isTrue
+        assertThat(documentEvaluationRepositoryImpl.existsBySectionIdIn(listOf(sectionId2))).isFalse
+    }
+
+    private fun flushAndClear() {
+        entityManager.flush()
+        entityManager.clear()
+    }
+}


### PR DESCRIPTION
## 📄 작업 내용 요약

`docs/api-spec-v2.md`, `docs/erd-v2.md` 기준 서류평가 기능을 신규 `document` 최상위 도메인으로 구현합니다 (기존 ats/hrms 폴더에 끼워넣지 않음).

- **ApplicantAnswer 확장**: 지원서 답변에 `sectionId` 필드 추가 (서류 평가 문항과 연결)
- **Rubric**: 파트별 서류 평가 문항 조회/수정, 배점 합계 100 검증, 평가 존재 시 잠금(409, [A1])
- **Evaluation**: 본인 서류 평가 조회/저장, 타 평가자 조회(제출 전 마스킹, [A5]), 평가자 진행 상태, 통합 조회(evaluation-view)
- **Comment**: 문항 단위 인라인 코멘트 조회/작성/삭제 (본인 작성 건만 삭제 가능, 403)
- **Deadline**: 파트별 서류 평가 마감일 조회/설정
- **마이그레이션**: V22 — document_section/document_evaluation/document_evaluation_item/document_comment/part_document_deadline 테이블 생성 + applicant_answer.section_id 컬럼 추가

기존 ats에 남아있던 미완성 WIP 테스트(DocumentEvaluationRepositoryImplTest, PartDocumentDeadlineRepositoryImplTest)를 document 도메인으로 이식해 그대로 통과시켰습니다.

범위 제외: 구글폼 동기화를 통한 문항 자동 생성([B1]), 기존 `GET /applicants`의 breaking change(sort/documentAverageScore/state enum 직렬화)

## 📎 Issue 번호
closed #314