### PR TITLE
[#320]; feat: GET /applicants breaking change - state enum, sort, 평균 점수

### DIFF
--- a/src/main/kotlin/com/yourssu/scouter/ats/application/domain/applicant/ApplicantController.kt
+++ b/src/main/kotlin/com/yourssu/scouter/ats/application/domain/applicant/ApplicantController.kt
@@ -4,6 +4,7 @@ import com.yourssu.scouter.ats.business.domain.applicant.ApplicantDto
 import com.yourssu.scouter.ats.business.domain.applicant.ApplicantPrivacyService
 import com.yourssu.scouter.ats.business.domain.applicant.ApplicantService
 import com.yourssu.scouter.ats.business.support.exception.ApplicantAccessDeniedException
+import com.yourssu.scouter.ats.implement.domain.applicant.ApplicantSort
 import com.yourssu.scouter.common.application.support.authentication.AuthUser
 import com.yourssu.scouter.common.application.support.authentication.AuthUserInfo
 import io.swagger.v3.oas.annotations.Operation
@@ -54,12 +55,16 @@ class ApplicantController(
         @RequestParam(required = false) state: String?,
         @RequestParam(required = false) semesterId: Long?,
         @RequestParam(required = false) partId: Long?,
+        @RequestParam(required = false, defaultValue = "DEFAULT") sort: String = "DEFAULT",
     ): ResponseEntity<List<ReadApplicantResponse>> {
+        val applicantSort = runCatching { ApplicantSort.valueOf(sort) }
+            .getOrElse { throw IllegalArgumentException("허용되지 않는 sort 값입니다: $sort") }
         val applicantDtos: List<ApplicantDto> = applicantService.readAllByFilters(
             name = name,
             state = state,
             semesterId = semesterId,
             partId = partId,
+            sort = applicantSort,
         )
         val accessible = applicantPrivacyService.filterAccessibleApplicants(authUserInfo.userId, applicantDtos)
         val responses = accessible.map(ReadApplicantResponse::from)
@@ -128,7 +133,7 @@ class ApplicantController(
             mediaType = "application/json",
             array = ArraySchema(schema = Schema(implementation = String::class)),
             examples =
-                [ExampleObject(value = "[ \"심사 진행 중\", \"서류 불합\", \"면접 불합\", \"인큐베이팅 불합\", \"최종 합격\" ]")]
+                [ExampleObject(value = "[ \"UNDER_REVIEW\", \"DOCUMENT_ACCEPTED\", \"DOCUMENT_REJECTED\", \"INTERVIEW_ACCEPTED\", \"INTERVIEW_REJECTED\", \"INCUBATING_REJECTED\", \"FINAL_ACCEPTED\" ]")]
         )]
     )
     @GetMapping("/applicants/states")

--- a/src/main/kotlin/com/yourssu/scouter/ats/application/domain/applicant/ReadApplicantResponse.kt
+++ b/src/main/kotlin/com/yourssu/scouter/ats/application/domain/applicant/ReadApplicantResponse.kt
@@ -1,7 +1,6 @@
 package com.yourssu.scouter.ats.application.domain.applicant
 
 import com.yourssu.scouter.ats.business.domain.applicant.ApplicantDto
-import com.yourssu.scouter.ats.business.support.utils.ApplicantStateConverter
 import java.time.Instant
 import java.time.LocalDate
 import java.time.ZoneOffset
@@ -33,6 +32,10 @@ data class ReadApplicantResponse(
     val age: String,
 
     val availableTimes: List<Instant>,
+
+    val documentAverageScore: Double?,
+
+    val interviewAverageScore: Double?,
 ) {
 
     companion object {
@@ -41,7 +44,7 @@ data class ReadApplicantResponse(
             division = applicantDto.part.division.name,
             part = applicantDto.part.name,
             name = applicantDto.name,
-            state = ApplicantStateConverter.convertToString(applicantDto.state),
+            state = applicantDto.state.name,
             applicationDate = applicantDto.applicationDateTime.atZone(ZoneOffset.UTC).toLocalDate(),
             email = applicantDto.email,
             phoneNumber = applicantDto.phoneNumber,
@@ -49,7 +52,9 @@ data class ReadApplicantResponse(
             studentId = applicantDto.studentId,
             semester = applicantDto.academicSemester,
             age = applicantDto.age,
-            availableTimes = applicantDto.availableTimes
+            availableTimes = applicantDto.availableTimes,
+            documentAverageScore = applicantDto.documentAverageScore,
+            interviewAverageScore = applicantDto.interviewAverageScore,
         )
     }
 }

--- a/src/main/kotlin/com/yourssu/scouter/ats/application/domain/applicant/UpdateApplicantRequest.kt
+++ b/src/main/kotlin/com/yourssu/scouter/ats/application/domain/applicant/UpdateApplicantRequest.kt
@@ -1,7 +1,7 @@
 package com.yourssu.scouter.ats.application.domain.applicant
 
 import com.yourssu.scouter.ats.business.domain.applicant.UpdateApplicantCommand
-import com.yourssu.scouter.ats.business.support.utils.ApplicantStateConverter
+import com.yourssu.scouter.ats.implement.domain.applicant.ApplicantState
 import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.constraints.Pattern
 import java.time.Instant
@@ -13,7 +13,7 @@ data class UpdateApplicantRequest(
 
     val name: String? = null,
 
-    @field:Schema(example = "심사 진행 중", description = "심사 진행 중 | 서류 불합 | 면접 불합 | 인큐베이팅 불합 | 최종 합격")
+    @field:Schema(example = "UNDER_REVIEW", description = "UNDER_REVIEW | DOCUMENT_ACCEPTED | DOCUMENT_REJECTED | INTERVIEW_ACCEPTED | INTERVIEW_REJECTED | INCUBATING_REJECTED | FINAL_ACCEPTED")
     val state: String? = null,
 
     val applicationDate: LocalDate? = null,
@@ -47,7 +47,10 @@ data class UpdateApplicantRequest(
         targetApplicantId = applicantId,
         partId = partId,
         name = name,
-        state = state?.let { ApplicantStateConverter.convertToEnum(it) },
+        state = state?.let {
+            runCatching { ApplicantState.valueOf(it) }
+                .getOrElse { throw IllegalArgumentException("허용되지 않는 state 값입니다: $it") }
+        },
         applicationDate = applicationDate,
         email = email,
         phoneNumber = phoneNumber,

--- a/src/main/kotlin/com/yourssu/scouter/ats/business/domain/applicant/ApplicantDto.kt
+++ b/src/main/kotlin/com/yourssu/scouter/ats/business/domain/applicant/ApplicantDto.kt
@@ -20,6 +20,8 @@ data class ApplicantDto(
     val applicationSemester: SemesterDto,
     val academicSemester: String,
     val availableTimes: List<Instant>,
+    val documentAverageScore: Double? = null,
+    val interviewAverageScore: Double? = null,
 ) {
 
     companion object {

--- a/src/main/kotlin/com/yourssu/scouter/ats/business/domain/applicant/ApplicantService.kt
+++ b/src/main/kotlin/com/yourssu/scouter/ats/business/domain/applicant/ApplicantService.kt
@@ -1,10 +1,10 @@
 package com.yourssu.scouter.ats.business.domain.applicant
 
-import com.yourssu.scouter.ats.business.support.utils.ApplicantStateConverter
 import com.yourssu.scouter.ats.implement.domain.applicant.Applicant
 import java.time.ZoneOffset
 import com.yourssu.scouter.ats.implement.domain.applicant.ApplicantAnswerReader
 import com.yourssu.scouter.ats.implement.domain.applicant.ApplicantReader
+import com.yourssu.scouter.ats.implement.domain.applicant.ApplicantSort
 import com.yourssu.scouter.ats.implement.domain.applicant.ApplicantState
 import com.yourssu.scouter.ats.implement.domain.applicant.ApplicantWriter
 import com.yourssu.scouter.common.implement.domain.department.Department
@@ -13,6 +13,8 @@ import com.yourssu.scouter.common.implement.domain.part.Part
 import com.yourssu.scouter.common.implement.domain.part.PartReader
 import com.yourssu.scouter.common.implement.domain.semester.Semester
 import com.yourssu.scouter.common.implement.domain.semester.SemesterReader
+import com.yourssu.scouter.document.implement.domain.evaluation.DocumentEvaluation
+import com.yourssu.scouter.document.implement.domain.evaluation.DocumentEvaluationReader
 import org.springframework.stereotype.Service
 
 @Service
@@ -23,6 +25,7 @@ class ApplicantService(
     private val departmentReader: DepartmentReader,
     private val partReader: PartReader,
     private val semesterReader: SemesterReader,
+    private val documentEvaluationReader: DocumentEvaluationReader,
 ) {
 
     fun create(command: CreateApplicantCommand): Long {
@@ -39,7 +42,9 @@ class ApplicantService(
     fun readById(applicantId: Long): ApplicantDto {
         val applicant: Applicant = applicantReader.readById(applicantId)
 
-        return ApplicantDto.from(applicant)
+        return ApplicantDto.from(applicant).copy(
+            documentAverageScore = averageSubmittedScore(documentEvaluationReader.readAllByApplicantId(applicantId)),
+        )
     }
 
     fun readAnswersByApplicantId(applicantId: Long): List<ApplicantAnswerDto> {
@@ -53,6 +58,7 @@ class ApplicantService(
         state: String?,
         semesterId: Long?,
         partId: Long?,
+        sort: ApplicantSort = ApplicantSort.DEFAULT,
     ): List<ApplicantDto> {
         var applicants: List<Applicant> = applicantReader.readAll()
 
@@ -60,7 +66,8 @@ class ApplicantService(
             applicants = applicants.filter { it.name.contains(name, ignoreCase = true) }
         }
         if (!state.isNullOrEmpty()) {
-            val applicantState: ApplicantState = ApplicantStateConverter.convertToEnum(state)
+            val applicantState: ApplicantState = runCatching { ApplicantState.valueOf(state) }
+                .getOrElse { throw IllegalArgumentException("허용되지 않는 state 값입니다: $state") }
             applicants = applicants.filter { it.state == applicantState }
         }
         if (semesterId != null) {
@@ -72,7 +79,34 @@ class ApplicantService(
             applicants = applicants.filter { it.part == part }
         }
 
-        return applicants.sorted().map { ApplicantDto.from(it) }
+        val orderedApplicants = when (sort) {
+            ApplicantSort.SEMESTER_DESC -> applicants.sortedByDescending { it.applicationSemester }
+            else -> applicants.sorted()
+        }
+
+        val evaluationsByApplicantId = documentEvaluationReader
+            .readAllByApplicantIdIn(orderedApplicants.mapNotNull { it.id })
+            .groupBy { it.applicantId }
+
+        val dtos = orderedApplicants.map { applicant ->
+            ApplicantDto.from(applicant).copy(
+                documentAverageScore = averageSubmittedScore(evaluationsByApplicantId[applicant.id].orEmpty()),
+                // 면접 평가 도메인이 아직 없어 항상 null — interview 도메인 구현 후 채워질 예정
+                interviewAverageScore = null,
+            )
+        }
+
+        return when (sort) {
+            ApplicantSort.DOCUMENT_SCORE_DESC -> dtos.sortedByDescending { it.documentAverageScore ?: Double.NEGATIVE_INFINITY }
+            ApplicantSort.DOCUMENT_SCORE_ASC -> dtos.sortedBy { it.documentAverageScore ?: Double.POSITIVE_INFINITY }
+            else -> dtos
+        }
+    }
+
+    private fun averageSubmittedScore(evaluations: List<DocumentEvaluation>): Double? {
+        val submittedScores = evaluations.filter { it.isSubmitted() }.map { it.totalScore() }
+
+        return if (submittedScores.isEmpty()) null else submittedScores.average()
     }
 
     fun updateById(command: UpdateApplicantCommand) {
@@ -104,14 +138,6 @@ class ApplicantService(
     }
 
     fun readAllStates(): List<String> {
-        val customOrder = listOf(
-            ApplicantState.UNDER_REVIEW,
-            ApplicantState.DOCUMENT_REJECTED,
-            ApplicantState.INTERVIEW_REJECTED,
-            ApplicantState.INCUBATING_REJECTED,
-            ApplicantState.FINAL_ACCEPTED,
-        )
-
-        return customOrder.map { ApplicantStateConverter.convertToString(it) }
+        return ApplicantState.entries.map { it.name }
     }
 }

--- a/src/main/kotlin/com/yourssu/scouter/ats/implement/domain/applicant/ApplicantSort.kt
+++ b/src/main/kotlin/com/yourssu/scouter/ats/implement/domain/applicant/ApplicantSort.kt
@@ -1,0 +1,8 @@
+package com.yourssu.scouter.ats.implement.domain.applicant
+
+enum class ApplicantSort {
+    DEFAULT,
+    SEMESTER_DESC,
+    DOCUMENT_SCORE_DESC,
+    DOCUMENT_SCORE_ASC,
+}

--- a/src/main/kotlin/com/yourssu/scouter/ats/implement/domain/applicant/ApplicantState.kt
+++ b/src/main/kotlin/com/yourssu/scouter/ats/implement/domain/applicant/ApplicantState.kt
@@ -3,7 +3,9 @@ package com.yourssu.scouter.ats.implement.domain.applicant
 enum class ApplicantState {
 
     UNDER_REVIEW,
+    DOCUMENT_ACCEPTED,
     DOCUMENT_REJECTED,
+    INTERVIEW_ACCEPTED,
     INTERVIEW_REJECTED,
     INCUBATING_REJECTED,
     FINAL_ACCEPTED,

--- a/src/main/kotlin/com/yourssu/scouter/document/implement/domain/evaluation/DocumentEvaluationReader.kt
+++ b/src/main/kotlin/com/yourssu/scouter/document/implement/domain/evaluation/DocumentEvaluationReader.kt
@@ -17,6 +17,10 @@ class DocumentEvaluationReader(
         return documentEvaluationRepository.findAllByApplicantId(applicantId)
     }
 
+    fun readAllByApplicantIdIn(applicantIds: List<Long>): List<DocumentEvaluation> {
+        return documentEvaluationRepository.findAllByApplicantIdIn(applicantIds)
+    }
+
     fun existsBySectionIdIn(sectionIds: List<Long>): Boolean {
         return documentEvaluationRepository.existsBySectionIdIn(sectionIds)
     }

--- a/src/main/kotlin/com/yourssu/scouter/document/implement/domain/evaluation/DocumentEvaluationRepository.kt
+++ b/src/main/kotlin/com/yourssu/scouter/document/implement/domain/evaluation/DocumentEvaluationRepository.kt
@@ -8,5 +8,7 @@ interface DocumentEvaluationRepository {
 
     fun findAllByApplicantId(applicantId: Long): List<DocumentEvaluation>
 
+    fun findAllByApplicantIdIn(applicantIds: List<Long>): List<DocumentEvaluation>
+
     fun existsBySectionIdIn(sectionIds: List<Long>): Boolean
 }

--- a/src/main/kotlin/com/yourssu/scouter/document/storage/domain/evaluation/DocumentEvaluationRepositoryImpl.kt
+++ b/src/main/kotlin/com/yourssu/scouter/document/storage/domain/evaluation/DocumentEvaluationRepositoryImpl.kt
@@ -61,6 +61,21 @@ class DocumentEvaluationRepositoryImpl(
         }
     }
 
+    override fun findAllByApplicantIdIn(applicantIds: List<Long>): List<DocumentEvaluation> {
+        if (applicantIds.isEmpty()) {
+            return emptyList()
+        }
+
+        val entities = jpaDocumentEvaluationRepository.findAllByApplicantIdIn(applicantIds)
+        val itemsByEvaluationId = jpaDocumentEvaluationItemRepository
+            .findAllByEvaluationIdIn(entities.mapNotNull { it.id })
+            .groupBy { it.evaluation.id }
+
+        return entities.map { entity ->
+            entity.toDomain((itemsByEvaluationId[entity.id] ?: emptyList()).map { it.toDomain() })
+        }
+    }
+
     override fun existsBySectionIdIn(sectionIds: List<Long>): Boolean {
         return jpaDocumentEvaluationItemRepository.existsBySectionIdIn(sectionIds)
     }

--- a/src/main/kotlin/com/yourssu/scouter/document/storage/domain/evaluation/JpaDocumentEvaluationRepository.kt
+++ b/src/main/kotlin/com/yourssu/scouter/document/storage/domain/evaluation/JpaDocumentEvaluationRepository.kt
@@ -7,4 +7,6 @@ interface JpaDocumentEvaluationRepository : JpaRepository<DocumentEvaluationEnti
     fun findByApplicantIdAndEvaluatorUserId(applicantId: Long, evaluatorUserId: Long): DocumentEvaluationEntity?
 
     fun findAllByApplicantId(applicantId: Long): List<DocumentEvaluationEntity>
+
+    fun findAllByApplicantIdIn(applicantIds: List<Long>): List<DocumentEvaluationEntity>
 }


### PR DESCRIPTION
## 📄 작업 내용 요약

⚠️ **프론트엔드 배포와 동시에 배포해야 하는 breaking change입니다.** 프론트 대응이 끝나기 전에는 머지하지 마세요.

- `ApplicantState`에 `DOCUMENT_ACCEPTED`, `INTERVIEW_ACCEPTED` 추가 (기존 데이터 백필 없음, [B3])
- `GET /applicants`, `GET /applicants/{applicantId}` 응답 `state`: 한글 표기("심사 진행 중") → enum 값("UNDER_REVIEW")
- `PATCH /applicants/{applicantId}` 요청 `state`: enum 값만 허용, 한글값/그 외 값은 400
- `GET /applicants/states` 응답을 enum 목록으로 변경
- `GET /applicants`에 `sort` 쿼리 파라미터 추가 (`DEFAULT`/`SEMESTER_DESC`/`DOCUMENT_SCORE_DESC`/`DOCUMENT_SCORE_ASC`), 점수 정렬 시 점수 없는 지원자는 항상 맨 뒤
- `GET /applicants` 응답에 `documentAverageScore`, `interviewAverageScore` 필드 추가
  - `documentAverageScore`는 document 도메인의 제출된 평가 평균 (0건이면 null)
  - `interviewAverageScore`는 면접 평가 도메인(#319)이 아직 없어 이번 PR에서는 항상 null — #319 완료 후 후속 PR에서 연결 예정
- `POST /applicants`(지원자 생성)의 `state`는 이번 범위에서 변경하지 않음 (기존 한글 값 유지)

## 📎 Issue 번호
closed #320