### PR TITLE
[#321]; feat: 구글폼 동기화 시 서류 평가 문항(DocumentSection) 자동 생성/갱신

### DIFF
--- a/src/main/kotlin/com/yourssu/scouter/ats/business/domain/applicant/ApplicantSyncService.kt
+++ b/src/main/kotlin/com/yourssu/scouter/ats/business/domain/applicant/ApplicantSyncService.kt
@@ -5,6 +5,9 @@ import com.yourssu.scouter.common.business.domain.authentication.OAuth2Service
 import com.yourssu.scouter.common.implement.domain.authentication.OAuth2Type
 import com.yourssu.scouter.common.implement.domain.semester.SemesterReader
 import com.yourssu.scouter.common.implement.domain.user.User
+import com.yourssu.scouter.common.implement.support.google.ResponseItem
+import com.yourssu.scouter.document.business.domain.rubric.DocumentSectionService
+import com.yourssu.scouter.document.implement.domain.rubric.DocumentSection
 import org.springframework.stereotype.Service
 import java.time.Instant
 import java.time.LocalDate
@@ -19,6 +22,7 @@ class ApplicantSyncService(
     private val applicantSyncLogWriter: ApplicantSyncLogWriter,
     private val applicantSyncMappingReader: ApplicantSyncMappingReader,
     private val formResponseProcessor: FormResponseToApplicantProcessor,
+    private val documentSectionService: DocumentSectionService,
 ) {
 
     fun includeFromForms(
@@ -101,17 +105,42 @@ class ApplicantSyncService(
         savedApplicants: List<Applicant>,
         syncResults: List<ApplicantSyncInfo>,
     ) {
-        val newAnswers: List<ApplicantAnswer> = savedApplicants.zip(syncResults) { saved, syncResult ->
+        val pairs = savedApplicants.zip(syncResults)
+        val sectionsByPartIdAndQuestion = syncDocumentSections(pairs)
+
+        val newAnswers: List<ApplicantAnswer> = pairs.flatMap { (saved, syncResult) ->
             syncResult.unmappedResponseItems.map { item ->
                 ApplicantAnswer(
                     applicantId = saved.id!!,
+                    sectionId = sectionsByPartIdAndQuestion[saved.part.id!! to item.question]?.id,
                     question = item.question,
                     answer = item.answer,
                 )
             }
-        }.flatten()
+        }
 
         applicantAnswerWriter.writeAll(newAnswers)
+    }
+
+    // 서류 평가 문항은 파트별로 관리되므로, 서술형 질문을 파트별로 모아 DocumentSection을 동기화한다 [B1].
+    private fun syncDocumentSections(
+        pairs: List<Pair<Applicant, ApplicantSyncInfo>>,
+    ): Map<Pair<Long, String>, DocumentSection> {
+        val descriptiveQuestionsByPartId: Map<Long, Set<String>> = pairs
+            .flatMap { (saved, syncResult) ->
+                syncResult.unmappedResponseItems
+                    .filter(ResponseItem::isDescriptive)
+                    .map { saved.part.id!! to it.question }
+            }
+            .groupBy({ it.first }, { it.second })
+            .mapValues { it.value.toSet() }
+
+        return descriptiveQuestionsByPartId
+            .flatMap { (partId, questions) ->
+                documentSectionService.syncSectionsFromQuestions(partId, questions)
+                    .map { (question, section) -> (partId to question) to section }
+            }
+            .toMap()
     }
 
     fun readLastUpdatedTime(): Instant? {

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/support/google/GoogleFormsClient.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/support/google/GoogleFormsClient.kt
@@ -50,7 +50,12 @@ data class QuestionItem(
 )
 
 data class Question(
-    val questionId: String
+    val questionId: String,
+    val textQuestion: TextQuestion? = null,
+)
+
+data class TextQuestion(
+    val paragraph: Boolean = false,
 )
 
 data class GoogleFormResponses(

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/support/google/GoogleFormsReader.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/support/google/GoogleFormsReader.kt
@@ -10,6 +10,7 @@ class GoogleFormsReader(
     fun getUserResponses(authorizationHeader: String, formId: String): List<UserResponse> {
         val questionResponse = googleFormsClient.getFormQuestions(authorizationHeader, formId)
         val questionMap: Map<String, String?> = makeQuestionIdAndTitleMap(questionResponse)
+        val descriptiveQuestionIds: Set<String> = makeDescriptiveQuestionIds(questionResponse)
         val groupQuestionMap: Map<String, String> = getGroupItems(questionResponse)
         val formResponses: GoogleFormResponses = googleFormsClient.getFormResponses(authorizationHeader, formId)
 
@@ -19,7 +20,7 @@ class GoogleFormsReader(
                 createTime = googleUserResponse.createTime,
                 respondentEmail = googleUserResponse.respondentEmail,
                 lastSubmittedTime = googleUserResponse.lastSubmittedTime,
-                responseItems = convertToResponseItems(googleUserResponse, questionMap, groupQuestionMap)
+                responseItems = convertToResponseItems(googleUserResponse, questionMap, groupQuestionMap, descriptiveQuestionIds)
             )
         }
     }
@@ -30,6 +31,14 @@ class GoogleFormsReader(
                 val questionId = item.questionItem?.question?.questionId ?: return@mapNotNull null
                 questionId to item.title
             }.toMap()
+
+    // 서술형(단락) 질문의 questionId 집합 — 이 질문들만 서류 평가 문항(DocumentSection) 생성 대상이 된다.
+    private fun makeDescriptiveQuestionIds(questionResponse: GoogleFormQuestions): Set<String> =
+        questionResponse.items
+            .mapNotNull { item -> item.questionItem?.question }
+            .filter { question -> question.textQuestion?.paragraph == true }
+            .map { question -> question.questionId }
+            .toSet()
 
     private fun getGroupItems(questionResponse: GoogleFormQuestions) =
         questionResponse.items.flatMap { item ->
@@ -42,12 +51,13 @@ class GoogleFormsReader(
     private fun convertToResponseItems(
         googleUserResponse: GoogleUserResponse,
         questionMap: Map<String, String?>,
-        groupQuestionMap: Map<String, String>
+        groupQuestionMap: Map<String, String>,
+        descriptiveQuestionIds: Set<String>,
     ): List<ResponseItem> {
         val responseItems: List<ResponseItem> = googleUserResponse.answers.mapNotNull { (questionId, answer) ->
             val questionTitle = questionMap[questionId] ?: groupQuestionMap[questionId] ?: return@mapNotNull null
             val answerText = answer.textAnswers?.answers?.joinToString(", ") { it.value.toString() } ?: ""
-            ResponseItem(questionTitle, answerText)
+            ResponseItem(questionTitle, answerText, isDescriptive = questionId in descriptiveQuestionIds)
         }
         return responseItems
     }

--- a/src/main/kotlin/com/yourssu/scouter/common/implement/support/google/UserResponse.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/implement/support/google/UserResponse.kt
@@ -41,5 +41,6 @@ data class UserResponse(
 
 data class ResponseItem(
     val question: String,
-    val answer: String
+    val answer: String,
+    val isDescriptive: Boolean = false,
 )

--- a/src/main/kotlin/com/yourssu/scouter/document/business/domain/rubric/DocumentSectionService.kt
+++ b/src/main/kotlin/com/yourssu/scouter/document/business/domain/rubric/DocumentSectionService.kt
@@ -53,4 +53,31 @@ class DocumentSectionService(
         }
         documentSectionWriter.writeAll(updated)
     }
+
+    // 구글폼 동기화 시 서술형 질문에서 문항을 자동 생성한다 [B1]. 질문 텍스트가 이미 있으면 기존 문항을 그대로 재사용하고,
+    // 새 질문 텍스트만 배점 0 / 지표 빈 문자열로 생성한다 (배점·지표는 이후 PUT rubrics로 채운다).
+    @Transactional
+    fun syncSectionsFromQuestions(partId: Long, questions: Set<String>): Map<String, DocumentSection> {
+        if (questions.isEmpty()) {
+            return emptyMap()
+        }
+
+        val existingSections = documentSectionReader.readAllByPartId(partId)
+        val existingByQuestion = existingSections.associateBy { it.question }
+
+        val newQuestions = questions.filterNot { existingByQuestion.containsKey(it) }
+        val createdSections = if (newQuestions.isEmpty()) {
+            emptyList()
+        } else {
+            documentSectionWriter.writeAll(
+                newQuestions.map { question ->
+                    DocumentSection(partId = partId, question = question, maxScore = 0, criterionDetail = "")
+                },
+            )
+        }
+
+        return (existingSections + createdSections)
+            .filter { it.question in questions }
+            .associateBy { it.question }
+    }
 }


### PR DESCRIPTION
## 📄 작업 내용 요약

`docs/api-spec-v2.md` [B1] 기준, 구글폼 동기화 시 폼의 서술형 질문에서 파트별 서류 평가 문항(DocumentSection)을 자동 생성하고 지원자 답변을 section에 연결합니다.

- Google Forms API의 `textQuestion.paragraph` 필드를 읽어 `ResponseItem.isDescriptive` 플래그로 노출 (기존 `GoogleFormsReader`/`UserResponse` 확장, `MemberSyncService` 등 다른 소비자에는 영향 없음)
- `ApplicantSyncService.writeUnmappedAnswers`에서 매핑되지 않은 서술형 질문을 파트별로 모아 `DocumentSectionService.syncSectionsFromQuestions`로 동기화
  - 질문 텍스트가 이미 존재하는 문항이면 그대로 재사용 (배점/지표는 API로만 수정, 동기화가 덮어쓰지 않음)
  - 새 질문 텍스트만 배점 0 / 지표 빈 문자열로 신규 생성 (이후 `PUT /parts/{partId}/documents/rubrics`로 채움)
- 매칭된 문항의 `ApplicantAnswer.sectionId`를 연결 (서술형이 아닌 매핑 안 된 질문은 기존처럼 `sectionId` null 유지)

## 📎 Issue 번호
closed #321