### PR TITLE
[#324] feat: 서류 코멘트 답글(대댓글) 기능 추가

### DIFF
--- a/src/main/kotlin/com/yourssu/scouter/document/application/domain/comment/CreateDocumentCommentRequest.kt
+++ b/src/main/kotlin/com/yourssu/scouter/document/application/domain/comment/CreateDocumentCommentRequest.kt
@@ -11,11 +11,14 @@ data class CreateDocumentCommentRequest(
 
     @field:NotBlank
     val content: String?,
+
+    val parentCommentId: Long? = null,
 ) {
     fun toCommand(applicantId: Long, authorUserId: Long): CreateDocumentCommentCommand = CreateDocumentCommentCommand(
         applicantId = applicantId,
         sectionId = sectionId!!,
         authorUserId = authorUserId,
         content = content!!,
+        parentCommentId = parentCommentId,
     )
 }

--- a/src/main/kotlin/com/yourssu/scouter/document/application/domain/comment/ReadDocumentCommentResponse.kt
+++ b/src/main/kotlin/com/yourssu/scouter/document/application/domain/comment/ReadDocumentCommentResponse.kt
@@ -20,6 +20,7 @@ data class ReadDocumentCommentResponse(
     val sectionId: Long,
     val content: String,
     val author: ReadDocumentCommentAuthorResponse,
+    val parentCommentId: Long?,
     val createdAt: Instant?,
 ) {
     companion object {
@@ -28,6 +29,7 @@ data class ReadDocumentCommentResponse(
             sectionId = dto.sectionId,
             content = dto.content,
             author = ReadDocumentCommentAuthorResponse.from(dto.author),
+            parentCommentId = dto.parentCommentId,
             createdAt = dto.createdAt,
         )
     }

--- a/src/main/kotlin/com/yourssu/scouter/document/business/domain/comment/CreateDocumentCommentCommand.kt
+++ b/src/main/kotlin/com/yourssu/scouter/document/business/domain/comment/CreateDocumentCommentCommand.kt
@@ -5,4 +5,5 @@ data class CreateDocumentCommentCommand(
     val sectionId: Long,
     val authorUserId: Long,
     val content: String,
+    val parentCommentId: Long? = null,
 )

--- a/src/main/kotlin/com/yourssu/scouter/document/business/domain/comment/DocumentCommentDto.kt
+++ b/src/main/kotlin/com/yourssu/scouter/document/business/domain/comment/DocumentCommentDto.kt
@@ -14,6 +14,7 @@ data class DocumentCommentDto(
     val sectionId: Long,
     val content: String,
     val author: DocumentCommentAuthorDto,
+    val parentCommentId: Long?,
     val createdAt: Instant?,
 ) {
     companion object {
@@ -22,6 +23,7 @@ data class DocumentCommentDto(
             sectionId = comment.sectionId,
             content = comment.content,
             author = author,
+            parentCommentId = comment.parentCommentId,
             createdAt = comment.createdAt,
         )
     }

--- a/src/main/kotlin/com/yourssu/scouter/document/business/domain/comment/DocumentCommentService.kt
+++ b/src/main/kotlin/com/yourssu/scouter/document/business/domain/comment/DocumentCommentService.kt
@@ -8,6 +8,8 @@ import com.yourssu.scouter.document.implement.domain.comment.DocumentCommentRead
 import com.yourssu.scouter.document.implement.domain.comment.DocumentCommentWriter
 import com.yourssu.scouter.document.implement.domain.rubric.DocumentSectionReader
 import com.yourssu.scouter.document.implement.support.exception.DocumentCommentAccessDeniedException
+import com.yourssu.scouter.document.implement.support.exception.DocumentCommentReplyDepthExceededException
+import com.yourssu.scouter.document.implement.support.exception.DocumentCommentSectionMismatchException
 import com.yourssu.scouter.document.implement.support.exception.DocumentSectionNotFoundException
 import com.yourssu.scouter.hrms.implement.domain.member.MemberReader
 import org.springframework.stereotype.Service
@@ -34,12 +36,23 @@ class DocumentCommentService(
             throw DocumentSectionNotFoundException("해당 파트에 존재하지 않는 문항입니다: ${command.sectionId}")
         }
 
+        if (command.parentCommentId != null) {
+            val parent = documentCommentReader.readById(command.parentCommentId)
+            if (parent.isReply) {
+                throw DocumentCommentReplyDepthExceededException("답글에는 다시 답글을 달 수 없습니다.")
+            }
+            if (parent.sectionId != command.sectionId) {
+                throw DocumentCommentSectionMismatchException("부모 코멘트와 sectionId가 일치하지 않습니다.")
+            }
+        }
+
         val saved = documentCommentWriter.write(
             DocumentComment(
                 applicantId = command.applicantId,
                 sectionId = command.sectionId,
                 authorUserId = command.authorUserId,
                 content = command.content,
+                parentCommentId = command.parentCommentId,
             ),
         )
 

--- a/src/main/kotlin/com/yourssu/scouter/document/implement/domain/comment/DocumentComment.kt
+++ b/src/main/kotlin/com/yourssu/scouter/document/implement/domain/comment/DocumentComment.kt
@@ -8,8 +8,12 @@ class DocumentComment(
     val sectionId: Long,
     val authorUserId: Long,
     val content: String,
+    val parentCommentId: Long? = null,
     val createdAt: Instant? = null,
 ) {
+
+    val isReply: Boolean
+        get() = parentCommentId != null
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true

--- a/src/main/kotlin/com/yourssu/scouter/document/implement/support/exception/DocumentCommentReplyDepthExceededException.kt
+++ b/src/main/kotlin/com/yourssu/scouter/document/implement/support/exception/DocumentCommentReplyDepthExceededException.kt
@@ -1,0 +1,8 @@
+package com.yourssu.scouter.document.implement.support.exception
+
+import com.yourssu.scouter.common.implement.support.exception.CustomException
+import org.springframework.http.HttpStatus
+
+class DocumentCommentReplyDepthExceededException(
+    message: String,
+) : CustomException(message, "DocumentComment-003", HttpStatus.BAD_REQUEST)

--- a/src/main/kotlin/com/yourssu/scouter/document/implement/support/exception/DocumentCommentSectionMismatchException.kt
+++ b/src/main/kotlin/com/yourssu/scouter/document/implement/support/exception/DocumentCommentSectionMismatchException.kt
@@ -1,0 +1,8 @@
+package com.yourssu.scouter.document.implement.support.exception
+
+import com.yourssu.scouter.common.implement.support.exception.CustomException
+import org.springframework.http.HttpStatus
+
+class DocumentCommentSectionMismatchException(
+    message: String,
+) : CustomException(message, "DocumentComment-004", HttpStatus.BAD_REQUEST)

--- a/src/main/kotlin/com/yourssu/scouter/document/storage/domain/comment/DocumentCommentEntity.kt
+++ b/src/main/kotlin/com/yourssu/scouter/document/storage/domain/comment/DocumentCommentEntity.kt
@@ -32,6 +32,9 @@ class DocumentCommentEntity(
 
     @Column(nullable = false, columnDefinition = "TEXT")
     val content: String,
+
+    @Column(name = "parent_comment_id")
+    val parentCommentId: Long? = null,
 ) {
 
     @CreatedDate
@@ -45,6 +48,7 @@ class DocumentCommentEntity(
         sectionId = sectionId,
         authorUserId = authorUserId,
         content = content,
+        parentCommentId = parentCommentId,
         createdAt = createdAt,
     )
 

--- a/src/main/kotlin/com/yourssu/scouter/document/storage/domain/comment/DocumentCommentRepositoryImpl.kt
+++ b/src/main/kotlin/com/yourssu/scouter/document/storage/domain/comment/DocumentCommentRepositoryImpl.kt
@@ -17,6 +17,7 @@ class DocumentCommentRepositoryImpl(
             sectionId = comment.sectionId,
             authorUserId = comment.authorUserId,
             content = comment.content,
+            parentCommentId = comment.parentCommentId,
         )
 
         return jpaDocumentCommentRepository.save(entity).toDomain()

--- a/src/main/resources/db/migration/V23__add_parent_comment_id_to_document_comment.sql
+++ b/src/main/resources/db/migration/V23__add_parent_comment_id_to_document_comment.sql
@@ -1,0 +1,4 @@
+ALTER TABLE document_comment
+    ADD COLUMN parent_comment_id BIGINT NULL,
+    ADD CONSTRAINT fk_document_comment_parent
+        FOREIGN KEY (parent_comment_id) REFERENCES document_comment (id) ON DELETE CASCADE;


### PR DESCRIPTION
## Summary
- 서류 코멘트에 답글을 달 수 있도록 `parentCommentId`를 추가했다 (1단계까지만 허용, 답글에 답글은 불가)
- `document_comment` 테이블에 `parent_comment_id` 컬럼과 FK(ON DELETE CASCADE)를 추가해 원 댓글 삭제 시 답글도 함께 삭제되도록 했다
- 부모 댓글이 이미 답글이거나 부모/자식의 sectionId가 다르면 400을 반환한다

closes #324

## Test plan
- [ ] `./gradlew compileKotlin` 통과 확인
- [ ] 로컬에서 원 댓글 작성 → 답글 작성 → 조회 시 parentCommentId 확인
- [ ] 답글에 답글 시도 시 400 확인
- [ ] 원 댓글 삭제 시 답글도 함께 삭제되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)