### PR TITLE
feat: members/me 응답에 상태별 members 조회 응답 필드를 재사용하도록 통합

### DIFF
--- a/src/main/kotlin/com/yourssu/scouter/hrms/application/domain/me/MeResponse.kt
+++ b/src/main/kotlin/com/yourssu/scouter/hrms/application/domain/me/MeResponse.kt
@@ -1,71 +1,55 @@
 package com.yourssu.scouter.hrms.application.domain.me
 
-import com.yourssu.scouter.hrms.application.domain.member.ReadDivisionAndPartInMemberResponse
+import com.yourssu.scouter.hrms.application.domain.member.ReadActiveMemberListItemResponse
+import com.yourssu.scouter.hrms.application.domain.member.ReadCompletedMemberListItemResponse
+import com.yourssu.scouter.hrms.application.domain.member.ReadGraduatedMemberListItemResponse
+import com.yourssu.scouter.hrms.application.domain.member.ReadInactiveMemberListItemResponse
+import com.yourssu.scouter.hrms.application.domain.member.ReadMemberResponse
+import com.yourssu.scouter.hrms.application.domain.member.ReadWithdrawnMemberListItemResponse
 import com.yourssu.scouter.hrms.business.domain.me.MeResult
-import com.yourssu.scouter.hrms.business.support.utils.MemberRoleConverter
-import com.yourssu.scouter.hrms.business.support.utils.MemberStateConverter
-import com.yourssu.scouter.hrms.business.support.utils.NicknameConverter
+import com.yourssu.scouter.hrms.business.domain.member.ActiveMemberDto
+import com.yourssu.scouter.hrms.business.domain.member.CompletedMemberDto
+import com.yourssu.scouter.hrms.business.domain.member.GraduatedMemberDto
+import com.yourssu.scouter.hrms.business.domain.member.InactiveMemberDto
+import com.yourssu.scouter.hrms.business.domain.member.WithdrawnMemberDto
 import io.swagger.v3.oas.annotations.media.Schema
 import java.time.Instant
-import java.time.LocalDate
 
+/**
+ * 내 정보 응답. [member]는 현재 상태(액티브/비액티브/수료/졸업/탈퇴)의 members 목록 조회 응답(*ListItemResponse)과
+ * 동일한 타입/필드를 그대로 사용하므로, members 조회 응답이 바뀌면 함께 바뀐다.
+ * note(비고)는 members 목록 조회에서도 민감정보로 마스킹되는 필드이므로 me 응답에서도 동일하게 숨긴다.
+ */
 @Schema(description = "내 정보 응답")
 data class MeResponse(
     @field:Schema(description = "구글 프로필 이미지 URL")
     val profileImageUrl: String,
-    @field:Schema(description = "멤버 ID", example = "1")
-    val memberId: Long,
-    @field:Schema(description = "이름", example = "홍길동")
-    val name: String,
-    @field:Schema(description = "이메일", example = "hong@soongsil.ac.kr")
-    val email: String,
-    @field:Schema(description = "전화번호", example = "010-1234-5678")
-    val phoneNumber: String,
-    @field:Schema(description = "생년월일", example = "2000-01-01")
-    val birthDate: LocalDate,
-    @field:Schema(description = "학과", example = "컴퓨터학부")
-    val department: String,
-    @field:Schema(description = "학번", example = "20210001")
-    val studentId: String,
-    @field:Schema(description = "소속 파트 목록")
-    val parts: List<ReadDivisionAndPartInMemberResponse>,
-    @field:Schema(description = "역할", example = "MEMBER")
-    val role: String,
-    @field:Schema(description = "닉네임", example = "piki(피키)")
-    val nickname: String,
-    @field:Schema(description = "상태", example = "활동")
-    val state: String,
-    @field:Schema(description = "가입일", example = "2024-03-01")
-    val joinDate: LocalDate,
     @field:Schema(description = "상태 변경 시간")
     val stateUpdatedTime: Instant,
     @field:Schema(description = "생성 시간")
     val createdTime: Instant,
     @field:Schema(description = "수정 시간")
     val updatedTime: Instant,
+    @field:Schema(
+        description = "멤버 정보(상태별 members 목록 조회 응답과 동일한 필드 구성)",
+        implementation = ReadMemberResponse::class,
+    )
+    val member: ReadMemberResponse,
 ) {
 
     companion object {
         fun from(result: MeResult): MeResponse = MeResponse(
             profileImageUrl = result.profileImageUrl,
-            memberId = result.member.id,
-            name = result.member.name,
-            email = result.member.email,
-            phoneNumber = result.member.phoneNumber,
-            birthDate = result.member.birthDate,
-            department = result.member.department.name,
-            studentId = result.member.studentId,
-            parts = result.member.parts.map { ReadDivisionAndPartInMemberResponse.from(it) },
-            role = MemberRoleConverter.convertToString(result.member.role),
-            nickname = NicknameConverter.combine(
-                nicknameEnglish = result.member.nicknameEnglish,
-                nicknameKorean = result.member.nicknameKorean,
-            ),
-            state = MemberStateConverter.convertToString(result.member.state),
-            joinDate = result.member.joinDate,
-            stateUpdatedTime = result.member.stateUpdatedTime,
-            createdTime = result.member.createdTime,
-            updatedTime = result.member.updatedTime,
+            stateUpdatedTime = result.member.member.stateUpdatedTime,
+            createdTime = result.member.member.createdTime,
+            updatedTime = result.member.member.updatedTime,
+            member = when (val memberState = result.member) {
+                is ActiveMemberDto -> ReadActiveMemberListItemResponse.from(memberState).copy(note = null)
+                is InactiveMemberDto -> ReadInactiveMemberListItemResponse.from(memberState).copy(note = null)
+                is CompletedMemberDto -> ReadCompletedMemberListItemResponse.from(memberState).copy(note = null)
+                is GraduatedMemberDto -> ReadGraduatedMemberListItemResponse.from(memberState).copy(note = null)
+                is WithdrawnMemberDto -> ReadWithdrawnMemberListItemResponse.from(memberState).copy(note = null)
+            },
         )
     }
 }

--- a/src/main/kotlin/com/yourssu/scouter/hrms/application/domain/member/ReadActiveMemberResponse.kt
+++ b/src/main/kotlin/com/yourssu/scouter/hrms/application/domain/member/ReadActiveMemberResponse.kt
@@ -41,7 +41,7 @@ data class ReadActiveMemberListItemResponse(
     val isOnLeave: Boolean?,
     @field:Schema(description = "비고(민감정보 마스킹 시 null)", example = "메모")
     val note: String?,
-) {
+) : ReadMemberResponse {
     companion object {
         fun from(activeMemberDto: ActiveMemberDto): ReadActiveMemberListItemResponse =
             ReadActiveMemberListItemResponse(

--- a/src/main/kotlin/com/yourssu/scouter/hrms/application/domain/member/ReadCompletedMemberResponse.kt
+++ b/src/main/kotlin/com/yourssu/scouter/hrms/application/domain/member/ReadCompletedMemberResponse.kt
@@ -38,7 +38,7 @@ data class ReadCompletedMemberListItemResponse(
     val completionSemester: String?,
     @field:Schema(description = "비고(민감정보 마스킹 시 null)", example = "메모")
     val note: String?,
-) {
+) : ReadMemberResponse {
     companion object {
         fun from(completedMemberDto: CompletedMemberDto): ReadCompletedMemberListItemResponse =
             ReadCompletedMemberListItemResponse(

--- a/src/main/kotlin/com/yourssu/scouter/hrms/application/domain/member/ReadGraduatedMemberResponse.kt
+++ b/src/main/kotlin/com/yourssu/scouter/hrms/application/domain/member/ReadGraduatedMemberResponse.kt
@@ -39,7 +39,7 @@ data class ReadGraduatedMemberListItemResponse(
     val isAdvisorDesired: Boolean,
     @field:Schema(description = "비고(민감정보 마스킹 시 null)", example = "메모")
     val note: String?,
-) {
+) : ReadMemberResponse {
     companion object {
         fun from(graduatedMemberDto: GraduatedMemberDto): ReadGraduatedMemberListItemResponse =
             ReadGraduatedMemberListItemResponse(

--- a/src/main/kotlin/com/yourssu/scouter/hrms/application/domain/member/ReadInactiveMemberResponse.kt
+++ b/src/main/kotlin/com/yourssu/scouter/hrms/application/domain/member/ReadInactiveMemberResponse.kt
@@ -57,7 +57,7 @@ data class ReadInactiveMemberListItemResponse(
     @field:Schema(description = "비액티브 기간 표기용 학기 수 라벨(예: 2학기, 모르면 null)")
     val inactiveSemesterCountLabel: String?,
     val note: String?,
-) {
+) : ReadMemberResponse {
     companion object {
         fun from(inactiveMemberDto: InactiveMemberDto): ReadInactiveMemberListItemResponse =
             ReadInactiveMemberListItemResponse(

--- a/src/main/kotlin/com/yourssu/scouter/hrms/application/domain/member/ReadMemberResponse.kt
+++ b/src/main/kotlin/com/yourssu/scouter/hrms/application/domain/member/ReadMemberResponse.kt
@@ -1,0 +1,19 @@
+package com.yourssu.scouter.hrms.application.domain.member
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+/**
+ * 상태별 멤버 목록 조회 응답(ReadActiveMemberListItemResponse 등)을 공통으로 다루기 위한 마커 인터페이스.
+ * 실제 응답은 멤버 상태(액티브/비액티브/수료/졸업/탈퇴)에 따라 아래 타입 중 하나로 내려간다.
+ */
+@Schema(
+    description = "멤버 상태에 따라 아래 타입 중 하나로 내려가는 멤버 정보",
+    oneOf = [
+        ReadActiveMemberListItemResponse::class,
+        ReadInactiveMemberListItemResponse::class,
+        ReadCompletedMemberListItemResponse::class,
+        ReadGraduatedMemberListItemResponse::class,
+        ReadWithdrawnMemberListItemResponse::class,
+    ],
+)
+sealed interface ReadMemberResponse

--- a/src/main/kotlin/com/yourssu/scouter/hrms/application/domain/member/ReadWithdrawnMemberResponse.kt
+++ b/src/main/kotlin/com/yourssu/scouter/hrms/application/domain/member/ReadWithdrawnMemberResponse.kt
@@ -25,7 +25,7 @@ data class ReadWithdrawnMemberListItemResponse(
     val withdrawnDate: LocalDate?,
     @field:Schema(description = "비고(민감정보 마스킹 시 null)", example = "개인 사정")
     val note: String?,
-) {
+) : ReadMemberResponse {
     companion object {
         fun from(withdrawnMemberDto: WithdrawnMemberDto): ReadWithdrawnMemberListItemResponse =
             ReadWithdrawnMemberListItemResponse(

--- a/src/main/kotlin/com/yourssu/scouter/hrms/business/domain/me/MeResult.kt
+++ b/src/main/kotlin/com/yourssu/scouter/hrms/business/domain/me/MeResult.kt
@@ -1,8 +1,8 @@
 package com.yourssu.scouter.hrms.business.domain.me
 
-import com.yourssu.scouter.hrms.business.domain.member.MemberDto
+import com.yourssu.scouter.hrms.business.domain.member.MemberStateDto
 
 data class MeResult(
     val profileImageUrl: String,
-    val member: MemberDto,
+    val member: MemberStateDto,
 )

--- a/src/main/kotlin/com/yourssu/scouter/hrms/business/domain/me/MeService.kt
+++ b/src/main/kotlin/com/yourssu/scouter/hrms/business/domain/me/MeService.kt
@@ -2,10 +2,16 @@ package com.yourssu.scouter.hrms.business.domain.me
 
 import com.yourssu.scouter.common.implement.domain.user.User
 import com.yourssu.scouter.common.implement.domain.user.UserReader
-import com.yourssu.scouter.hrms.business.domain.member.MemberDto
+import com.yourssu.scouter.hrms.business.domain.member.ActiveMemberDto
+import com.yourssu.scouter.hrms.business.domain.member.CompletedMemberDto
+import com.yourssu.scouter.hrms.business.domain.member.GraduatedMemberDto
+import com.yourssu.scouter.hrms.business.domain.member.InactiveMemberDto
+import com.yourssu.scouter.hrms.business.domain.member.MemberStateDto
+import com.yourssu.scouter.hrms.business.domain.member.WithdrawnMemberDto
 import com.yourssu.scouter.hrms.business.support.exception.MemberNotRegisteredException
 import com.yourssu.scouter.hrms.implement.domain.member.Member
 import com.yourssu.scouter.hrms.implement.domain.member.MemberReader
+import com.yourssu.scouter.hrms.implement.domain.member.MemberState
 import org.springframework.stereotype.Service
 
 @Service
@@ -18,10 +24,19 @@ class MeService(
         val user: User = userReader.readById(userId)
         val member: Member = memberReader.readByEmailOrNull(user.getEmailAddress())
             ?: throw MemberNotRegisteredException("등록된 멤버가 아닙니다.")
+        val memberId: Long = member.id!!
+
+        val memberState: MemberStateDto = when (member.state) {
+            MemberState.ACTIVE -> ActiveMemberDto.from(memberReader.readActiveByMemberId(memberId))
+            MemberState.INACTIVE -> InactiveMemberDto.from(memberReader.readInactiveByMemberId(memberId))
+            MemberState.COMPLETED -> CompletedMemberDto.from(memberReader.readCompletedByMemberId(memberId))
+            MemberState.GRADUATED -> GraduatedMemberDto.from(memberReader.readGraduatedByMemberId(memberId))
+            MemberState.WITHDRAWN -> WithdrawnMemberDto.from(memberReader.readWithdrawnByMemberId(memberId))
+        }
 
         return MeResult(
             profileImageUrl = user.userInfo.profileImageUrl,
-            member = MemberDto.from(member),
+            member = memberState,
         )
     }
 }

--- a/src/main/kotlin/com/yourssu/scouter/hrms/business/domain/member/ActiveMemberDto.kt
+++ b/src/main/kotlin/com/yourssu/scouter/hrms/business/domain/member/ActiveMemberDto.kt
@@ -4,11 +4,11 @@ import com.yourssu.scouter.hrms.implement.domain.member.ActiveMember
 
 data class ActiveMemberDto(
     val id: Long,
-    val member: MemberDto,
+    override val member: MemberDto,
     val isMembershipFeePaid: Boolean,
     val grade: Int? = null,
     val isOnLeave: Boolean? = null,
-) {
+) : MemberStateDto {
 
     companion object {
         fun from(activeMember: ActiveMember): ActiveMemberDto = ActiveMemberDto(

--- a/src/main/kotlin/com/yourssu/scouter/hrms/business/domain/member/CompletedMemberDto.kt
+++ b/src/main/kotlin/com/yourssu/scouter/hrms/business/domain/member/CompletedMemberDto.kt
@@ -5,9 +5,9 @@ import com.yourssu.scouter.hrms.implement.domain.member.CompletedMember
 
 data class CompletedMemberDto(
     val id: Long,
-    val member: MemberDto,
+    override val member: MemberDto,
     val completionSemester: SemesterDto,
-) {
+) : MemberStateDto {
 
     companion object {
         fun from(completedMember: CompletedMember): CompletedMemberDto = CompletedMemberDto(

--- a/src/main/kotlin/com/yourssu/scouter/hrms/business/domain/member/GraduatedMemberDto.kt
+++ b/src/main/kotlin/com/yourssu/scouter/hrms/business/domain/member/GraduatedMemberDto.kt
@@ -4,10 +4,10 @@ import com.yourssu.scouter.hrms.implement.domain.member.GraduatedMember
 
 data class GraduatedMemberDto(
     val id: Long,
-    val member: MemberDto,
+    override val member: MemberDto,
     val activePeriod: SemesterPeriodDto,
     val isAdvisorDesired: Boolean,
-) {
+) : MemberStateDto {
 
     companion object {
         fun from(graduatedMember: GraduatedMember): GraduatedMemberDto = GraduatedMemberDto(

--- a/src/main/kotlin/com/yourssu/scouter/hrms/business/domain/member/InactiveMemberDto.kt
+++ b/src/main/kotlin/com/yourssu/scouter/hrms/business/domain/member/InactiveMemberDto.kt
@@ -5,7 +5,7 @@ import com.yourssu.scouter.hrms.implement.domain.member.InactiveMember
 
 data class InactiveMemberDto(
     val id: Long,
-    val member: MemberDto,
+    override val member: MemberDto,
     val activePeriod: SemesterPeriodDto,
     val expectedReturnSemester: SemesterDto,
     val inactivePeriod: SemesterPeriodDto,
@@ -15,7 +15,7 @@ data class InactiveMemberDto(
     val activitySemestersLabel: String? = null,
     val totalActiveSemesters: Int? = null,
     val totalInactiveSemesters: Int? = null,
-) {
+) : MemberStateDto {
 
     companion object {
         fun from(inactiveMember: InactiveMember): InactiveMemberDto = InactiveMemberDto(

--- a/src/main/kotlin/com/yourssu/scouter/hrms/business/domain/member/MemberStateDto.kt
+++ b/src/main/kotlin/com/yourssu/scouter/hrms/business/domain/member/MemberStateDto.kt
@@ -1,0 +1,6 @@
+package com.yourssu.scouter.hrms.business.domain.member
+
+/** 상태별 멤버 조회 결과(ActiveMemberDto 등)를 공통으로 다루기 위한 마커 인터페이스 */
+sealed interface MemberStateDto {
+    val member: MemberDto
+}

--- a/src/main/kotlin/com/yourssu/scouter/hrms/business/domain/member/WithdrawnMemberDto.kt
+++ b/src/main/kotlin/com/yourssu/scouter/hrms/business/domain/member/WithdrawnMemberDto.kt
@@ -5,9 +5,9 @@ import java.time.LocalDate
 
 data class WithdrawnMemberDto(
     val id: Long,
-    val member: MemberDto,
+    override val member: MemberDto,
     val withdrawnDate: LocalDate? = null,
-) {
+) : MemberStateDto {
 
     companion object {
         fun from(withdrawnMember: WithdrawnMember): WithdrawnMemberDto = WithdrawnMemberDto(

--- a/src/test/kotlin/com/yourssu/scouter/hrms/business/domain/authentication/LoginServiceTest.kt
+++ b/src/test/kotlin/com/yourssu/scouter/hrms/business/domain/authentication/LoginServiceTest.kt
@@ -129,11 +129,16 @@ class LoginServiceTest {
             val meResponse = com.yourssu.scouter.hrms.application.domain.me.MeResponse.from(
                 com.yourssu.scouter.hrms.business.domain.me.MeResult(
                     profileImageUrl = result.profileImageUrl,
-                    member = result.member,
+                    member = com.yourssu.scouter.hrms.business.domain.member.ActiveMemberDto(
+                        id = result.member.id,
+                        member = result.member,
+                        isMembershipFeePaid = false,
+                    ),
                 )
             )
-            val fields = meResponse.javaClass.declaredFields.map { it.name }
-            assertThat(fields).doesNotContain("note")
+            val activeMemberResponse = meResponse.member
+                as com.yourssu.scouter.hrms.application.domain.member.ReadActiveMemberListItemResponse
+            assertThat(activeMemberResponse.note).isNull()
         }
 
         @Test

--- a/src/test/kotlin/com/yourssu/scouter/hrms/business/domain/me/MeServiceTest.kt
+++ b/src/test/kotlin/com/yourssu/scouter/hrms/business/domain/me/MeServiceTest.kt
@@ -7,7 +7,10 @@ import com.yourssu.scouter.common.implement.domain.user.UserInfo
 import com.yourssu.scouter.common.implement.domain.user.UserReader
 import com.yourssu.scouter.hrms.business.support.exception.MemberNotRegisteredException
 import com.yourssu.scouter.hrms.fixture.MemberFixtureBuilder
+import com.yourssu.scouter.hrms.implement.domain.member.ActiveMember
 import com.yourssu.scouter.hrms.implement.domain.member.MemberReader
+import com.yourssu.scouter.hrms.implement.domain.member.MemberState
+import com.yourssu.scouter.hrms.implement.domain.member.WithdrawnMember
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.BeforeEach
@@ -57,18 +60,20 @@ class MeServiceTest {
             // given
             val user = createUser()
             val member = MemberFixtureBuilder().email("hong@soongsil.ac.kr").build()
+            val activeMember = ActiveMember(id = 1L, member = member)
 
             whenever(userReader.readById(1L)).thenReturn(user)
             whenever(memberReader.readByEmailOrNull("hong@soongsil.ac.kr")).thenReturn(member)
+            whenever(memberReader.readActiveByMemberId(member.id!!)).thenReturn(activeMember)
 
             // when
             val result = meService.getMe(1L)
 
             // then
             assertThat(result.profileImageUrl).isEqualTo("https://lh3.googleusercontent.com/photo.jpg")
-            assertThat(result.member.id).isEqualTo(member.id)
-            assertThat(result.member.email).isEqualTo("hong@soongsil.ac.kr")
-            assertThat(result.member.name).isEqualTo("홍길동")
+            assertThat(result.member.member.id).isEqualTo(member.id)
+            assertThat(result.member.member.email).isEqualTo("hong@soongsil.ac.kr")
+            assertThat(result.member.member.name).isEqualTo("홍길동")
         }
 
         @Test
@@ -90,17 +95,49 @@ class MeServiceTest {
             // given
             val user = createUser()
             val member = MemberFixtureBuilder().email("hong@soongsil.ac.kr").build()
+            val activeMember = ActiveMember(id = 1L, member = member)
 
             whenever(userReader.readById(1L)).thenReturn(user)
             whenever(memberReader.readByEmailOrNull("hong@soongsil.ac.kr")).thenReturn(member)
+            whenever(memberReader.readActiveByMemberId(member.id!!)).thenReturn(activeMember)
 
             // when
             val result = meService.getMe(1L)
 
             // then
             val meResponse = com.yourssu.scouter.hrms.application.domain.me.MeResponse.from(result)
-            val fields = meResponse.javaClass.declaredFields.map { it.name }
-            assertThat(fields).doesNotContain("note")
+            val activeMemberResponse = meResponse.member
+                as com.yourssu.scouter.hrms.application.domain.member.ReadActiveMemberListItemResponse
+            assertThat(activeMemberResponse.note).isNull()
+        }
+
+        @Test
+        fun `탈퇴 상태 멤버는 탈퇴 멤버 응답 형태(withdrawnDate 포함, email 등 미포함)로 반환된다`() {
+            // given
+            val user = createUser()
+            val member = MemberFixtureBuilder()
+                .email("hong@soongsil.ac.kr")
+                .state(MemberState.WITHDRAWN)
+                .build()
+            val withdrawnMember = WithdrawnMember(
+                id = 1L,
+                member = member,
+                withdrawnDate = java.time.LocalDate.of(2025, 9, 1),
+            )
+
+            whenever(userReader.readById(1L)).thenReturn(user)
+            whenever(memberReader.readByEmailOrNull("hong@soongsil.ac.kr")).thenReturn(member)
+            whenever(memberReader.readWithdrawnByMemberId(member.id!!)).thenReturn(withdrawnMember)
+
+            // when
+            val result = meService.getMe(1L)
+            val meResponse = com.yourssu.scouter.hrms.application.domain.me.MeResponse.from(result)
+
+            // then
+            val withdrawnMemberResponse = meResponse.member
+                as com.yourssu.scouter.hrms.application.domain.member.ReadWithdrawnMemberListItemResponse
+            assertThat(withdrawnMemberResponse.withdrawnDate).isEqualTo(java.time.LocalDate.of(2025, 9, 1))
+            assertThat(withdrawnMemberResponse.note).isNull()
         }
     }
 }

--- a/src/test/kotlin/com/yourssu/scouter/hrms/fixture/MemberFixtureBuilder.kt
+++ b/src/test/kotlin/com/yourssu/scouter/hrms/fixture/MemberFixtureBuilder.kt
@@ -37,6 +37,7 @@ class MemberFixtureBuilder {
     fun name(name: String) = apply { this.name = name }
     fun email(email: String) = apply { this.email = email }
     fun studentId(studentId: String) = apply { this.studentId = studentId }
+    fun state(state: MemberState) = apply { this.state = state }
 
     fun build() = Member(
         id = id,


### PR DESCRIPTION
## Summary
- `/members/me` 응답이 자체 고정 필드를 나열하던 방식에서 벗어나, 로그인한 멤버의 상태(액티브/비액티브/수료/졸업/탈퇴)에 대응하는 `/members/{state}` 목록 조회 응답(`Read*ListItemResponse`)을 그대로 재사용하도록 변경했습니다. 이제 members 조회 응답 필드가 바뀌면 me 응답도 자동으로 따라갑니다.
- `note`(비고)는 members 목록 조회에서도 민감정보로 마스킹되는 필드라 me 응답에서도 동일하게 숨김 처리했습니다.
- `ReadMemberResponse`에 `@Schema(oneOf = [...])`를 추가해 Swagger 문서에서 상태별 응답 타입이 드러나도록 했습니다.

## Test plan
- [x] `./gradlew compileKotlin` / `compileTestKotlin` 통과
- [x] `./gradlew test` 전체 스위트 통과 (WITHDRAWN 상태 케이스 신규 테스트 포함)
- [ ] `/swagger-ui.html`에서 `/members/me` 응답 스키마 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)