### PR TITLE
[#329] feat: 인라인 코멘트 수정 기능 및 isEdited 컬럼 추가

### DIFF
--- a/src/main/kotlin/com/yourssu/scouter/recruiting/comment/application/DocumentCommentController.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/comment/application/DocumentCommentController.kt
@@ -4,6 +4,8 @@ import com.yourssu.scouter.recruiting.comment.application.dto.CreateDocumentComm
 
 import com.yourssu.scouter.recruiting.comment.application.dto.ReadDocumentCommentResponse
 
+import com.yourssu.scouter.recruiting.comment.application.dto.UpdateDocumentCommentRequest
+
 import com.yourssu.scouter.auth.support.application.authentication.AuthUser
 import com.yourssu.scouter.auth.support.application.authentication.AuthUserInfo
 import com.yourssu.scouter.recruiting.comment.business.dto.DocumentCommentDto
@@ -16,6 +18,7 @@ import jakarta.validation.Valid
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
@@ -53,6 +56,19 @@ class DocumentCommentController(
         val dto: DocumentCommentDto = documentCommentService.create(request.toCommand(applicantId, authUserInfo.userId))
 
         return ResponseEntity.created(URI.create("/applicants/$applicantId/documents/comments/${dto.commentId}")).build()
+    }
+
+    @Operation(summary = "인라인 코멘트 수정", description = "본인이 작성한 코멘트만 수정 가능합니다.")
+    @PatchMapping("/applicants/{applicantId}/documents/comments/{commentId}")
+    fun update(
+        @AuthUser authUserInfo: AuthUserInfo,
+        @PathVariable applicantId: Long,
+        @PathVariable commentId: Long,
+        @RequestBody @Valid request: UpdateDocumentCommentRequest,
+    ): ResponseEntity<ReadDocumentCommentResponse> {
+        val dto = documentCommentService.update(request.toCommand(commentId, authUserInfo.userId))
+
+        return ResponseEntity.ok(ReadDocumentCommentResponse.from(dto))
     }
 
     @Operation(summary = "인라인 코멘트 삭제", description = "본인이 작성한 코멘트만 삭제 가능합니다.")

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/comment/application/dto/ReadDocumentCommentResponse.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/comment/application/dto/ReadDocumentCommentResponse.kt
@@ -21,6 +21,7 @@ data class ReadDocumentCommentResponse(
     val content: String,
     val author: ReadDocumentCommentAuthorResponse,
     val parentCommentId: Long?,
+    val isEdited: Boolean,
     val createdAt: Instant?,
 ) {
     companion object {
@@ -30,6 +31,7 @@ data class ReadDocumentCommentResponse(
             content = dto.content,
             author = ReadDocumentCommentAuthorResponse.from(dto.author),
             parentCommentId = dto.parentCommentId,
+            isEdited = dto.isEdited,
             createdAt = dto.createdAt,
         )
     }

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/comment/application/dto/UpdateDocumentCommentRequest.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/comment/application/dto/UpdateDocumentCommentRequest.kt
@@ -1,0 +1,16 @@
+package com.yourssu.scouter.recruiting.comment.application.dto
+
+import com.yourssu.scouter.recruiting.comment.business.dto.UpdateDocumentCommentCommand
+import jakarta.validation.constraints.NotBlank
+
+data class UpdateDocumentCommentRequest(
+
+    @field:NotBlank
+    val content: String?,
+) {
+    fun toCommand(commentId: Long, requesterUserId: Long): UpdateDocumentCommentCommand = UpdateDocumentCommentCommand(
+        commentId = commentId,
+        requesterUserId = requesterUserId,
+        content = content!!,
+    )
+}

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/comment/business/DocumentCommentService.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/comment/business/DocumentCommentService.kt
@@ -6,6 +6,8 @@ import com.yourssu.scouter.recruiting.comment.business.dto.CreateDocumentComment
 
 import com.yourssu.scouter.recruiting.comment.business.dto.DocumentCommentDto
 
+import com.yourssu.scouter.recruiting.comment.business.dto.UpdateDocumentCommentCommand
+
 import com.yourssu.scouter.recruiting.applicant.implement.ApplicantReader
 import com.yourssu.scouter.auth.user.implement.User
 import com.yourssu.scouter.auth.user.implement.UserReader
@@ -63,6 +65,20 @@ class DocumentCommentService(
         )
 
         return DocumentCommentDto.of(saved, toAuthorDto(command.authorUserId))
+    }
+
+    @Transactional
+    fun update(command: UpdateDocumentCommentCommand): DocumentCommentDto {
+        require(command.content.isNotBlank()) { "코멘트 내용은 비어있을 수 없습니다." }
+
+        val comment = documentCommentReader.readById(command.commentId)
+        if (comment.authorUserId != command.requesterUserId) {
+            throw DocumentCommentAccessDeniedException("본인이 작성한 코멘트만 수정할 수 있습니다.")
+        }
+
+        val updated = documentCommentWriter.update(comment.edit(command.content))
+
+        return DocumentCommentDto.of(updated, toAuthorDto(updated.authorUserId))
     }
 
     fun readAllByApplicantId(applicantId: Long): List<DocumentCommentDto> {

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/comment/business/dto/DocumentCommentDto.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/comment/business/dto/DocumentCommentDto.kt
@@ -15,6 +15,7 @@ data class DocumentCommentDto(
     val content: String,
     val author: DocumentCommentAuthorDto,
     val parentCommentId: Long?,
+    val isEdited: Boolean,
     val createdAt: Instant?,
 ) {
     companion object {
@@ -24,6 +25,7 @@ data class DocumentCommentDto(
             content = comment.content,
             author = author,
             parentCommentId = comment.parentCommentId,
+            isEdited = comment.isEdited,
             createdAt = comment.createdAt,
         )
     }

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/comment/business/dto/UpdateDocumentCommentCommand.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/comment/business/dto/UpdateDocumentCommentCommand.kt
@@ -1,0 +1,7 @@
+package com.yourssu.scouter.recruiting.comment.business.dto
+
+data class UpdateDocumentCommentCommand(
+    val commentId: Long,
+    val requesterUserId: Long,
+    val content: String,
+)

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/comment/implement/DocumentComment.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/comment/implement/DocumentComment.kt
@@ -9,11 +9,23 @@ class DocumentComment(
     val authorUserId: Long,
     val content: String,
     val parentCommentId: Long? = null,
+    val isEdited: Boolean = false,
     val createdAt: Instant? = null,
 ) {
 
     val isReply: Boolean
         get() = parentCommentId != null
+
+    fun edit(newContent: String): DocumentComment = DocumentComment(
+        id = id,
+        applicantId = applicantId,
+        sectionId = sectionId,
+        authorUserId = authorUserId,
+        content = newContent,
+        parentCommentId = parentCommentId,
+        isEdited = true,
+        createdAt = createdAt,
+    )
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/comment/implement/DocumentCommentRepository.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/comment/implement/DocumentCommentRepository.kt
@@ -4,6 +4,8 @@ interface DocumentCommentRepository {
 
     fun save(comment: DocumentComment): DocumentComment
 
+    fun update(comment: DocumentComment): DocumentComment
+
     fun findAllByApplicantId(applicantId: Long): List<DocumentComment>
 
     fun findById(commentId: Long): DocumentComment?

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/comment/implement/DocumentCommentWriter.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/comment/implement/DocumentCommentWriter.kt
@@ -13,6 +13,10 @@ class DocumentCommentWriter(
         return documentCommentRepository.save(comment)
     }
 
+    fun update(comment: DocumentComment): DocumentComment {
+        return documentCommentRepository.update(comment)
+    }
+
     fun delete(commentId: Long) {
         documentCommentRepository.deleteById(commentId)
     }

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/comment/storage/DocumentCommentEntity.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/comment/storage/DocumentCommentEntity.kt
@@ -31,10 +31,13 @@ class DocumentCommentEntity(
     val authorUserId: Long,
 
     @Column(nullable = false, columnDefinition = "TEXT")
-    val content: String,
+    var content: String,
 
     @Column(name = "parent_comment_id")
     val parentCommentId: Long? = null,
+
+    @Column(name = "is_edited", nullable = false)
+    var isEdited: Boolean = false,
 ) {
 
     @CreatedDate
@@ -49,6 +52,7 @@ class DocumentCommentEntity(
         authorUserId = authorUserId,
         content = content,
         parentCommentId = parentCommentId,
+        isEdited = isEdited,
         createdAt = createdAt,
     )
 

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/comment/storage/DocumentCommentRepositoryImpl.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/comment/storage/DocumentCommentRepositoryImpl.kt
@@ -2,6 +2,7 @@ package com.yourssu.scouter.recruiting.comment.storage
 
 import com.yourssu.scouter.recruiting.comment.implement.DocumentComment
 import com.yourssu.scouter.recruiting.comment.implement.DocumentCommentRepository
+import com.yourssu.scouter.recruiting.support.implement.exception.DocumentCommentNotFoundException
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Repository
 
@@ -18,7 +19,18 @@ class DocumentCommentRepositoryImpl(
             authorUserId = comment.authorUserId,
             content = comment.content,
             parentCommentId = comment.parentCommentId,
+            isEdited = comment.isEdited,
         )
+
+        return jpaDocumentCommentRepository.save(entity).toDomain()
+    }
+
+    override fun update(comment: DocumentComment): DocumentComment {
+        val entity = jpaDocumentCommentRepository.findByIdOrNull(comment.id)
+            ?: throw DocumentCommentNotFoundException("지정한 코멘트를 찾을 수 없습니다.")
+
+        entity.content = comment.content
+        entity.isEdited = comment.isEdited
 
         return jpaDocumentCommentRepository.save(entity).toDomain()
     }

--- a/src/main/resources/db/migration/V24__add_is_edited_to_document_comment.sql
+++ b/src/main/resources/db/migration/V24__add_is_edited_to_document_comment.sql
@@ -1,0 +1,2 @@
+ALTER TABLE document_comment
+    ADD COLUMN is_edited BOOLEAN NOT NULL DEFAULT FALSE;


### PR DESCRIPTION
## Summary
- 인라인(서류) 코멘트 수정 API(PATCH) 추가 - 본인이 작성한 코멘트만 수정 가능
- `document_comment` 테이블에 수정 여부를 나타내는 `is_edited` 컬럼 추가, 조회 응답에 `isEdited` 노출

closes #329

## Test plan
- [x] `./gradlew compileKotlin`, `compileTestKotlin` 통과
- [ ] PATCH /applicants/{applicantId}/documents/comments/{commentId} 로 본인 코멘트 수정 시 200 및 isEdited=true 확인
- [ ] 타인 코멘트 수정 시 403(DocumentComment-002) 확인