### PR TITLE
[#334] 인라인 코멘트 작성자 식별자를 userId 대신 memberId로 노출

### DIFF
--- a/src/main/kotlin/com/yourssu/scouter/hrms/member/implement/MemberEvaluatorDirectory.kt
+++ b/src/main/kotlin/com/yourssu/scouter/hrms/member/implement/MemberEvaluatorDirectory.kt
@@ -18,6 +18,7 @@ class MemberEvaluatorDirectory(
     override fun findEvaluatorInfo(email: String): EvaluatorInfo? {
         val member = memberReader.readAllActive().find { it.member.email == email }?.member ?: return null
         return EvaluatorInfo(
+            memberId = member.id,
             nicknameEnglish = member.nicknameEnglish,
             partName = member.parts.firstOrNull()?.name,
         )

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/comment/application/dto/ReadDocumentCommentResponse.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/comment/application/dto/ReadDocumentCommentResponse.kt
@@ -5,13 +5,13 @@ import com.yourssu.scouter.recruiting.comment.business.dto.DocumentCommentDto
 import java.time.Instant
 
 data class ReadDocumentCommentAuthorResponse(
-    val userId: Long,
+    val memberId: Long?,
     val nickname: String,
     val part: String,
 ) {
     companion object {
         fun from(dto: DocumentCommentAuthorDto): ReadDocumentCommentAuthorResponse =
-            ReadDocumentCommentAuthorResponse(dto.userId, dto.nickname, dto.part)
+            ReadDocumentCommentAuthorResponse(dto.memberId, dto.nickname, dto.part)
     }
 }
 

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/comment/business/DocumentCommentService.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/comment/business/DocumentCommentService.kt
@@ -105,7 +105,7 @@ class DocumentCommentService(
         val info = evaluatorDirectory.findEvaluatorInfo(user.userInfo.email)
 
         return DocumentCommentAuthorDto(
-            userId = userId,
+            memberId = info?.memberId,
             nickname = info?.nicknameEnglish ?: user.userInfo.name,
             part = info?.partName ?: "",
         )

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/comment/business/dto/DocumentCommentDto.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/comment/business/dto/DocumentCommentDto.kt
@@ -4,7 +4,7 @@ import com.yourssu.scouter.recruiting.comment.implement.DocumentComment
 import java.time.Instant
 
 data class DocumentCommentAuthorDto(
-    val userId: Long,
+    val memberId: Long?,
     val nickname: String,
     val part: String,
 )

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/support/business/EvaluatorDirectory.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/support/business/EvaluatorDirectory.kt
@@ -11,6 +11,7 @@ data class EvaluatorSummary(
 )
 
 data class EvaluatorInfo(
+    val memberId: Long?,
     val nicknameEnglish: String?,
     val partName: String?,
 )


### PR DESCRIPTION
## 배경
`DocumentCommentController`의 인라인 코멘트 조회/수정 응답이 인증 도메인(User)의 내부 PK인 `userId`를 그대로 외부 API에 노출하고 있었습니다. 반면 `GET /members/me` 응답은 HRMS 도메인(Member)의 `memberId`만 내려주기 때문에, 프론트엔드에서 "내가 쓴 코멘트인지" 판별하려 해도 기준 식별자가 서로 달라 비교할 수 없는 문제가 있었습니다.

## 변경 사항
- `EvaluatorDirectory.EvaluatorInfo`에 `memberId: Long?` 필드 추가
- `MemberEvaluatorDirectory.findEvaluatorInfo`에서 이미 조회 중인 `Member`로부터 `memberId` 채움 (추가 쿼리 없음)
- `DocumentCommentService.toAuthorDto`가 `userId` 대신 `memberId`를 매핑하도록 변경
- `DocumentCommentAuthorDto`, `ReadDocumentCommentAuthorResponse`의 `userId` 필드를 `memberId`로 교체
- 내부 저장/도메인 로직(`DocumentComment.authorUserId`, 권한 체크)은 변경하지 않고 API 응답 계층에서만 memberId로 변환

Resolves #334

## Test plan
- [x] `./gradlew compileKotlin` 통과 확인
- [x] 코멘트 목록/작성/수정 API 응답에서 `author.memberId`가 `/members/me`의 `memberId`와 일치하는지 실제 환경에서 확인