### PR TITLE
[#316]; feat: 파트 면접 요구조건/스크립트 API 구현

### DIFF
--- a/src/main/kotlin/com/yourssu/scouter/recruiting/interview/application/InterviewScriptController.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/interview/application/InterviewScriptController.kt
@@ -1,0 +1,40 @@
+package com.yourssu.scouter.recruiting.interview.application
+
+import com.yourssu.scouter.recruiting.interview.application.dto.ReadInterviewScriptResponse
+import com.yourssu.scouter.recruiting.interview.application.dto.UpdateInterviewScriptRequest
+import com.yourssu.scouter.recruiting.interview.business.InterviewScriptService
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.validation.Valid
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RestController
+
+@Tag(name = "면접 스크립트")
+@RestController
+class InterviewScriptController(
+    private val interviewScriptService: InterviewScriptService,
+) {
+
+    @Operation(summary = "파트별 면접 스크립트 조회")
+    @GetMapping("/parts/{partId}/interviews/scripts")
+    fun readByPartId(
+        @PathVariable partId: Long,
+    ): ResponseEntity<ReadInterviewScriptResponse> {
+        return ResponseEntity.ok(ReadInterviewScriptResponse.from(interviewScriptService.readByPartId(partId)))
+    }
+
+    @Operation(summary = "파트별 면접 스크립트 수정")
+    @PutMapping("/parts/{partId}/interviews/scripts")
+    fun upsert(
+        @PathVariable partId: Long,
+        @RequestBody @Valid request: UpdateInterviewScriptRequest,
+    ): ResponseEntity<Unit> {
+        interviewScriptService.upsert(partId, request.opening!!, request.closing!!)
+
+        return ResponseEntity.ok().build()
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/interview/application/PartInterviewRequirementController.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/interview/application/PartInterviewRequirementController.kt
@@ -1,0 +1,42 @@
+package com.yourssu.scouter.recruiting.interview.application
+
+import com.yourssu.scouter.recruiting.interview.application.dto.ReadPartInterviewRequirementResponse
+import com.yourssu.scouter.recruiting.interview.application.dto.UpdatePartInterviewRequirementRequest
+import com.yourssu.scouter.recruiting.interview.business.PartInterviewRequirementService
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.validation.Valid
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RestController
+
+@Tag(name = "면접 요구조건")
+@RestController
+class PartInterviewRequirementController(
+    private val partInterviewRequirementService: PartInterviewRequirementService,
+) {
+
+    @Operation(summary = "파트별 면접 요구조건 조회")
+    @GetMapping("/parts/{partId}/interviews/requirements")
+    fun readByPartId(
+        @PathVariable partId: Long,
+    ): ResponseEntity<ReadPartInterviewRequirementResponse> {
+        return ResponseEntity.ok(
+            ReadPartInterviewRequirementResponse.from(partInterviewRequirementService.readByPartId(partId)),
+        )
+    }
+
+    @Operation(summary = "파트별 면접 요구조건 수정")
+    @PutMapping("/parts/{partId}/interviews/requirements")
+    fun upsert(
+        @PathVariable partId: Long,
+        @RequestBody @Valid request: UpdatePartInterviewRequirementRequest,
+    ): ResponseEntity<Unit> {
+        partInterviewRequirementService.upsert(partId, request.culture!!, request.team!!, request.job!!)
+
+        return ResponseEntity.ok().build()
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/interview/application/dto/ReadInterviewScriptResponse.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/interview/application/dto/ReadInterviewScriptResponse.kt
@@ -1,0 +1,15 @@
+package com.yourssu.scouter.recruiting.interview.application.dto
+
+import com.yourssu.scouter.recruiting.interview.business.dto.InterviewScriptDto
+
+data class ReadInterviewScriptResponse(
+    val opening: String?,
+    val closing: String?,
+) {
+    companion object {
+        fun from(dto: InterviewScriptDto): ReadInterviewScriptResponse = ReadInterviewScriptResponse(
+            opening = dto.opening,
+            closing = dto.closing,
+        )
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/interview/application/dto/ReadPartInterviewRequirementResponse.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/interview/application/dto/ReadPartInterviewRequirementResponse.kt
@@ -1,0 +1,17 @@
+package com.yourssu.scouter.recruiting.interview.application.dto
+
+import com.yourssu.scouter.recruiting.interview.business.dto.PartInterviewRequirementDto
+
+data class ReadPartInterviewRequirementResponse(
+    val culture: String?,
+    val team: String?,
+    val job: String?,
+) {
+    companion object {
+        fun from(dto: PartInterviewRequirementDto): ReadPartInterviewRequirementResponse = ReadPartInterviewRequirementResponse(
+            culture = dto.culture,
+            team = dto.team,
+            job = dto.job,
+        )
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/interview/application/dto/UpdateInterviewScriptRequest.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/interview/application/dto/UpdateInterviewScriptRequest.kt
@@ -1,0 +1,12 @@
+package com.yourssu.scouter.recruiting.interview.application.dto
+
+import jakarta.validation.constraints.NotBlank
+
+data class UpdateInterviewScriptRequest(
+
+    @field:NotBlank
+    val opening: String?,
+
+    @field:NotBlank
+    val closing: String?,
+)

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/interview/application/dto/UpdatePartInterviewRequirementRequest.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/interview/application/dto/UpdatePartInterviewRequirementRequest.kt
@@ -1,0 +1,15 @@
+package com.yourssu.scouter.recruiting.interview.application.dto
+
+import jakarta.validation.constraints.NotBlank
+
+data class UpdatePartInterviewRequirementRequest(
+
+    @field:NotBlank
+    val culture: String?,
+
+    @field:NotBlank
+    val team: String?,
+
+    @field:NotBlank
+    val job: String?,
+)

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/interview/business/InterviewScriptService.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/interview/business/InterviewScriptService.kt
@@ -1,0 +1,30 @@
+package com.yourssu.scouter.recruiting.interview.business
+
+import com.yourssu.scouter.common.part.implement.PartReader
+import com.yourssu.scouter.recruiting.interview.business.dto.InterviewScriptDto
+import com.yourssu.scouter.recruiting.interview.implement.InterviewScript
+import com.yourssu.scouter.recruiting.interview.implement.InterviewScriptReader
+import com.yourssu.scouter.recruiting.interview.implement.InterviewScriptWriter
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class InterviewScriptService(
+    private val interviewScriptReader: InterviewScriptReader,
+    private val interviewScriptWriter: InterviewScriptWriter,
+    private val partReader: PartReader,
+) {
+
+    fun readByPartId(partId: Long): InterviewScriptDto {
+        partReader.readById(partId)
+
+        return InterviewScriptDto.from(interviewScriptReader.readByPartId(partId))
+    }
+
+    @Transactional
+    fun upsert(partId: Long, opening: String, closing: String) {
+        partReader.readById(partId)
+
+        interviewScriptWriter.upsert(InterviewScript(partId, opening, closing))
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/interview/business/PartInterviewRequirementService.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/interview/business/PartInterviewRequirementService.kt
@@ -1,0 +1,30 @@
+package com.yourssu.scouter.recruiting.interview.business
+
+import com.yourssu.scouter.common.part.implement.PartReader
+import com.yourssu.scouter.recruiting.interview.business.dto.PartInterviewRequirementDto
+import com.yourssu.scouter.recruiting.interview.implement.PartInterviewRequirement
+import com.yourssu.scouter.recruiting.interview.implement.PartInterviewRequirementReader
+import com.yourssu.scouter.recruiting.interview.implement.PartInterviewRequirementWriter
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class PartInterviewRequirementService(
+    private val partInterviewRequirementReader: PartInterviewRequirementReader,
+    private val partInterviewRequirementWriter: PartInterviewRequirementWriter,
+    private val partReader: PartReader,
+) {
+
+    fun readByPartId(partId: Long): PartInterviewRequirementDto {
+        partReader.readById(partId)
+
+        return PartInterviewRequirementDto.from(partInterviewRequirementReader.readByPartId(partId))
+    }
+
+    @Transactional
+    fun upsert(partId: Long, culture: String, team: String, job: String) {
+        partReader.readById(partId)
+
+        partInterviewRequirementWriter.upsert(PartInterviewRequirement(partId, culture, team, job))
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/interview/business/dto/InterviewScriptDto.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/interview/business/dto/InterviewScriptDto.kt
@@ -1,0 +1,15 @@
+package com.yourssu.scouter.recruiting.interview.business.dto
+
+import com.yourssu.scouter.recruiting.interview.implement.InterviewScript
+
+data class InterviewScriptDto(
+    val opening: String?,
+    val closing: String?,
+) {
+    companion object {
+        fun from(script: InterviewScript?): InterviewScriptDto = InterviewScriptDto(
+            opening = script?.opening,
+            closing = script?.closing,
+        )
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/interview/business/dto/PartInterviewRequirementDto.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/interview/business/dto/PartInterviewRequirementDto.kt
@@ -1,0 +1,17 @@
+package com.yourssu.scouter.recruiting.interview.business.dto
+
+import com.yourssu.scouter.recruiting.interview.implement.PartInterviewRequirement
+
+data class PartInterviewRequirementDto(
+    val culture: String?,
+    val team: String?,
+    val job: String?,
+) {
+    companion object {
+        fun from(requirement: PartInterviewRequirement?): PartInterviewRequirementDto = PartInterviewRequirementDto(
+            culture = requirement?.culture,
+            team = requirement?.team,
+            job = requirement?.job,
+        )
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/interview/implement/InterviewScript.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/interview/implement/InterviewScript.kt
@@ -1,0 +1,7 @@
+package com.yourssu.scouter.recruiting.interview.implement
+
+class InterviewScript(
+    val partId: Long,
+    val opening: String,
+    val closing: String,
+)

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/interview/implement/InterviewScriptReader.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/interview/implement/InterviewScriptReader.kt
@@ -1,0 +1,15 @@
+package com.yourssu.scouter.recruiting.interview.implement
+
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+
+@Component
+@Transactional(readOnly = true)
+class InterviewScriptReader(
+    private val interviewScriptRepository: InterviewScriptRepository,
+) {
+
+    fun readByPartId(partId: Long): InterviewScript? {
+        return interviewScriptRepository.findByPartId(partId)
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/interview/implement/InterviewScriptRepository.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/interview/implement/InterviewScriptRepository.kt
@@ -1,0 +1,8 @@
+package com.yourssu.scouter.recruiting.interview.implement
+
+interface InterviewScriptRepository {
+
+    fun findByPartId(partId: Long): InterviewScript?
+
+    fun upsert(script: InterviewScript): InterviewScript
+}

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/interview/implement/InterviewScriptWriter.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/interview/implement/InterviewScriptWriter.kt
@@ -1,0 +1,15 @@
+package com.yourssu.scouter.recruiting.interview.implement
+
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+
+@Component
+@Transactional
+class InterviewScriptWriter(
+    private val interviewScriptRepository: InterviewScriptRepository,
+) {
+
+    fun upsert(script: InterviewScript): InterviewScript {
+        return interviewScriptRepository.upsert(script)
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/interview/implement/PartInterviewRequirement.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/interview/implement/PartInterviewRequirement.kt
@@ -1,0 +1,8 @@
+package com.yourssu.scouter.recruiting.interview.implement
+
+class PartInterviewRequirement(
+    val partId: Long,
+    val culture: String,
+    val team: String,
+    val job: String,
+)

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/interview/implement/PartInterviewRequirementReader.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/interview/implement/PartInterviewRequirementReader.kt
@@ -1,0 +1,15 @@
+package com.yourssu.scouter.recruiting.interview.implement
+
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+
+@Component
+@Transactional(readOnly = true)
+class PartInterviewRequirementReader(
+    private val partInterviewRequirementRepository: PartInterviewRequirementRepository,
+) {
+
+    fun readByPartId(partId: Long): PartInterviewRequirement? {
+        return partInterviewRequirementRepository.findByPartId(partId)
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/interview/implement/PartInterviewRequirementRepository.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/interview/implement/PartInterviewRequirementRepository.kt
@@ -1,0 +1,8 @@
+package com.yourssu.scouter.recruiting.interview.implement
+
+interface PartInterviewRequirementRepository {
+
+    fun findByPartId(partId: Long): PartInterviewRequirement?
+
+    fun upsert(requirement: PartInterviewRequirement): PartInterviewRequirement
+}

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/interview/implement/PartInterviewRequirementWriter.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/interview/implement/PartInterviewRequirementWriter.kt
@@ -1,0 +1,15 @@
+package com.yourssu.scouter.recruiting.interview.implement
+
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+
+@Component
+@Transactional
+class PartInterviewRequirementWriter(
+    private val partInterviewRequirementRepository: PartInterviewRequirementRepository,
+) {
+
+    fun upsert(requirement: PartInterviewRequirement): PartInterviewRequirement {
+        return partInterviewRequirementRepository.upsert(requirement)
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/interview/storage/InterviewScriptEntity.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/interview/storage/InterviewScriptEntity.kt
@@ -1,0 +1,29 @@
+package com.yourssu.scouter.recruiting.interview.storage
+
+import com.yourssu.scouter.recruiting.interview.implement.InterviewScript
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+
+@Entity
+@Table(name = "interview_script")
+class InterviewScriptEntity(
+
+    @Id
+    @Column(name = "part_id")
+    val partId: Long,
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    val opening: String,
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    val closing: String,
+) {
+
+    fun toDomain(): InterviewScript = InterviewScript(
+        partId = partId,
+        opening = opening,
+        closing = closing,
+    )
+}

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/interview/storage/InterviewScriptRepositoryImpl.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/interview/storage/InterviewScriptRepositoryImpl.kt
@@ -1,0 +1,26 @@
+package com.yourssu.scouter.recruiting.interview.storage
+
+import com.yourssu.scouter.recruiting.interview.implement.InterviewScript
+import com.yourssu.scouter.recruiting.interview.implement.InterviewScriptRepository
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Repository
+
+@Repository
+class InterviewScriptRepositoryImpl(
+    private val jpaInterviewScriptRepository: JpaInterviewScriptRepository,
+) : InterviewScriptRepository {
+
+    override fun findByPartId(partId: Long): InterviewScript? {
+        return jpaInterviewScriptRepository.findByIdOrNull(partId)?.toDomain()
+    }
+
+    override fun upsert(script: InterviewScript): InterviewScript {
+        val entity = InterviewScriptEntity(
+            partId = script.partId,
+            opening = script.opening,
+            closing = script.closing,
+        )
+
+        return jpaInterviewScriptRepository.save(entity).toDomain()
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/interview/storage/JpaInterviewScriptRepository.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/interview/storage/JpaInterviewScriptRepository.kt
@@ -1,0 +1,5 @@
+package com.yourssu.scouter.recruiting.interview.storage
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface JpaInterviewScriptRepository : JpaRepository<InterviewScriptEntity, Long>

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/interview/storage/JpaPartInterviewRequirementRepository.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/interview/storage/JpaPartInterviewRequirementRepository.kt
@@ -1,0 +1,5 @@
+package com.yourssu.scouter.recruiting.interview.storage
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface JpaPartInterviewRequirementRepository : JpaRepository<PartInterviewRequirementEntity, Long>

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/interview/storage/PartInterviewRequirementEntity.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/interview/storage/PartInterviewRequirementEntity.kt
@@ -1,0 +1,33 @@
+package com.yourssu.scouter.recruiting.interview.storage
+
+import com.yourssu.scouter.recruiting.interview.implement.PartInterviewRequirement
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+
+@Entity
+@Table(name = "part_interview_requirement")
+class PartInterviewRequirementEntity(
+
+    @Id
+    @Column(name = "part_id")
+    val partId: Long,
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    val culture: String,
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    val team: String,
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    val job: String,
+) {
+
+    fun toDomain(): PartInterviewRequirement = PartInterviewRequirement(
+        partId = partId,
+        culture = culture,
+        team = team,
+        job = job,
+    )
+}

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/interview/storage/PartInterviewRequirementRepositoryImpl.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/interview/storage/PartInterviewRequirementRepositoryImpl.kt
@@ -1,0 +1,27 @@
+package com.yourssu.scouter.recruiting.interview.storage
+
+import com.yourssu.scouter.recruiting.interview.implement.PartInterviewRequirement
+import com.yourssu.scouter.recruiting.interview.implement.PartInterviewRequirementRepository
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Repository
+
+@Repository
+class PartInterviewRequirementRepositoryImpl(
+    private val jpaPartInterviewRequirementRepository: JpaPartInterviewRequirementRepository,
+) : PartInterviewRequirementRepository {
+
+    override fun findByPartId(partId: Long): PartInterviewRequirement? {
+        return jpaPartInterviewRequirementRepository.findByIdOrNull(partId)?.toDomain()
+    }
+
+    override fun upsert(requirement: PartInterviewRequirement): PartInterviewRequirement {
+        val entity = PartInterviewRequirementEntity(
+            partId = requirement.partId,
+            culture = requirement.culture,
+            team = requirement.team,
+            job = requirement.job,
+        )
+
+        return jpaPartInterviewRequirementRepository.save(entity).toDomain()
+    }
+}

--- a/src/main/resources/db/migration/V26__create_part_interview_requirement_table.sql
+++ b/src/main/resources/db/migration/V26__create_part_interview_requirement_table.sql
@@ -1,0 +1,6 @@
+CREATE TABLE part_interview_requirement (
+    part_id BIGINT PRIMARY KEY,
+    culture TEXT NOT NULL,
+    team    TEXT NOT NULL,
+    job     TEXT NOT NULL
+);

--- a/src/main/resources/db/migration/V27__create_interview_script_table.sql
+++ b/src/main/resources/db/migration/V27__create_interview_script_table.sql
@@ -1,0 +1,5 @@
+CREATE TABLE interview_script (
+    part_id BIGINT PRIMARY KEY,
+    opening TEXT NOT NULL,
+    closing TEXT NOT NULL
+);

--- a/src/test/kotlin/com/yourssu/scouter/recruiting/interview/storage/InterviewScriptRepositoryImplTest.kt
+++ b/src/test/kotlin/com/yourssu/scouter/recruiting/interview/storage/InterviewScriptRepositoryImplTest.kt
@@ -1,0 +1,80 @@
+package com.yourssu.scouter.recruiting.interview.storage
+
+import com.yourssu.scouter.common.division.storage.DivisionEntity
+import com.yourssu.scouter.common.part.storage.PartEntity
+import com.yourssu.scouter.recruiting.interview.implement.InterviewScript
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatCode
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager
+import org.springframework.context.annotation.Import
+
+@DataJpaTest
+@Import(InterviewScriptRepositoryImpl::class)
+@Suppress("NonAsciiCharacters")
+class InterviewScriptRepositoryImplTest {
+
+    @Autowired
+    lateinit var interviewScriptRepositoryImpl: InterviewScriptRepositoryImpl
+
+    @Autowired
+    lateinit var entityManager: TestEntityManager
+
+    private var partId: Long = 0
+
+    @BeforeEach
+    fun setUp() {
+        val division = entityManager.persist(DivisionEntity(null, "개발", 1))
+        val part = entityManager.persist(PartEntity(null, division, "PM", 1))
+        partId = part.id!!
+
+        entityManager.flush()
+        entityManager.clear()
+    }
+
+    @Test
+    fun `설정된 스크립트가 없으면 null을 반환한다`() {
+        // when
+        val result = interviewScriptRepositoryImpl.findByPartId(partId)
+
+        // then
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `스크립트가 없는 파트에 처음 설정하면 저장된다`() {
+        // given
+        val script = InterviewScript(partId, "안녕하세요, 면접에 참여해 주셔서 감사합니다.", "오늘 면접 수고하셨습니다.")
+
+        // when
+        assertThatCode {
+            interviewScriptRepositoryImpl.upsert(script)
+        }.doesNotThrowAnyException()
+
+        // then
+        val found = interviewScriptRepositoryImpl.findByPartId(partId)
+        assertThat(found).isNotNull
+        assertThat(found!!.opening).isEqualTo("안녕하세요, 면접에 참여해 주셔서 감사합니다.")
+        assertThat(found.closing).isEqualTo("오늘 면접 수고하셨습니다.")
+    }
+
+    @Test
+    fun `이미 설정된 스크립트를 다시 저장해도 예외 없이 갱신된다`() {
+        // given: 최초 설정
+        interviewScriptRepositoryImpl.upsert(InterviewScript(partId, "기존 오프닝", "기존 클로징"))
+
+        // when: 같은 파트에 재설정
+        assertThatCode {
+            interviewScriptRepositoryImpl.upsert(InterviewScript(partId, "새로운 오프닝", "새로운 클로징"))
+        }.doesNotThrowAnyException()
+
+        // then
+        val found = interviewScriptRepositoryImpl.findByPartId(partId)
+        assertThat(found).isNotNull
+        assertThat(found!!.opening).isEqualTo("새로운 오프닝")
+        assertThat(found.closing).isEqualTo("새로운 클로징")
+    }
+}

--- a/src/test/kotlin/com/yourssu/scouter/recruiting/interview/storage/PartInterviewRequirementRepositoryImplTest.kt
+++ b/src/test/kotlin/com/yourssu/scouter/recruiting/interview/storage/PartInterviewRequirementRepositoryImplTest.kt
@@ -1,0 +1,82 @@
+package com.yourssu.scouter.recruiting.interview.storage
+
+import com.yourssu.scouter.common.division.storage.DivisionEntity
+import com.yourssu.scouter.common.part.storage.PartEntity
+import com.yourssu.scouter.recruiting.interview.implement.PartInterviewRequirement
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatCode
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager
+import org.springframework.context.annotation.Import
+
+@DataJpaTest
+@Import(PartInterviewRequirementRepositoryImpl::class)
+@Suppress("NonAsciiCharacters")
+class PartInterviewRequirementRepositoryImplTest {
+
+    @Autowired
+    lateinit var partInterviewRequirementRepositoryImpl: PartInterviewRequirementRepositoryImpl
+
+    @Autowired
+    lateinit var entityManager: TestEntityManager
+
+    private var partId: Long = 0
+
+    @BeforeEach
+    fun setUp() {
+        val division = entityManager.persist(DivisionEntity(null, "개발", 1))
+        val part = entityManager.persist(PartEntity(null, division, "PM", 1))
+        partId = part.id!!
+
+        entityManager.flush()
+        entityManager.clear()
+    }
+
+    @Test
+    fun `설정된 요구조건이 없으면 null을 반환한다`() {
+        // when
+        val result = partInterviewRequirementRepositoryImpl.findByPartId(partId)
+
+        // then
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `요구조건이 없는 파트에 처음 설정하면 저장된다`() {
+        // given
+        val requirement = PartInterviewRequirement(partId, "주도성", "커뮤니케이션", "문제 구조화")
+
+        // when
+        assertThatCode {
+            partInterviewRequirementRepositoryImpl.upsert(requirement)
+        }.doesNotThrowAnyException()
+
+        // then
+        val found = partInterviewRequirementRepositoryImpl.findByPartId(partId)
+        assertThat(found).isNotNull
+        assertThat(found!!.culture).isEqualTo("주도성")
+        assertThat(found.team).isEqualTo("커뮤니케이션")
+        assertThat(found.job).isEqualTo("문제 구조화")
+    }
+
+    @Test
+    fun `이미 설정된 요구조건을 다시 저장해도 예외 없이 갱신된다`() {
+        // given: 최초 설정
+        partInterviewRequirementRepositoryImpl.upsert(PartInterviewRequirement(partId, "주도성", "커뮤니케이션", "문제 구조화"))
+
+        // when: 같은 파트에 재설정
+        assertThatCode {
+            partInterviewRequirementRepositoryImpl.upsert(PartInterviewRequirement(partId, "집중력", "책임감", "실행안 전환"))
+        }.doesNotThrowAnyException()
+
+        // then
+        val found = partInterviewRequirementRepositoryImpl.findByPartId(partId)
+        assertThat(found).isNotNull
+        assertThat(found!!.culture).isEqualTo("집중력")
+        assertThat(found.team).isEqualTo("책임감")
+        assertThat(found.job).isEqualTo("실행안 전환")
+    }
+}


### PR DESCRIPTION
## Summary
- 면접관 할당은 이제 파트의 모든 액티브 멤버가 참여하는 것으로 정책이 바뀌어 구현 범위에서 제외
  - `GET/PUT /parts/{partId}/interviews/requirements` — PartInterviewRequirement (culture/team/job)
  - `GET/PUT /parts/{partId}/interviews/scripts` — InterviewScript (opening/closing)
- 새 aggregate `recruiting/interview`를 `recruiting/deadline`(PartDocumentDeadline)과 동일한 4계층 Reader/Writer/upsert 패턴으로 구성
- `V26__create_interview_config_tables.sql` 마이그레이션 추가

## Test plan
- [x] `./gradlew test` 전체 통과
- [x] `./gradlew bootRun`으로 로컬 기동 후 두 엔드포인트가 라우팅되고(401 인증 필요 응답 확인), `/v3/api-docs`에 정상 노출되는지 확인
- [ ] 리뷰어 확인

Closes #316