### PR TITLE
[#319]; feat: 면접 루브릭 및 면접 평가 api 구현

### DIFF
--- a/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/application/InterviewEvaluationController.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/application/InterviewEvaluationController.kt
@@ -60,13 +60,13 @@ class InterviewEvaluationController(
             content = [Content(
                 schema = Schema(implementation = SaveInterviewEvaluationRequest::class),
                 examples = [ExampleObject(value = """{
-                                                          "items": [
-                                                            { "evaluationItemId": 1, "score": 50 },
-                                                            { "evaluationItemId": 2, "score": 35 }
-                                                          ],
-                                                          "result": "FINAL_PASS",
-                                                          "submit": true
-                                                        }""")],
+  "items": [
+    { "itemId": 1, "score": 8 }
+  ],
+  "overallComment": "질문에 대한 답변은 구조적이고 문화 적합성은 높습니다.",
+  "result": "FINAL_PASS",
+  "submit": true
+}""")],
             )],
         ),
     )

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/application/InterviewEvaluationController.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/application/InterviewEvaluationController.kt
@@ -1,0 +1,135 @@
+package com.yourssu.scouter.recruiting.evaluation.application
+
+import com.yourssu.scouter.auth.support.application.authentication.AuthUser
+import com.yourssu.scouter.auth.support.application.authentication.AuthUserInfo
+import com.yourssu.scouter.hrms.member.business.MemberPrivacyService
+import com.yourssu.scouter.recruiting.applicant.business.ApplicantAccessScope
+import com.yourssu.scouter.recruiting.applicant.business.ApplicantPrivacyService
+import com.yourssu.scouter.recruiting.applicant.business.ApplicantService
+import com.yourssu.scouter.recruiting.applicant.business.dto.ApplicantDto
+import com.yourssu.scouter.recruiting.evaluation.application.dto.ReadInterviewEvaluationResponse
+import com.yourssu.scouter.recruiting.evaluation.application.dto.ReadOtherInterviewEvaluationResponse
+import com.yourssu.scouter.recruiting.evaluation.application.dto.ReadEvaluatorStatusResponse
+import com.yourssu.scouter.recruiting.evaluation.application.dto.SaveInterviewEvaluationRequest
+import com.yourssu.scouter.recruiting.evaluation.business.InterviewEvaluationService
+import com.yourssu.scouter.recruiting.support.business.exception.ApplicantAccessDeniedException
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.ExampleObject
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.validation.Valid
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.*
+
+@Tag(name = "면접 평가", description = "지원자별 면접 평가 내역 및 평가 상태 관리 API")
+@RestController
+class InterviewEvaluationController(
+    private val interviewEvaluationService: InterviewEvaluationService,
+    private val applicantService: ApplicantService,
+    private val applicantPrivacyService: ApplicantPrivacyService,
+    private val memberPrivacyService: MemberPrivacyService,
+) {
+
+    @Operation(summary = "면접 평가 조회 (본인)", description = "로그인한 면접관 본인의 임시저장/최종제출 면접 평가 내역을 조회합니다.")
+    @ApiResponses(value = [
+        ApiResponse(responseCode = "200", description = "조회 성공", content = [Content(schema = Schema(implementation = ReadInterviewEvaluationResponse::class))]),
+        ApiResponse(responseCode = "403", description = "해당 지원자의 정보를 조회할 권한이 없음"),
+        ApiResponse(responseCode = "404", description = "지원자를 찾을 수 없음"),
+    ])
+    @GetMapping("/applicants/{applicantId}/interviews/evaluations")
+    fun readMy(
+        @AuthUser authUserInfo: AuthUserInfo,
+        @Parameter(description = "지원자 ID", example = "1") @PathVariable applicantId: Long,
+    ): ResponseEntity<ReadInterviewEvaluationResponse> {
+        requireAccessible(applicantId, authUserInfo.userId)
+
+        val myEvaluation = interviewEvaluationService.readMy(applicantId, authUserInfo.userId)
+        return ResponseEntity.ok(ReadInterviewEvaluationResponse.from(myEvaluation))
+    }
+
+    @Operation(
+        summary = "면접 평가 저장/수정",
+        description = "로그인한 면접관 본인의 평가 정보를 저장합니다. submit이 false이면 임시저장, true이면 최종 제출입니다. 제출 시 요청된 점수가 배점을 초과하면 안 됩니다.",
+        requestBody = io.swagger.v3.oas.annotations.parameters.RequestBody(
+            required = true,
+            description = "평가 정보 저장 요청 바디",
+            content = [Content(
+                schema = Schema(implementation = SaveInterviewEvaluationRequest::class),
+                examples = [ExampleObject(value = """{
+                                                          "items": [
+                                                            { "evaluationItemId": 1, "score": 50 },
+                                                            { "evaluationItemId": 2, "score": 35 }
+                                                          ],
+                                                          "result": "FINAL_PASS",
+                                                          "submit": true
+                                                        }""")],
+            )],
+        ),
+    )
+    @ApiResponses(value = [
+        ApiResponse(responseCode = "200", description = "저장/수정 성공"),
+        ApiResponse(responseCode = "400", description = "요청 형식이 올바르지 않거나 배점 한도를 초과함"),
+        ApiResponse(responseCode = "403", description = "해당 지원자의 정보를 수정할 권한이 없음"),
+        ApiResponse(responseCode = "404", description = "지원자 혹은 평가 항목을 찾을 수 없음"),
+    ])
+    @PutMapping("/applicants/{applicantId}/interviews/evaluations")
+    fun save(
+        @AuthUser authUserInfo: AuthUserInfo,
+        @Parameter(description = "지원자 ID", example = "1") @PathVariable applicantId: Long,
+        @RequestBody @Valid request: SaveInterviewEvaluationRequest,
+    ): ResponseEntity<Unit> {
+        requireAccessible(applicantId, authUserInfo.userId)
+
+        interviewEvaluationService.save(request.toCommand(applicantId, authUserInfo.userId))
+        return ResponseEntity.ok().build()
+    }
+
+    @Operation(summary = "다른 평가자 면접 평가 조회", description = "다른 면접관들의 평가 내역을 조회합니다. 본인이 평가를 완료(최종 제출)한 경우에만 타인 평가가 조회 가능합니다.")
+    @ApiResponses(value = [
+        ApiResponse(responseCode = "200", description = "조회 성공", content = [Content(schema = Schema(implementation = ReadOtherInterviewEvaluationResponse::class))]),
+        ApiResponse(responseCode = "403", description = "해당 지원자의 정보를 조회할 권한이 없거나, 본인이 아직 최종 제출하지 않아 블라인드 처리됨"),
+        ApiResponse(responseCode = "404", description = "지원자를 찾을 수 없음"),
+    ])
+    @GetMapping("/applicants/{applicantId}/interviews/evaluations/others")
+    fun readOthers(
+        @AuthUser authUserInfo: AuthUserInfo,
+        @Parameter(description = "지원자 ID", example = "1") @PathVariable applicantId: Long,
+    ): ResponseEntity<List<ReadOtherInterviewEvaluationResponse>> {
+        requireAccessible(applicantId, authUserInfo.userId)
+
+        val others = interviewEvaluationService.readOthers(applicantId, authUserInfo.userId)
+        return ResponseEntity.ok(others.map(ReadOtherInterviewEvaluationResponse::from))
+    }
+
+    @Operation(summary = "면접 평가자 상태 목록 조회", description = "해당 지원자에게 할당된 면접관들의 평가 작성 진행 상태를 조회합니다.")
+    @ApiResponses(value = [
+        ApiResponse(responseCode = "200", description = "조회 성공", content = [Content(schema = Schema(implementation = ReadEvaluatorStatusResponse::class))]),
+        ApiResponse(responseCode = "403", description = "해당 지원자의 정보를 조회할 권한이 없음"),
+        ApiResponse(responseCode = "404", description = "지원자를 찾을 수 없음"),
+    ])
+    @GetMapping("/applicants/{applicantId}/interviews/evaluations/status")
+    fun readStatuses(
+        @AuthUser authUserInfo: AuthUserInfo,
+        @Parameter(description = "지원자 ID", example = "1") @PathVariable applicantId: Long,
+    ): ResponseEntity<List<ReadEvaluatorStatusResponse>> {
+        requireAccessible(applicantId, authUserInfo.userId)
+
+        val statuses = interviewEvaluationService.readStatuses(applicantId)
+        return ResponseEntity.ok(statuses.map(ReadEvaluatorStatusResponse::from))
+    }
+
+    private fun requireAccessible(applicantId: Long, userId: Long) {
+        val applicantDto: ApplicantDto = applicantService.readById(applicantId)
+        val isPrivileged = memberPrivacyService.isPrivilegedUser(userId)
+        val memberPartIds = if (isPrivileged) emptySet() else memberPrivacyService.getMemberPartIds(userId)
+        val scope = ApplicantAccessScope(isPrivileged, memberPartIds)
+        val accessible = applicantPrivacyService.filterAccessibleApplicants(scope, listOf(applicantDto))
+        if (accessible.isEmpty()) {
+            throw ApplicantAccessDeniedException("해당 지원자의 정보를 조회할 권한이 없습니다.")
+        }
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/application/dto/ReadInterviewEvaluationResponse.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/application/dto/ReadInterviewEvaluationResponse.kt
@@ -4,7 +4,7 @@ import com.yourssu.scouter.recruiting.evaluation.business.dto.InterviewEvaluatio
 import com.yourssu.scouter.recruiting.evaluation.business.dto.InterviewEvaluationItemDto
 import com.yourssu.scouter.recruiting.evaluation.implement.InterviewResult
 import com.yourssu.scouter.recruiting.rubric.implement.RubricGroupType
-import java.time.Instant
+import java.time.LocalDateTime
 
 data class ReadInterviewEvaluationGroupResponse(
     val group: String,
@@ -23,7 +23,7 @@ data class ReadInterviewEvaluationResponse(
     val groups: List<ReadInterviewEvaluationGroupResponse>,
     val overallComment: String,
     val result: InterviewResult,
-    val submittedAt: Instant?,
+    val submittedAt: LocalDateTime?,
 ) {
     companion object {
         fun from(dto: InterviewEvaluationDto): ReadInterviewEvaluationResponse {
@@ -57,3 +57,4 @@ data class ReadInterviewEvaluationResponse(
         }
     }
 }
+

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/application/dto/ReadInterviewEvaluationResponse.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/application/dto/ReadInterviewEvaluationResponse.kt
@@ -1,0 +1,41 @@
+package com.yourssu.scouter.recruiting.evaluation.application.dto
+
+import com.yourssu.scouter.recruiting.evaluation.business.dto.InterviewEvaluationDto
+import com.yourssu.scouter.recruiting.evaluation.business.dto.InterviewEvaluationItemDto
+import com.yourssu.scouter.recruiting.evaluation.implement.InterviewResult
+import com.yourssu.scouter.recruiting.rubric.implement.RubricGroupType
+import java.time.Instant
+
+data class ReadInterviewEvaluationItemResponse(
+    val evaluationItemId: Long,
+    val keyword: String,
+    val rubricType: RubricGroupType,
+    val maxScore: Int,
+    val score: Int,
+) {
+    companion object {
+        fun from(dto: InterviewEvaluationItemDto): ReadInterviewEvaluationItemResponse = ReadInterviewEvaluationItemResponse(
+            evaluationItemId = dto.evaluationItemId,
+            keyword = dto.keyword,
+            rubricType = dto.rubricType,
+            maxScore = dto.maxScore,
+            score = dto.score
+        )
+    }
+}
+
+data class ReadInterviewEvaluationResponse(
+    val totalScore: Int,
+    val items: List<ReadInterviewEvaluationItemResponse>,
+    val result: InterviewResult,
+    val submittedAt: Instant?,
+) {
+    companion object {
+        fun from(dto: InterviewEvaluationDto): ReadInterviewEvaluationResponse = ReadInterviewEvaluationResponse(
+            totalScore = dto.totalScore,
+            items = dto.items.map(ReadInterviewEvaluationItemResponse::from),
+            result = dto.result,
+            submittedAt = dto.submittedAt
+        )
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/application/dto/ReadInterviewEvaluationResponse.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/application/dto/ReadInterviewEvaluationResponse.kt
@@ -6,36 +6,54 @@ import com.yourssu.scouter.recruiting.evaluation.implement.InterviewResult
 import com.yourssu.scouter.recruiting.rubric.implement.RubricGroupType
 import java.time.Instant
 
+data class ReadInterviewEvaluationGroupResponse(
+    val group: String,
+    val items: List<ReadInterviewEvaluationItemResponse>
+)
+
 data class ReadInterviewEvaluationItemResponse(
-    val evaluationItemId: Long,
-    val keyword: String,
-    val rubricType: RubricGroupType,
+    val itemId: Long,
+    val itemTitle: String,
     val maxScore: Int,
     val score: Int,
-) {
-    companion object {
-        fun from(dto: InterviewEvaluationItemDto): ReadInterviewEvaluationItemResponse = ReadInterviewEvaluationItemResponse(
-            evaluationItemId = dto.evaluationItemId,
-            keyword = dto.keyword,
-            rubricType = dto.rubricType,
-            maxScore = dto.maxScore,
-            score = dto.score
-        )
-    }
-}
+)
 
 data class ReadInterviewEvaluationResponse(
     val totalScore: Int,
-    val items: List<ReadInterviewEvaluationItemResponse>,
+    val groups: List<ReadInterviewEvaluationGroupResponse>,
+    val overallComment: String,
     val result: InterviewResult,
     val submittedAt: Instant?,
 ) {
     companion object {
-        fun from(dto: InterviewEvaluationDto): ReadInterviewEvaluationResponse = ReadInterviewEvaluationResponse(
-            totalScore = dto.totalScore,
-            items = dto.items.map(ReadInterviewEvaluationItemResponse::from),
-            result = dto.result,
-            submittedAt = dto.submittedAt
-        )
+        fun from(dto: InterviewEvaluationDto): ReadInterviewEvaluationResponse {
+            val itemsByGroup = dto.items.groupBy { it.rubricType }
+            val groups = listOf(RubricGroupType.CULTURE, RubricGroupType.TEAM, RubricGroupType.JOB).map { groupType ->
+                val items = itemsByGroup[groupType] ?: emptyList()
+                ReadInterviewEvaluationGroupResponse(
+                    group = when (groupType) {
+                        RubricGroupType.CULTURE -> "CULTURE_FIT"
+                        RubricGroupType.TEAM -> "TEAM_FIT"
+                        RubricGroupType.JOB -> "JOB_FIT"
+                    },
+                    items = items.map {
+                        ReadInterviewEvaluationItemResponse(
+                            itemId = it.evaluationItemId,
+                            itemTitle = it.keyword,
+                            maxScore = it.maxScore,
+                            score = it.score
+                        )
+                    }
+                )
+            }
+
+            return ReadInterviewEvaluationResponse(
+                totalScore = dto.totalScore,
+                groups = groups,
+                overallComment = dto.overallComment,
+                result = dto.result,
+                submittedAt = dto.submittedAt
+            )
+        }
     }
 }

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/application/dto/ReadOtherInterviewEvaluationResponse.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/application/dto/ReadOtherInterviewEvaluationResponse.kt
@@ -1,0 +1,33 @@
+package com.yourssu.scouter.recruiting.evaluation.application.dto
+
+import com.yourssu.scouter.recruiting.evaluation.business.dto.OtherInterviewEvaluationDto
+import com.yourssu.scouter.recruiting.evaluation.business.dto.OtherInterviewEvaluationItemDto
+import com.yourssu.scouter.recruiting.evaluation.implement.InterviewResult
+
+data class ReadOtherInterviewEvaluationItemResponse(
+    val evaluationItemId: Long,
+    val score: Int,
+) {
+    companion object {
+        fun from(dto: OtherInterviewEvaluationItemDto): ReadOtherInterviewEvaluationItemResponse =
+            ReadOtherInterviewEvaluationItemResponse(dto.evaluationItemId, dto.score)
+    }
+}
+
+data class ReadOtherInterviewEvaluationResponse(
+    val evaluatorId: Long,
+    val evaluatorName: String,
+    val totalScore: Int,
+    val result: InterviewResult,
+    val items: List<ReadOtherInterviewEvaluationItemResponse>,
+) {
+    companion object {
+        fun from(dto: OtherInterviewEvaluationDto): ReadOtherInterviewEvaluationResponse = ReadOtherInterviewEvaluationResponse(
+            evaluatorId = dto.evaluatorId,
+            evaluatorName = dto.evaluatorName,
+            totalScore = dto.totalScore,
+            result = dto.result,
+            items = dto.items.map(ReadOtherInterviewEvaluationItemResponse::from),
+        )
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/application/dto/ReadOtherInterviewEvaluationResponse.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/application/dto/ReadOtherInterviewEvaluationResponse.kt
@@ -5,7 +5,7 @@ import com.yourssu.scouter.recruiting.evaluation.business.dto.OtherInterviewEval
 import com.yourssu.scouter.recruiting.evaluation.implement.InterviewResult
 
 data class ReadOtherInterviewEvaluationItemResponse(
-    val evaluationItemId: Long,
+    val itemId: Long,
     val score: Int,
 ) {
     companion object {
@@ -19,6 +19,7 @@ data class ReadOtherInterviewEvaluationResponse(
     val evaluatorName: String,
     val totalScore: Int,
     val result: InterviewResult,
+    val overallComment: String,
     val items: List<ReadOtherInterviewEvaluationItemResponse>,
 ) {
     companion object {
@@ -27,6 +28,7 @@ data class ReadOtherInterviewEvaluationResponse(
             evaluatorName = dto.evaluatorName,
             totalScore = dto.totalScore,
             result = dto.result,
+            overallComment = dto.overallComment,
             items = dto.items.map(ReadOtherInterviewEvaluationItemResponse::from),
         )
     }

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/application/dto/SaveInterviewEvaluationRequest.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/application/dto/SaveInterviewEvaluationRequest.kt
@@ -7,19 +7,21 @@ import jakarta.validation.constraints.NotNull
 
 data class SaveInterviewEvaluationItemRequest(
     @field:NotNull
-    val evaluationItemId: Long?,
+    val itemId: Long?,
 
     @field:NotNull
     val score: Int?,
 ) {
     fun toCommand(): SaveInterviewEvaluationItemCommand = SaveInterviewEvaluationItemCommand(
-        evaluationItemId = evaluationItemId!!,
+        evaluationItemId = itemId!!,
         score = score!!,
     )
 }
 
 data class SaveInterviewEvaluationRequest(
     val items: List<SaveInterviewEvaluationItemRequest> = emptyList(),
+
+    val overallComment: String = "",
 
     @field:NotNull
     val result: InterviewResult?,
@@ -31,6 +33,7 @@ data class SaveInterviewEvaluationRequest(
         applicantId = applicantId,
         evaluatorUserId = evaluatorUserId,
         items = items.map { it.toCommand() },
+        overallComment = overallComment,
         result = result!!,
         submit = submit!!,
     )

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/application/dto/SaveInterviewEvaluationRequest.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/application/dto/SaveInterviewEvaluationRequest.kt
@@ -1,0 +1,37 @@
+package com.yourssu.scouter.recruiting.evaluation.application.dto
+
+import com.yourssu.scouter.recruiting.evaluation.business.dto.SaveInterviewEvaluationCommand
+import com.yourssu.scouter.recruiting.evaluation.business.dto.SaveInterviewEvaluationItemCommand
+import com.yourssu.scouter.recruiting.evaluation.implement.InterviewResult
+import jakarta.validation.constraints.NotNull
+
+data class SaveInterviewEvaluationItemRequest(
+    @field:NotNull
+    val evaluationItemId: Long?,
+
+    @field:NotNull
+    val score: Int?,
+) {
+    fun toCommand(): SaveInterviewEvaluationItemCommand = SaveInterviewEvaluationItemCommand(
+        evaluationItemId = evaluationItemId!!,
+        score = score!!,
+    )
+}
+
+data class SaveInterviewEvaluationRequest(
+    val items: List<SaveInterviewEvaluationItemRequest> = emptyList(),
+
+    @field:NotNull
+    val result: InterviewResult?,
+
+    @field:NotNull
+    val submit: Boolean?,
+) {
+    fun toCommand(applicantId: Long, evaluatorUserId: Long): SaveInterviewEvaluationCommand = SaveInterviewEvaluationCommand(
+        applicantId = applicantId,
+        evaluatorUserId = evaluatorUserId,
+        items = items.map { it.toCommand() },
+        result = result!!,
+        submit = submit!!,
+    )
+}

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/application/dto/SaveInterviewEvaluationRequest.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/application/dto/SaveInterviewEvaluationRequest.kt
@@ -3,6 +3,7 @@ package com.yourssu.scouter.recruiting.evaluation.application.dto
 import com.yourssu.scouter.recruiting.evaluation.business.dto.SaveInterviewEvaluationCommand
 import com.yourssu.scouter.recruiting.evaluation.business.dto.SaveInterviewEvaluationItemCommand
 import com.yourssu.scouter.recruiting.evaluation.implement.InterviewResult
+import jakarta.validation.constraints.NotEmpty
 import jakarta.validation.constraints.NotNull
 
 data class SaveInterviewEvaluationItemRequest(
@@ -19,6 +20,7 @@ data class SaveInterviewEvaluationItemRequest(
 }
 
 data class SaveInterviewEvaluationRequest(
+    @field:NotEmpty(message = "평가 항목 점수 리스트는 비어있을 수 없습니다.")
     val items: List<SaveInterviewEvaluationItemRequest> = emptyList(),
 
     val overallComment: String = "",

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/business/InterviewEvaluationService.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/business/InterviewEvaluationService.kt
@@ -1,7 +1,6 @@
 package com.yourssu.scouter.recruiting.evaluation.business
 
-import com.yourssu.scouter.auth.user.implement.User
-import com.yourssu.scouter.auth.user.implement.UserReader
+import com.yourssu.scouter.hrms.member.implement.MemberReader
 import com.yourssu.scouter.recruiting.applicant.implement.Applicant
 import com.yourssu.scouter.recruiting.applicant.implement.ApplicantReader
 import com.yourssu.scouter.recruiting.evaluation.business.dto.*
@@ -24,14 +23,13 @@ class InterviewEvaluationService(
     private val finalEvaluationWriter: FinalEvaluationWriter,
     private val interviewRubricReader: InterviewRubricReader,
     private val applicantReader: ApplicantReader,
-    private val userReader: UserReader,
+    private val memberReader: MemberReader,
     private val evaluatorDirectory: EvaluatorDirectory,
 ) {
 
     fun readMy(applicantId: Long, evaluatorUserId: Long): InterviewEvaluationDto {
         val applicant = applicantReader.readById(applicantId)
-        val semesterStr = "${applicant.applicationSemester.year.value}-${applicant.applicationSemester.term.intValue}"
-        val rubric = interviewRubricReader.getByPartIdAndSemester(applicant.part.id!!, semesterStr)
+        val rubric = interviewRubricReader.getByPartIdAndSemester(applicant.part.id!!, applicant.applicationSemester)
         val rubricItems = rubric.items.associateBy { it.id }
 
         val evaluation = interviewEvaluationReader.readByApplicantIdAndEvaluatorUserId(applicantId, evaluatorUserId)
@@ -61,8 +59,7 @@ class InterviewEvaluationService(
     @Transactional
     fun save(command: SaveInterviewEvaluationCommand) {
         val applicant = applicantReader.readById(command.applicantId)
-        val semesterStr = "${applicant.applicationSemester.year.value}-${applicant.applicationSemester.term.intValue}"
-        val rubric = interviewRubricReader.getByPartIdAndSemester(applicant.part.id!!, semesterStr)
+        val rubric = interviewRubricReader.getByPartIdAndSemester(applicant.part.id!!, applicant.applicationSemester)
         val rubricItems = rubric.items.associateBy { it.id }
 
         val items = command.items.map { item ->
@@ -79,13 +76,8 @@ class InterviewEvaluationService(
             )
         }
 
-        val existingEvaluation = interviewEvaluationReader.readByApplicantIdAndEvaluatorUserId(
-            command.applicantId,
-            command.evaluatorUserId
-        )
-
         val evaluation = InterviewEvaluation(
-            id = existingEvaluation?.id,
+            id = null,
             applicantId = command.applicantId,
             evaluatorUserId = command.evaluatorUserId,
             items = items
@@ -122,18 +114,21 @@ class InterviewEvaluationService(
             viewerUserId
         )?.submit ?: false
 
-        val evaluators = userReader.readAllByIds(finalEvaluations.map { it.memberId }).associateBy { it.id }
+        val evaluators = finalEvaluations.map { finalEval ->
+                    memberReader.readById(finalEval.memberId)
+                }.associateBy { it.id }
+
         val evaluationsByEvaluator = interviewEvaluationReader.readAllByApplicantId(applicantId)
             .associateBy { it.evaluatorUserId }
 
         return finalEvaluations.map { finalEval ->
             val evaluator = evaluators[finalEval.memberId]
-            val comment = if (viewerHasSubmitted) finalEval.overallComment else ""
+            val comment = if (viewerHasSubmitted) finalEval.overallComment else "" // 내 평가를 제출하지 않았다면 다른 사람의 총평을 볼수 없게 한다.
             val evaluation = evaluationsByEvaluator[finalEval.memberId]
 
             OtherInterviewEvaluationDto(
                 evaluatorId = finalEval.memberId,
-                evaluatorName = evaluator?.userInfo?.name ?: "",
+                evaluatorName = evaluator?.name ?: "",
                 totalScore = finalEval.score,
                 result = finalEval.interviewResult,
                 overallComment = comment,
@@ -147,13 +142,15 @@ class InterviewEvaluationService(
         val partId = applicant.part.id!!
 
         val evaluators = evaluatorDirectory.findEvaluatorsByPartId(partId)
-        val usersByEmail = userReader.readAllByEmails(evaluators.map { it.email }).associateBy { it.userInfo.email }
+        val membersByEmail = evaluators.mapNotNull { evaluator ->
+            memberReader.readByEmailOrNull(evaluator.email)
+        }.associateBy { it.email }
 
         val finalEvaluationsByEvaluator = finalEvaluationReader.readAllByApplicantId(applicantId).associateBy { it.memberId }
 
         return evaluators.mapNotNull { evaluator ->
-            val user = usersByEmail[evaluator.email] ?: return@mapNotNull null
-            val finalEval = finalEvaluationsByEvaluator[user.id]
+            val member = membersByEmail[evaluator.email] ?: return@mapNotNull null
+            val finalEval = finalEvaluationsByEvaluator[member.id]
             val status = when {
                 finalEval == null -> EvaluationStatus.NOT_STARTED
                 finalEval.submit -> EvaluationStatus.SUBMITTED
@@ -161,7 +158,7 @@ class InterviewEvaluationService(
             }
 
             EvaluatorStatusDto(
-                userId = user.id!!,
+                userId = member.id!!,
                 name = evaluator.name,
                 status = status
             )

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/business/InterviewEvaluationService.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/business/InterviewEvaluationService.kt
@@ -1,6 +1,6 @@
 package com.yourssu.scouter.recruiting.evaluation.business
 
-import com.yourssu.scouter.hrms.member.implement.MemberReader
+import com.yourssu.scouter.auth.user.implement.UserReader
 import com.yourssu.scouter.recruiting.applicant.implement.Applicant
 import com.yourssu.scouter.recruiting.applicant.implement.ApplicantReader
 import com.yourssu.scouter.recruiting.evaluation.business.dto.*
@@ -16,6 +16,7 @@ import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDateTime
 
 @Service
+@Transactional(readOnly = true)
 class InterviewEvaluationService(
     private val interviewEvaluationReader: InterviewEvaluationReader,
     private val interviewEvaluationWriter: InterviewEvaluationWriter,
@@ -23,7 +24,7 @@ class InterviewEvaluationService(
     private val finalEvaluationWriter: FinalEvaluationWriter,
     private val interviewRubricReader: InterviewRubricReader,
     private val applicantReader: ApplicantReader,
-    private val memberReader: MemberReader,
+    private val userReader: UserReader,
     private val evaluatorDirectory: EvaluatorDirectory,
 ) {
 
@@ -92,7 +93,7 @@ class InterviewEvaluationService(
 
         val finalEvaluation = FinalEvaluation(
             id = existingFinal?.id,
-            memberId = command.evaluatorUserId,
+            evaluatorUserId = command.evaluatorUserId,
             interviewRubricId = rubric.id!!,
             applicantId = command.applicantId,
             overallComment = command.overallComment,
@@ -107,7 +108,7 @@ class InterviewEvaluationService(
 
     fun readOthers(applicantId: Long, viewerUserId: Long): List<OtherInterviewEvaluationDto> {
         val finalEvaluations = finalEvaluationReader.readAllByApplicantId(applicantId)
-            .filter { it.submit && it.memberId != viewerUserId }
+            .filter { it.submit && it.evaluatorUserId != viewerUserId }
 
         val viewerHasSubmitted = finalEvaluationReader.readByApplicantIdAndEvaluatorUserId(
             applicantId,
@@ -115,20 +116,20 @@ class InterviewEvaluationService(
         )?.submit ?: false
 
         val evaluators = finalEvaluations.map { finalEval ->
-                    memberReader.readById(finalEval.memberId)
+                    userReader.readById(finalEval.evaluatorUserId)
                 }.associateBy { it.id }
 
         val evaluationsByEvaluator = interviewEvaluationReader.readAllByApplicantId(applicantId)
             .associateBy { it.evaluatorUserId }
 
         return finalEvaluations.map { finalEval ->
-            val evaluator = evaluators[finalEval.memberId]
+            val evaluator = evaluators[finalEval.evaluatorUserId]
             val comment = if (viewerHasSubmitted) finalEval.overallComment else "" // 내 평가를 제출하지 않았다면 다른 사람의 총평을 볼수 없게 한다.
-            val evaluation = evaluationsByEvaluator[finalEval.memberId]
+            val evaluation = evaluationsByEvaluator[finalEval.evaluatorUserId]
 
             OtherInterviewEvaluationDto(
-                evaluatorId = finalEval.memberId,
-                evaluatorName = evaluator?.name ?: "",
+                evaluatorId = finalEval.evaluatorUserId,
+                evaluatorName = evaluator?.userInfo?.name ?: "",
                 totalScore = finalEval.score,
                 result = finalEval.interviewResult,
                 overallComment = comment,
@@ -142,15 +143,13 @@ class InterviewEvaluationService(
         val partId = applicant.part.id!!
 
         val evaluators = evaluatorDirectory.findEvaluatorsByPartId(partId)
-        val membersByEmail = evaluators.mapNotNull { evaluator ->
-            memberReader.readByEmailOrNull(evaluator.email)
-        }.associateBy { it.email }
+        val usersByEmail = userReader.readAllByEmails(evaluators.map { it.email }).associateBy { it.userInfo.email }
 
-        val finalEvaluationsByEvaluator = finalEvaluationReader.readAllByApplicantId(applicantId).associateBy { it.memberId }
+        val finalEvaluationsByEvaluator = finalEvaluationReader.readAllByApplicantId(applicantId).associateBy { it.evaluatorUserId }
 
         return evaluators.mapNotNull { evaluator ->
-            val member = membersByEmail[evaluator.email] ?: return@mapNotNull null
-            val finalEval = finalEvaluationsByEvaluator[member.id]
+            val user = usersByEmail[evaluator.email] ?: return@mapNotNull null
+            val finalEval = finalEvaluationsByEvaluator[user.id]
             val status = when {
                 finalEval == null -> EvaluationStatus.NOT_STARTED
                 finalEval.submit -> EvaluationStatus.SUBMITTED
@@ -158,7 +157,7 @@ class InterviewEvaluationService(
             }
 
             EvaluatorStatusDto(
-                userId = member.id!!,
+                userId = user.id!!,
                 name = evaluator.name,
                 status = status
             )

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/business/InterviewEvaluationService.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/business/InterviewEvaluationService.kt
@@ -14,12 +14,14 @@ import com.yourssu.scouter.recruiting.support.implement.exception.InterviewEvalu
 import com.yourssu.scouter.recruiting.support.implement.exception.InterviewEvaluationItemNotFoundException
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
-import java.time.Instant
+import java.time.LocalDateTime
 
 @Service
 class InterviewEvaluationService(
     private val interviewEvaluationReader: InterviewEvaluationReader,
     private val interviewEvaluationWriter: InterviewEvaluationWriter,
+    private val finalEvaluationReader: FinalEvaluationReader,
+    private val finalEvaluationWriter: FinalEvaluationWriter,
     private val interviewRubricReader: InterviewRubricReader,
     private val applicantReader: ApplicantReader,
     private val userReader: UserReader,
@@ -33,7 +35,10 @@ class InterviewEvaluationService(
         val rubricItems = rubric.items.associateBy { it.id }
 
         val evaluation = interviewEvaluationReader.readByApplicantIdAndEvaluatorUserId(applicantId, evaluatorUserId)
-            ?: return InterviewEvaluationDto(
+        val finalEval = finalEvaluationReader.readByApplicantIdAndEvaluatorUserId(applicantId, evaluatorUserId)
+
+        if (evaluation == null) {
+            return InterviewEvaluationDto(
                 totalScore = 0,
                 items = rubric.items.map { item ->
                     InterviewEvaluationItemDto(
@@ -44,12 +49,13 @@ class InterviewEvaluationService(
                         score = 0
                     )
                 },
-                overallComment = "",
-                result = InterviewResult.PENDING,
-                submittedAt = null
+                overallComment = finalEval?.overallComment ?: "",
+                result = finalEval?.interviewResult ?: InterviewResult.PENDING,
+                submittedAt = finalEval?.submittedAt
             )
+        }
 
-        return toDto(evaluation, rubricItems)
+        return toDto(evaluation, finalEval, rubricItems)
     }
 
     @Transactional
@@ -73,45 +79,65 @@ class InterviewEvaluationService(
             )
         }
 
-        val existing = interviewEvaluationReader.readByApplicantIdAndEvaluatorUserId(
+        val existingEvaluation = interviewEvaluationReader.readByApplicantIdAndEvaluatorUserId(
             command.applicantId,
             command.evaluatorUserId
         )
 
         val evaluation = InterviewEvaluation(
-            id = existing?.id,
+            id = existingEvaluation?.id,
             applicantId = command.applicantId,
             evaluatorUserId = command.evaluatorUserId,
-            items = items,
-            overallComment = command.overallComment,
-            result = command.result,
-            submittedAt = if (command.submit) Instant.now() else existing?.submittedAt
+            items = items
         )
 
-        interviewEvaluationWriter.write(evaluation)
+        val savedEvaluation = interviewEvaluationWriter.write(evaluation)
+
+        val existingFinal = finalEvaluationReader.readByApplicantIdAndEvaluatorUserId(
+            command.applicantId,
+            command.evaluatorUserId
+        )
+
+        val finalEvaluation = FinalEvaluation(
+            id = existingFinal?.id,
+            memberId = command.evaluatorUserId,
+            interviewRubricId = rubric.id!!,
+            applicantId = command.applicantId,
+            overallComment = command.overallComment,
+            interviewResult = command.result,
+            score = savedEvaluation.totalScore(),
+            submit = command.submit,
+            submittedAt = if (command.submit) LocalDateTime.now() else existingFinal?.submittedAt
+        )
+
+        finalEvaluationWriter.write(finalEvaluation)
     }
 
     fun readOthers(applicantId: Long, viewerUserId: Long): List<OtherInterviewEvaluationDto> {
-        val evaluations = interviewEvaluationReader.readAllByApplicantId(applicantId)
-            .filter { it.isSubmitted() && it.evaluatorUserId != viewerUserId }
+        val finalEvaluations = finalEvaluationReader.readAllByApplicantId(applicantId)
+            .filter { it.submit && it.memberId != viewerUserId }
 
-        val viewerHasSubmitted = interviewEvaluationReader.readByApplicantIdAndEvaluatorUserId(
+        val viewerHasSubmitted = finalEvaluationReader.readByApplicantIdAndEvaluatorUserId(
             applicantId,
             viewerUserId
-        )?.isSubmitted() ?: false
+        )?.submit ?: false
 
-        val evaluators = userReader.readAllByIds(evaluations.map { it.evaluatorUserId }).associateBy { it.id }
+        val evaluators = userReader.readAllByIds(finalEvaluations.map { it.memberId }).associateBy { it.id }
+        val evaluationsByEvaluator = interviewEvaluationReader.readAllByApplicantId(applicantId)
+            .associateBy { it.evaluatorUserId }
 
-        return evaluations.map { evaluation ->
-            val evaluator = evaluators[evaluation.evaluatorUserId]
-            val comment = if (viewerHasSubmitted) evaluation.overallComment else ""
+        return finalEvaluations.map { finalEval ->
+            val evaluator = evaluators[finalEval.memberId]
+            val comment = if (viewerHasSubmitted) finalEval.overallComment else ""
+            val evaluation = evaluationsByEvaluator[finalEval.memberId]
+
             OtherInterviewEvaluationDto(
-                evaluatorId = evaluation.evaluatorUserId,
+                evaluatorId = finalEval.memberId,
                 evaluatorName = evaluator?.userInfo?.name ?: "",
-                totalScore = evaluation.totalScore(),
-                result = evaluation.result,
+                totalScore = finalEval.score,
+                result = finalEval.interviewResult,
                 overallComment = comment,
-                items = evaluation.items.map { OtherInterviewEvaluationItemDto(it.evaluationItemId, it.score) }
+                items = evaluation?.items?.map { OtherInterviewEvaluationItemDto(it.evaluationItemId, it.score) } ?: emptyList()
             )
         }
     }
@@ -123,14 +149,14 @@ class InterviewEvaluationService(
         val evaluators = evaluatorDirectory.findEvaluatorsByPartId(partId)
         val usersByEmail = userReader.readAllByEmails(evaluators.map { it.email }).associateBy { it.userInfo.email }
 
-        val evaluationsByEvaluator = interviewEvaluationReader.readAllByApplicantId(applicantId).associateBy { it.evaluatorUserId }
+        val finalEvaluationsByEvaluator = finalEvaluationReader.readAllByApplicantId(applicantId).associateBy { it.memberId }
 
         return evaluators.mapNotNull { evaluator ->
             val user = usersByEmail[evaluator.email] ?: return@mapNotNull null
-            val evaluation = evaluationsByEvaluator[user.id]
+            val finalEval = finalEvaluationsByEvaluator[user.id]
             val status = when {
-                evaluation == null -> EvaluationStatus.NOT_STARTED
-                evaluation.isSubmitted() -> EvaluationStatus.SUBMITTED
+                finalEval == null -> EvaluationStatus.NOT_STARTED
+                finalEval.submit -> EvaluationStatus.SUBMITTED
                 else -> EvaluationStatus.IN_PROGRESS
             }
 
@@ -144,6 +170,7 @@ class InterviewEvaluationService(
 
     private fun toDto(
         evaluation: InterviewEvaluation,
+        finalEvaluation: FinalEvaluation?,
         rubricItems: Map<Long?, InterviewEvaluationItem>
     ): InterviewEvaluationDto {
         val items = evaluation.items.map { item ->
@@ -160,9 +187,11 @@ class InterviewEvaluationService(
         return InterviewEvaluationDto(
             totalScore = evaluation.totalScore(),
             items = items,
-            overallComment = evaluation.overallComment,
-            result = evaluation.result,
-            submittedAt = evaluation.submittedAt
+            overallComment = finalEvaluation?.overallComment ?: "",
+            result = finalEvaluation?.interviewResult ?: InterviewResult.PENDING,
+            submittedAt = finalEvaluation?.submittedAt
         )
     }
 }
+
+

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/business/InterviewEvaluationService.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/business/InterviewEvaluationService.kt
@@ -1,0 +1,169 @@
+package com.yourssu.scouter.recruiting.evaluation.business
+
+import com.yourssu.scouter.auth.user.implement.User
+import com.yourssu.scouter.auth.user.implement.UserReader
+import com.yourssu.scouter.recruiting.applicant.implement.Applicant
+import com.yourssu.scouter.recruiting.applicant.implement.ApplicantReader
+import com.yourssu.scouter.recruiting.evaluation.business.dto.*
+import com.yourssu.scouter.recruiting.evaluation.implement.*
+import com.yourssu.scouter.recruiting.rubric.implement.InterviewRubric
+import com.yourssu.scouter.recruiting.rubric.implement.InterviewRubricReader
+import com.yourssu.scouter.recruiting.rubric.implement.RubricGroupType
+import com.yourssu.scouter.recruiting.support.business.EvaluatorDirectory
+import com.yourssu.scouter.recruiting.support.implement.exception.InterviewEvaluationAccessDeniedException
+import com.yourssu.scouter.recruiting.support.implement.exception.InterviewEvaluationInvalidScoreException
+import com.yourssu.scouter.recruiting.support.implement.exception.InterviewEvaluationItemNotFoundException
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.Instant
+
+@Service
+class InterviewEvaluationService(
+    private val interviewEvaluationReader: InterviewEvaluationReader,
+    private val interviewEvaluationWriter: InterviewEvaluationWriter,
+    private val interviewRubricReader: InterviewRubricReader,
+    private val applicantReader: ApplicantReader,
+    private val userReader: UserReader,
+    private val evaluatorDirectory: EvaluatorDirectory,
+) {
+
+    fun readMy(applicantId: Long, evaluatorUserId: Long): InterviewEvaluationDto {
+        val applicant = applicantReader.readById(applicantId)
+        val semesterStr = "${applicant.applicationSemester.year.value}-${applicant.applicationSemester.term.intValue}"
+        val rubric = interviewRubricReader.getByPartIdAndSemester(applicant.part.id!!, semesterStr)
+        val rubricItems = rubric.items.associateBy { it.id }
+
+        val evaluation = interviewEvaluationReader.readByApplicantIdAndEvaluatorUserId(applicantId, evaluatorUserId)
+            ?: return InterviewEvaluationDto(
+                totalScore = 0,
+                items = rubric.items.map { item ->
+                    InterviewEvaluationItemDto(
+                        evaluationItemId = item.id!!,
+                        keyword = item.keyword,
+                        rubricType = item.rubricType,
+                        maxScore = item.maxScore,
+                        score = 0
+                    )
+                },
+                result = InterviewResult.PENDING,
+                submittedAt = null
+            )
+
+        return toDto(evaluation, rubricItems)
+    }
+
+    @Transactional
+    fun save(command: SaveInterviewEvaluationCommand) {
+        val applicant = applicantReader.readById(command.applicantId)
+        val semesterStr = "${applicant.applicationSemester.year.value}-${applicant.applicationSemester.term.intValue}"
+        val rubric = interviewRubricReader.getByPartIdAndSemester(applicant.part.id!!, semesterStr)
+        val rubricItems = rubric.items.associateBy { it.id }
+
+        val items = command.items.map { item ->
+            val rubricItem = rubricItems[item.evaluationItemId]
+                ?: throw InterviewEvaluationItemNotFoundException("해당 루브릭에 존재하지 않는 항목입니다: ${item.evaluationItemId}")
+
+            if (item.score > rubricItem.maxScore) {
+                throw InterviewEvaluationInvalidScoreException("점수는 배점(${rubricItem.maxScore})을 초과할 수 없습니다.")
+            }
+
+            InterviewEvaluationScoreItem(
+                evaluationItemId = item.evaluationItemId,
+                score = item.score
+            )
+        }
+
+        val existing = interviewEvaluationReader.readByApplicantIdAndEvaluatorUserId(
+            command.applicantId,
+            command.evaluatorUserId
+        )
+
+        val evaluation = InterviewEvaluation(
+            id = existing?.id,
+            applicantId = command.applicantId,
+            evaluatorUserId = command.evaluatorUserId,
+            items = items,
+            result = command.result,
+            submittedAt = if (command.submit) Instant.now() else existing?.submittedAt
+        )
+
+        interviewEvaluationWriter.write(evaluation)
+    }
+
+    fun readOthers(applicantId: Long, viewerUserId: Long): List<OtherInterviewEvaluationDto> {
+//        val applicant = applicantReader.readById(applicantId)
+        val evaluations = interviewEvaluationReader.readAllByApplicantId(applicantId)
+            .filter { it.isSubmitted() && it.evaluatorUserId != viewerUserId }
+
+        val viewerHasSubmitted = interviewEvaluationReader.readByApplicantIdAndEvaluatorUserId(
+            applicantId,
+            viewerUserId
+        )?.isSubmitted() ?: false
+
+        if (!viewerHasSubmitted) {
+            throw InterviewEvaluationAccessDeniedException("본인의 평가를 최종 제출한 경우에만 다른 면접관의 평가를 조회할 수 있습니다.")
+        }
+
+        val evaluators = userReader.readAllByIds(evaluations.map { it.evaluatorUserId }).associateBy { it.id }
+
+        return evaluations.map { evaluation ->
+            val evaluator = evaluators[evaluation.evaluatorUserId]
+            OtherInterviewEvaluationDto(
+                evaluatorId = evaluation.evaluatorUserId,
+                evaluatorName = evaluator?.userInfo?.name ?: "",
+                totalScore = evaluation.totalScore(),
+                result = evaluation.result,
+                items = evaluation.items.map { OtherInterviewEvaluationItemDto(it.evaluationItemId, it.score) }
+            )
+        }
+    }
+
+    fun readStatuses(applicantId: Long): List<EvaluatorStatusDto> {
+        val applicant = applicantReader.readById(applicantId)
+        val partId = applicant.part.id!!
+
+        val evaluators = evaluatorDirectory.findEvaluatorsByPartId(partId)
+        val usersByEmail = userReader.readAllByEmails(evaluators.map { it.email }).associateBy { it.userInfo.email }
+
+        val evaluationsByEvaluator = interviewEvaluationReader.readAllByApplicantId(applicantId).associateBy { it.evaluatorUserId }
+
+        return evaluators.mapNotNull { evaluator ->
+            val user = usersByEmail[evaluator.email] ?: return@mapNotNull null
+            val evaluation = evaluationsByEvaluator[user.id]
+            val status = when {
+                evaluation == null -> EvaluationStatus.NOT_STARTED
+                evaluation.isSubmitted() -> EvaluationStatus.SUBMITTED
+                else -> EvaluationStatus.IN_PROGRESS
+            }
+
+            EvaluatorStatusDto(
+                userId = user.id!!,
+                name = evaluator.name,
+                status = status
+            )
+        }
+    }
+
+    private fun toDto(
+        evaluation: InterviewEvaluation,
+        rubricItems: Map<Long?, InterviewEvaluationItem>
+    ): InterviewEvaluationDto {
+        val items = evaluation.items.map { item ->
+            val rubricItem = rubricItems[item.evaluationItemId]
+            InterviewEvaluationItemDto(
+                evaluationItemId = item.evaluationItemId,
+                keyword = rubricItem?.keyword ?: "",
+                rubricType = rubricItem?.rubricType ?: RubricGroupType.JOB,
+                maxScore = rubricItem?.maxScore ?: 0,
+                score = item.score
+            )
+        }
+
+        return InterviewEvaluationDto(
+            totalScore = evaluation.totalScore(),
+            items = items,
+            result = evaluation.result,
+            submittedAt = evaluation.submittedAt
+        )
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/business/InterviewEvaluationService.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/business/InterviewEvaluationService.kt
@@ -10,7 +10,6 @@ import com.yourssu.scouter.recruiting.rubric.implement.InterviewRubric
 import com.yourssu.scouter.recruiting.rubric.implement.InterviewRubricReader
 import com.yourssu.scouter.recruiting.rubric.implement.RubricGroupType
 import com.yourssu.scouter.recruiting.support.business.EvaluatorDirectory
-import com.yourssu.scouter.recruiting.support.implement.exception.InterviewEvaluationAccessDeniedException
 import com.yourssu.scouter.recruiting.support.implement.exception.InterviewEvaluationInvalidScoreException
 import com.yourssu.scouter.recruiting.support.implement.exception.InterviewEvaluationItemNotFoundException
 import org.springframework.stereotype.Service
@@ -45,6 +44,7 @@ class InterviewEvaluationService(
                         score = 0
                     )
                 },
+                overallComment = "",
                 result = InterviewResult.PENDING,
                 submittedAt = null
             )
@@ -83,6 +83,7 @@ class InterviewEvaluationService(
             applicantId = command.applicantId,
             evaluatorUserId = command.evaluatorUserId,
             items = items,
+            overallComment = command.overallComment,
             result = command.result,
             submittedAt = if (command.submit) Instant.now() else existing?.submittedAt
         )
@@ -91,7 +92,6 @@ class InterviewEvaluationService(
     }
 
     fun readOthers(applicantId: Long, viewerUserId: Long): List<OtherInterviewEvaluationDto> {
-//        val applicant = applicantReader.readById(applicantId)
         val evaluations = interviewEvaluationReader.readAllByApplicantId(applicantId)
             .filter { it.isSubmitted() && it.evaluatorUserId != viewerUserId }
 
@@ -100,19 +100,17 @@ class InterviewEvaluationService(
             viewerUserId
         )?.isSubmitted() ?: false
 
-        if (!viewerHasSubmitted) {
-            throw InterviewEvaluationAccessDeniedException("본인의 평가를 최종 제출한 경우에만 다른 면접관의 평가를 조회할 수 있습니다.")
-        }
-
         val evaluators = userReader.readAllByIds(evaluations.map { it.evaluatorUserId }).associateBy { it.id }
 
         return evaluations.map { evaluation ->
             val evaluator = evaluators[evaluation.evaluatorUserId]
+            val comment = if (viewerHasSubmitted) evaluation.overallComment else ""
             OtherInterviewEvaluationDto(
                 evaluatorId = evaluation.evaluatorUserId,
                 evaluatorName = evaluator?.userInfo?.name ?: "",
                 totalScore = evaluation.totalScore(),
                 result = evaluation.result,
+                overallComment = comment,
                 items = evaluation.items.map { OtherInterviewEvaluationItemDto(it.evaluationItemId, it.score) }
             )
         }
@@ -162,6 +160,7 @@ class InterviewEvaluationService(
         return InterviewEvaluationDto(
             totalScore = evaluation.totalScore(),
             items = items,
+            overallComment = evaluation.overallComment,
             result = evaluation.result,
             submittedAt = evaluation.submittedAt
         )

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/business/dto/InterviewEvaluationDto.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/business/dto/InterviewEvaluationDto.kt
@@ -1,0 +1,11 @@
+package com.yourssu.scouter.recruiting.evaluation.business.dto
+
+import com.yourssu.scouter.recruiting.evaluation.implement.InterviewResult
+import java.time.Instant
+
+data class InterviewEvaluationDto(
+    val totalScore: Int,
+    val items: List<InterviewEvaluationItemDto>,
+    val result: InterviewResult,
+    val submittedAt: Instant?,
+)

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/business/dto/InterviewEvaluationDto.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/business/dto/InterviewEvaluationDto.kt
@@ -1,12 +1,13 @@
 package com.yourssu.scouter.recruiting.evaluation.business.dto
 
 import com.yourssu.scouter.recruiting.evaluation.implement.InterviewResult
-import java.time.Instant
+import java.time.LocalDateTime
 
 data class InterviewEvaluationDto(
     val totalScore: Int,
     val items: List<InterviewEvaluationItemDto>,
     val overallComment: String,
     val result: InterviewResult,
-    val submittedAt: Instant?,
+    val submittedAt: LocalDateTime?,
 )
+

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/business/dto/InterviewEvaluationDto.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/business/dto/InterviewEvaluationDto.kt
@@ -6,6 +6,7 @@ import java.time.Instant
 data class InterviewEvaluationDto(
     val totalScore: Int,
     val items: List<InterviewEvaluationItemDto>,
+    val overallComment: String,
     val result: InterviewResult,
     val submittedAt: Instant?,
 )

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/business/dto/InterviewEvaluationItemDto.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/business/dto/InterviewEvaluationItemDto.kt
@@ -1,0 +1,11 @@
+package com.yourssu.scouter.recruiting.evaluation.business.dto
+
+import com.yourssu.scouter.recruiting.rubric.implement.RubricGroupType
+
+data class InterviewEvaluationItemDto(
+    val evaluationItemId: Long,
+    val keyword: String,
+    val rubricType: RubricGroupType,
+    val maxScore: Int,
+    val score: Int,
+)

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/business/dto/OtherInterviewEvaluationDto.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/business/dto/OtherInterviewEvaluationDto.kt
@@ -7,5 +7,6 @@ data class OtherInterviewEvaluationDto(
     val evaluatorName: String,
     val totalScore: Int,
     val result: InterviewResult,
+    val overallComment: String,
     val items: List<OtherInterviewEvaluationItemDto>,
 )

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/business/dto/OtherInterviewEvaluationDto.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/business/dto/OtherInterviewEvaluationDto.kt
@@ -1,0 +1,11 @@
+package com.yourssu.scouter.recruiting.evaluation.business.dto
+
+import com.yourssu.scouter.recruiting.evaluation.implement.InterviewResult
+
+data class OtherInterviewEvaluationDto(
+    val evaluatorId: Long,
+    val evaluatorName: String,
+    val totalScore: Int,
+    val result: InterviewResult,
+    val items: List<OtherInterviewEvaluationItemDto>,
+)

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/business/dto/OtherInterviewEvaluationItemDto.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/business/dto/OtherInterviewEvaluationItemDto.kt
@@ -1,0 +1,6 @@
+package com.yourssu.scouter.recruiting.evaluation.business.dto
+
+data class OtherInterviewEvaluationItemDto(
+    val evaluationItemId: Long,
+    val score: Int,
+)

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/business/dto/SaveInterviewEvaluationCommand.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/business/dto/SaveInterviewEvaluationCommand.kt
@@ -1,0 +1,11 @@
+package com.yourssu.scouter.recruiting.evaluation.business.dto
+
+import com.yourssu.scouter.recruiting.evaluation.implement.InterviewResult
+
+data class SaveInterviewEvaluationCommand(
+    val applicantId: Long,
+    val evaluatorUserId: Long,
+    val items: List<SaveInterviewEvaluationItemCommand>,
+    val result: InterviewResult,
+    val submit: Boolean,
+)

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/business/dto/SaveInterviewEvaluationCommand.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/business/dto/SaveInterviewEvaluationCommand.kt
@@ -6,6 +6,7 @@ data class SaveInterviewEvaluationCommand(
     val applicantId: Long,
     val evaluatorUserId: Long,
     val items: List<SaveInterviewEvaluationItemCommand>,
+    val overallComment: String = "",
     val result: InterviewResult,
     val submit: Boolean,
 )

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/business/dto/SaveInterviewEvaluationItemCommand.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/business/dto/SaveInterviewEvaluationItemCommand.kt
@@ -1,0 +1,6 @@
+package com.yourssu.scouter.recruiting.evaluation.business.dto
+
+data class SaveInterviewEvaluationItemCommand(
+    val evaluationItemId: Long,
+    val score: Int,
+)

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/implement/FinalEvaluation.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/implement/FinalEvaluation.kt
@@ -4,7 +4,7 @@ import java.time.LocalDateTime
 
 class FinalEvaluation(
     val id: Long? = null,
-    val memberId: Long,
+    val evaluatorUserId: Long,
     val interviewRubricId: Long,
     val applicantId: Long,
     val overallComment: String = "",

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/implement/FinalEvaluation.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/implement/FinalEvaluation.kt
@@ -1,0 +1,18 @@
+package com.yourssu.scouter.recruiting.evaluation.implement
+
+import java.time.LocalDateTime
+
+class FinalEvaluation(
+    val id: Long? = null,
+    val memberId: Long,
+    val interviewRubricId: Long,
+    val applicantId: Long,
+    val overallComment: String = "",
+    val interviewResult: InterviewResult = InterviewResult.PENDING,
+    val score: Int,
+    val submit: Boolean = false,
+    val submittedAt: LocalDateTime? = null
+) {
+    fun isSubmitted(): Boolean = submit
+}
+

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/implement/FinalEvaluationReader.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/implement/FinalEvaluationReader.kt
@@ -9,7 +9,7 @@ class FinalEvaluationReader(
     private val finalEvaluationRepository: FinalEvaluationRepository,
 ) {
     fun readByApplicantIdAndEvaluatorUserId(applicantId: Long, evaluatorUserId: Long): FinalEvaluation? {
-        return finalEvaluationRepository.findByApplicantIdAndMemberId(applicantId, evaluatorUserId)
+        return finalEvaluationRepository.findByApplicantIdAndEvaluatorUserId(applicantId, evaluatorUserId)
     }
 
     fun readAllByApplicantId(applicantId: Long): List<FinalEvaluation> {

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/implement/FinalEvaluationReader.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/implement/FinalEvaluationReader.kt
@@ -1,0 +1,22 @@
+package com.yourssu.scouter.recruiting.evaluation.implement
+
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+
+@Component
+@Transactional(readOnly = true)
+class FinalEvaluationReader(
+    private val finalEvaluationRepository: FinalEvaluationRepository,
+) {
+    fun readByApplicantIdAndEvaluatorUserId(applicantId: Long, evaluatorUserId: Long): FinalEvaluation? {
+        return finalEvaluationRepository.findByApplicantIdAndMemberId(applicantId, evaluatorUserId)
+    }
+
+    fun readAllByApplicantId(applicantId: Long): List<FinalEvaluation> {
+        return finalEvaluationRepository.findAllByApplicantId(applicantId)
+    }
+
+    fun readAllByApplicantIdIn(applicantIds: List<Long>): List<FinalEvaluation> {
+        return finalEvaluationRepository.findAllByApplicantIdIn(applicantIds)
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/implement/FinalEvaluationRepository.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/implement/FinalEvaluationRepository.kt
@@ -2,7 +2,7 @@ package com.yourssu.scouter.recruiting.evaluation.implement
 
 interface FinalEvaluationRepository {
     fun save(finalEvaluation: FinalEvaluation): FinalEvaluation
-    fun findByApplicantIdAndMemberId(applicantId: Long, memberId: Long): FinalEvaluation?
+    fun findByApplicantIdAndEvaluatorUserId(applicantId: Long, evaluatorUserId: Long): FinalEvaluation?
     fun findAllByApplicantId(applicantId: Long): List<FinalEvaluation>
     fun findAllByApplicantIdIn(applicantIds: List<Long>): List<FinalEvaluation>
 }

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/implement/FinalEvaluationRepository.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/implement/FinalEvaluationRepository.kt
@@ -1,0 +1,8 @@
+package com.yourssu.scouter.recruiting.evaluation.implement
+
+interface FinalEvaluationRepository {
+    fun save(finalEvaluation: FinalEvaluation): FinalEvaluation
+    fun findByApplicantIdAndMemberId(applicantId: Long, memberId: Long): FinalEvaluation?
+    fun findAllByApplicantId(applicantId: Long): List<FinalEvaluation>
+    fun findAllByApplicantIdIn(applicantIds: List<Long>): List<FinalEvaluation>
+}

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/implement/FinalEvaluationWriter.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/implement/FinalEvaluationWriter.kt
@@ -1,0 +1,14 @@
+package com.yourssu.scouter.recruiting.evaluation.implement
+
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+
+@Component
+@Transactional
+class FinalEvaluationWriter(
+    private val finalEvaluationRepository: FinalEvaluationRepository,
+) {
+    fun write(finalEvaluation: FinalEvaluation): FinalEvaluation {
+        return finalEvaluationRepository.save(finalEvaluation)
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/implement/InterviewEvaluation.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/implement/InterviewEvaluation.kt
@@ -7,6 +7,7 @@ class InterviewEvaluation(
     val applicantId: Long,
     val evaluatorUserId: Long, // Entity의 memberId
     val items: List<InterviewEvaluationScoreItem>,
+    val overallComment: String = "",
     val result: InterviewResult = InterviewResult.PENDING,
     val submittedAt: Instant? = null,
 ) {
@@ -18,6 +19,7 @@ class InterviewEvaluation(
     fun update(
         items: List<InterviewEvaluationScoreItem>,
         result: InterviewResult,
+        overallComment: String = this.overallComment,
         submittedAt: Instant? = this.submittedAt
     ): InterviewEvaluation {
         return InterviewEvaluation(
@@ -25,6 +27,7 @@ class InterviewEvaluation(
             applicantId = this.applicantId,
             evaluatorUserId = this.evaluatorUserId,
             items = items,
+            overallComment = overallComment,
             result = result,
             submittedAt = submittedAt
         )

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/implement/InterviewEvaluation.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/implement/InterviewEvaluation.kt
@@ -1,35 +1,22 @@
 package com.yourssu.scouter.recruiting.evaluation.implement
 
-import java.time.Instant
-
 class InterviewEvaluation(
     val id: Long? = null,
     val applicantId: Long,
     val evaluatorUserId: Long, // Entity의 memberId
-    val items: List<InterviewEvaluationScoreItem>,
-    val overallComment: String = "",
-    val result: InterviewResult = InterviewResult.PENDING,
-    val submittedAt: Instant? = null,
+    val items: List<InterviewEvaluationScoreItem>
 ) {
 
     fun totalScore(): Int = items.sumOf { it.score }
 
-    fun isSubmitted(): Boolean = submittedAt != null
-
     fun update(
-        items: List<InterviewEvaluationScoreItem>,
-        result: InterviewResult,
-        overallComment: String = this.overallComment,
-        submittedAt: Instant? = this.submittedAt
+        items: List<InterviewEvaluationScoreItem>
     ): InterviewEvaluation {
         return InterviewEvaluation(
             id = this.id,
             applicantId = this.applicantId,
             evaluatorUserId = this.evaluatorUserId,
-            items = items,
-            overallComment = overallComment,
-            result = result,
-            submittedAt = submittedAt
+            items = items
         )
     }
 
@@ -45,4 +32,4 @@ class InterviewEvaluation(
     override fun hashCode(): Int {
         return id?.hashCode() ?: 0
     }
-}
+}

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/implement/InterviewEvaluation.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/implement/InterviewEvaluation.kt
@@ -1,0 +1,45 @@
+package com.yourssu.scouter.recruiting.evaluation.implement
+
+import java.time.Instant
+
+class InterviewEvaluation(
+    val id: Long? = null,
+    val applicantId: Long,
+    val evaluatorUserId: Long, // Entity의 memberId
+    val items: List<InterviewEvaluationScoreItem>,
+    val result: InterviewResult = InterviewResult.PENDING,
+    val submittedAt: Instant? = null,
+) {
+
+    fun totalScore(): Int = items.sumOf { it.score }
+
+    fun isSubmitted(): Boolean = submittedAt != null
+
+    fun update(
+        items: List<InterviewEvaluationScoreItem>,
+        result: InterviewResult,
+        submittedAt: Instant? = this.submittedAt
+    ): InterviewEvaluation {
+        return InterviewEvaluation(
+            id = this.id,
+            applicantId = this.applicantId,
+            evaluatorUserId = this.evaluatorUserId,
+            items = items,
+            result = result,
+            submittedAt = submittedAt
+        )
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as InterviewEvaluation
+
+        return id == other.id
+    }
+
+    override fun hashCode(): Int {
+        return id?.hashCode() ?: 0
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/implement/InterviewEvaluation.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/implement/InterviewEvaluation.kt
@@ -19,17 +19,4 @@ class InterviewEvaluation(
             items = items
         )
     }
-
-    override fun equals(other: Any?): Boolean {
-        if (this === other) return true
-        if (javaClass != other?.javaClass) return false
-
-        other as InterviewEvaluation
-
-        return id == other.id
-    }
-
-    override fun hashCode(): Int {
-        return id?.hashCode() ?: 0
-    }
 }

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/implement/InterviewEvaluationItem.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/implement/InterviewEvaluationItem.kt
@@ -1,0 +1,25 @@
+package com.yourssu.scouter.recruiting.evaluation.implement
+
+import com.yourssu.scouter.recruiting.rubric.implement.RubricGroupType
+
+
+class InterviewEvaluationItem(
+    val id: Long? = null,
+    val keyword: String,
+    val rubricType: RubricGroupType,
+    val maxScore: Int,
+) {
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as InterviewEvaluationItem
+
+        return id == other.id
+    }
+
+    override fun hashCode(): Int {
+        return id?.hashCode() ?: 0
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/implement/InterviewEvaluationReader.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/implement/InterviewEvaluationReader.kt
@@ -1,0 +1,22 @@
+package com.yourssu.scouter.recruiting.evaluation.implement
+
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+
+@Component
+@Transactional(readOnly = true)
+class InterviewEvaluationReader(
+    private val interviewEvaluationRepository: InterviewEvaluationRepository,
+) {
+    fun readByApplicantIdAndEvaluatorUserId(applicantId: Long, evaluatorUserId: Long): InterviewEvaluation? {
+        return interviewEvaluationRepository.findByApplicantIdAndEvaluatorUserId(applicantId, evaluatorUserId)
+    }
+
+    fun readAllByApplicantId(applicantId: Long): List<InterviewEvaluation> {
+        return interviewEvaluationRepository.findAllByApplicantId(applicantId)
+    }
+
+    fun readAllByApplicantIdIn(applicantIds: List<Long>): List<InterviewEvaluation> {
+        return interviewEvaluationRepository.findAllByApplicantIdIn(applicantIds)
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/implement/InterviewEvaluationReader.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/implement/InterviewEvaluationReader.kt
@@ -19,4 +19,8 @@ class InterviewEvaluationReader(
     fun readAllByApplicantIdIn(applicantIds: List<Long>): List<InterviewEvaluation> {
         return interviewEvaluationRepository.findAllByApplicantIdIn(applicantIds)
     }
+
+    fun existsByInterviewEvaluationItemIdIn(itemIds: List<Long>): Boolean {
+        return interviewEvaluationRepository.existsByInterviewEvaluationItemIdIn(itemIds)
+    }
 }

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/implement/InterviewEvaluationRepository.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/implement/InterviewEvaluationRepository.kt
@@ -1,0 +1,8 @@
+package com.yourssu.scouter.recruiting.evaluation.implement
+
+interface InterviewEvaluationRepository {
+    fun save(evaluation: InterviewEvaluation): InterviewEvaluation
+    fun findByApplicantIdAndEvaluatorUserId(applicantId: Long, evaluatorUserId: Long): InterviewEvaluation?
+    fun findAllByApplicantId(applicantId: Long): List<InterviewEvaluation>
+    fun findAllByApplicantIdIn(applicantIds: List<Long>): List<InterviewEvaluation>
+}

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/implement/InterviewEvaluationRepository.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/implement/InterviewEvaluationRepository.kt
@@ -5,4 +5,5 @@ interface InterviewEvaluationRepository {
     fun findByApplicantIdAndEvaluatorUserId(applicantId: Long, evaluatorUserId: Long): InterviewEvaluation?
     fun findAllByApplicantId(applicantId: Long): List<InterviewEvaluation>
     fun findAllByApplicantIdIn(applicantIds: List<Long>): List<InterviewEvaluation>
+    fun existsByInterviewEvaluationItemIdIn(itemIds: List<Long>): Boolean
 }

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/implement/InterviewEvaluationScoreItem.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/implement/InterviewEvaluationScoreItem.kt
@@ -1,0 +1,21 @@
+package com.yourssu.scouter.recruiting.evaluation.implement
+
+class InterviewEvaluationScoreItem(
+    val id: Long? = null,
+    val evaluationItemId: Long, // InterviewEvaluationItemEntity의 ID
+    val score: Int,
+) {
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as InterviewEvaluationScoreItem
+
+        return id == other.id
+    }
+
+    override fun hashCode(): Int {
+        return id?.hashCode() ?: 0
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/implement/InterviewEvaluationWriter.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/implement/InterviewEvaluationWriter.kt
@@ -1,0 +1,14 @@
+package com.yourssu.scouter.recruiting.evaluation.implement
+
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+
+@Component
+@Transactional
+class InterviewEvaluationWriter(
+    private val interviewEvaluationRepository: InterviewEvaluationRepository,
+) {
+    fun write(evaluation: InterviewEvaluation): InterviewEvaluation {
+        return interviewEvaluationRepository.save(evaluation)
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/implement/InterviewResult.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/implement/InterviewResult.kt
@@ -1,0 +1,7 @@
+package com.yourssu.scouter.recruiting.evaluation.implement
+
+enum class InterviewResult {
+    PENDING,
+    FINAL_PASS,
+    INTERVIEW_FAIL
+}

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/storage/FinalEvaluationEntity.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/storage/FinalEvaluationEntity.kt
@@ -3,7 +3,7 @@ package com.yourssu.scouter.recruiting.evaluation.storage
 import com.yourssu.scouter.recruiting.applicant.storage.ApplicantEntity
 import com.yourssu.scouter.recruiting.evaluation.implement.InterviewResult
 import com.yourssu.scouter.recruiting.rubric.storage.InterviewRubricEntity
-import com.yourssu.scouter.hrms.member.storage.MemberEntity
+import com.yourssu.scouter.auth.user.storage.UserEntity
 import jakarta.persistence.*
 import java.time.LocalDateTime
 
@@ -15,8 +15,8 @@ class FinalEvaluationEntity(
     val id: Long = 0L,
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member_id", nullable = false)
-    val member: MemberEntity,
+    @JoinColumn(name = "user_id", nullable = false)
+    val user: UserEntity,
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "interview_rubric_id", nullable = false)

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/storage/FinalEvaluationEntity.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/storage/FinalEvaluationEntity.kt
@@ -1,0 +1,53 @@
+package com.yourssu.scouter.recruiting.evaluation.storage
+
+import com.yourssu.scouter.recruiting.applicant.storage.ApplicantEntity
+import com.yourssu.scouter.recruiting.evaluation.implement.InterviewResult
+import com.yourssu.scouter.recruiting.rubric.storage.InterviewRubricEntity
+import com.yourssu.scouter.hrms.member.storage.MemberEntity
+import jakarta.persistence.*
+import java.time.LocalDateTime
+
+@Entity
+@Table(name = "final_evaluation")
+class FinalEvaluationEntity(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0L,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    val member: MemberEntity,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "interview_rubric_id", nullable = false)
+    val interviewRubric: InterviewRubricEntity,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "applicant_id", nullable = false)
+    val applicant: ApplicantEntity,
+
+    @Column(name = "overall_comment", columnDefinition = "TEXT")
+    var overallComment: String? = null,
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "interview_result", nullable = false)
+    var interviewResult: InterviewResult = InterviewResult.PENDING,
+
+    @Column(nullable = false)
+    var score: Int,
+
+    @Column(nullable = false)
+    var submit: Boolean = false,
+
+    @Column(name = "submitted_at")
+    var submittedAt: LocalDateTime? = null
+) {
+    fun update(overallComment: String?, interviewResult: InterviewResult, score: Int, submit: Boolean, submittedAt: LocalDateTime?) {
+        this.overallComment = overallComment
+        this.interviewResult = interviewResult
+        this.score = score
+        this.submit = submit
+        this.submittedAt = submittedAt
+    }
+}
+

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/storage/FinalEvaluationRepositoryImpl.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/storage/FinalEvaluationRepositoryImpl.kt
@@ -3,22 +3,22 @@ package com.yourssu.scouter.recruiting.evaluation.storage
 import com.yourssu.scouter.recruiting.evaluation.implement.FinalEvaluation
 import com.yourssu.scouter.recruiting.evaluation.implement.FinalEvaluationRepository
 import com.yourssu.scouter.recruiting.rubric.storage.JpaInterviewRubricRepository
-import com.yourssu.scouter.hrms.member.storage.JpaMemberRepository
+import com.yourssu.scouter.auth.user.storage.JpaUserRepository
 import com.yourssu.scouter.recruiting.applicant.storage.JpaApplicantRepository
 import org.springframework.stereotype.Repository
 
 @Repository
 class FinalEvaluationRepositoryImpl(
     private val jpaFinalEvaluationRepository: JpaFinalEvaluationRepository,
-    private val jpaMemberRepository: JpaMemberRepository,
+    private val jpaUserRepository: JpaUserRepository,
     private val jpaInterviewRubricRepository: JpaInterviewRubricRepository,
     private val jpaApplicantRepository: JpaApplicantRepository,
 ) : FinalEvaluationRepository {
 
     override fun save(finalEvaluation: FinalEvaluation): FinalEvaluation {
-        val existing = jpaFinalEvaluationRepository.findByApplicantIdAndMemberId(
+        val existing = jpaFinalEvaluationRepository.findByApplicantIdAndUserId(
             finalEvaluation.applicantId,
-            finalEvaluation.memberId
+            finalEvaluation.evaluatorUserId
         )
 
         val entity = if (existing != null) {
@@ -31,11 +31,11 @@ class FinalEvaluationRepositoryImpl(
             )
             jpaFinalEvaluationRepository.save(existing)
         } else {
-            val memberRef = jpaMemberRepository.getReferenceById(finalEvaluation.memberId)
+            val userRef = jpaUserRepository.getReferenceById(finalEvaluation.evaluatorUserId)
             val rubricRef = jpaInterviewRubricRepository.getReferenceById(finalEvaluation.interviewRubricId)
             val applicantRef = jpaApplicantRepository.getReferenceById(finalEvaluation.applicantId)
             val newEntity = FinalEvaluationEntity(
-                member = memberRef,
+                user = userRef,
                 interviewRubric = rubricRef,
                 applicant = applicantRef,
                 overallComment = finalEvaluation.overallComment,
@@ -50,8 +50,8 @@ class FinalEvaluationRepositoryImpl(
         return toDomain(entity)
     }
 
-    override fun findByApplicantIdAndMemberId(applicantId: Long, memberId: Long): FinalEvaluation? {
-        val entity = jpaFinalEvaluationRepository.findByApplicantIdAndMemberId(applicantId, memberId) ?: return null
+    override fun findByApplicantIdAndEvaluatorUserId(applicantId: Long, evaluatorUserId: Long): FinalEvaluation? {
+        val entity = jpaFinalEvaluationRepository.findByApplicantIdAndUserId(applicantId, evaluatorUserId) ?: return null
         return toDomain(entity)
     }
 
@@ -67,7 +67,7 @@ class FinalEvaluationRepositoryImpl(
     private fun toDomain(entity: FinalEvaluationEntity): FinalEvaluation {
         return FinalEvaluation(
             id = entity.id,
-            memberId = entity.member.id!!,
+            evaluatorUserId = entity.user.id!!,
             interviewRubricId = entity.interviewRubric.id,
             applicantId = entity.applicant.id!!,
             overallComment = entity.overallComment ?: "",

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/storage/FinalEvaluationRepositoryImpl.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/storage/FinalEvaluationRepositoryImpl.kt
@@ -1,0 +1,80 @@
+package com.yourssu.scouter.recruiting.evaluation.storage
+
+import com.yourssu.scouter.recruiting.evaluation.implement.FinalEvaluation
+import com.yourssu.scouter.recruiting.evaluation.implement.FinalEvaluationRepository
+import com.yourssu.scouter.recruiting.rubric.storage.JpaInterviewRubricRepository
+import com.yourssu.scouter.hrms.member.storage.JpaMemberRepository
+import com.yourssu.scouter.recruiting.applicant.storage.JpaApplicantRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+class FinalEvaluationRepositoryImpl(
+    private val jpaFinalEvaluationRepository: JpaFinalEvaluationRepository,
+    private val jpaMemberRepository: JpaMemberRepository,
+    private val jpaInterviewRubricRepository: JpaInterviewRubricRepository,
+    private val jpaApplicantRepository: JpaApplicantRepository,
+) : FinalEvaluationRepository {
+
+    override fun save(finalEvaluation: FinalEvaluation): FinalEvaluation {
+        val existing = jpaFinalEvaluationRepository.findByApplicantIdAndMemberId(
+            finalEvaluation.applicantId,
+            finalEvaluation.memberId
+        )
+
+        val entity = if (existing != null) {
+            existing.update(
+                overallComment = finalEvaluation.overallComment,
+                interviewResult = finalEvaluation.interviewResult,
+                score = finalEvaluation.score,
+                submit = finalEvaluation.submit,
+                submittedAt = finalEvaluation.submittedAt
+            )
+            jpaFinalEvaluationRepository.save(existing)
+        } else {
+            val memberRef = jpaMemberRepository.getReferenceById(finalEvaluation.memberId)
+            val rubricRef = jpaInterviewRubricRepository.getReferenceById(finalEvaluation.interviewRubricId)
+            val applicantRef = jpaApplicantRepository.getReferenceById(finalEvaluation.applicantId)
+            val newEntity = FinalEvaluationEntity(
+                member = memberRef,
+                interviewRubric = rubricRef,
+                applicant = applicantRef,
+                overallComment = finalEvaluation.overallComment,
+                interviewResult = finalEvaluation.interviewResult,
+                score = finalEvaluation.score,
+                submit = finalEvaluation.submit,
+                submittedAt = finalEvaluation.submittedAt
+            )
+            jpaFinalEvaluationRepository.save(newEntity)
+        }
+
+        return toDomain(entity)
+    }
+
+    override fun findByApplicantIdAndMemberId(applicantId: Long, memberId: Long): FinalEvaluation? {
+        val entity = jpaFinalEvaluationRepository.findByApplicantIdAndMemberId(applicantId, memberId) ?: return null
+        return toDomain(entity)
+    }
+
+    override fun findAllByApplicantId(applicantId: Long): List<FinalEvaluation> {
+        return jpaFinalEvaluationRepository.findAllByApplicantId(applicantId).map(::toDomain)
+    }
+
+    override fun findAllByApplicantIdIn(applicantIds: List<Long>): List<FinalEvaluation> {
+        if (applicantIds.isEmpty()) return emptyList()
+        return jpaFinalEvaluationRepository.findAllByApplicantIdIn(applicantIds).map(::toDomain)
+    }
+
+    private fun toDomain(entity: FinalEvaluationEntity): FinalEvaluation {
+        return FinalEvaluation(
+            id = entity.id,
+            memberId = entity.member.id!!,
+            interviewRubricId = entity.interviewRubric.id,
+            applicantId = entity.applicant.id!!,
+            overallComment = entity.overallComment ?: "",
+            interviewResult = entity.interviewResult,
+            score = entity.score,
+            submit = entity.submit,
+            submittedAt = entity.submittedAt
+        )
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/storage/InterivewEvaluationEntity.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/storage/InterivewEvaluationEntity.kt
@@ -1,0 +1,35 @@
+package com.yourssu.scouter.recruiting.evaluation.storage
+
+import com.yourssu.scouter.recruiting.evaluation.implement.InterviewResult
+import jakarta.persistence.*
+
+@Entity
+@Table(name = "interview_evaluation")
+class InterviewEvaluationEntity(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0L,
+
+    @Column(name = "applicant_id", nullable = false)
+    val applicantId: Long,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "interview_evaluation_item_id", nullable = false)
+    var interviewEvaluationItem: InterviewEvaluationItemEntity,
+
+    @Column(name = "member_id", nullable = false)
+    val memberId: Long, // 평가자 ID
+
+    @Column(nullable = false)
+    var score: Int,
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    var result: InterviewResult = InterviewResult.PENDING
+
+) {
+    fun updateEvaluation(newScore: Int, newResult: InterviewResult) {
+        this.score = newScore
+        this.result = newResult
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/storage/InterviewEvaluationEntity.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/storage/InterviewEvaluationEntity.kt
@@ -16,8 +16,8 @@ class InterviewEvaluationEntity(
     @JoinColumn(name = "interview_evaluation_item_id", nullable = false)
     var interviewEvaluationItem: InterviewEvaluationItemEntity,
 
-    @Column(name = "member_id", nullable = false)
-    val memberId: Long, // 평가자 ID
+    @Column(name = "user_id", nullable = false)
+    val userId: Long, // 평가자 ID
 
     @Column(nullable = false)
     var score: Int

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/storage/InterviewEvaluationEntity.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/storage/InterviewEvaluationEntity.kt
@@ -2,6 +2,7 @@ package com.yourssu.scouter.recruiting.evaluation.storage
 
 import com.yourssu.scouter.recruiting.evaluation.implement.InterviewResult
 import jakarta.persistence.*
+import java.time.Instant
 
 @Entity
 @Table(name = "interview_evaluation")
@@ -25,11 +26,14 @@ class InterviewEvaluationEntity(
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
-    var result: InterviewResult = InterviewResult.PENDING
+    var result: InterviewResult = InterviewResult.PENDING,
 
+    @Column(name = "submitted_at")
+    var submittedAt: Instant? = null
 ) {
-    fun updateEvaluation(newScore: Int, newResult: InterviewResult) {
+    fun updateEvaluation(newScore: Int, newResult: InterviewResult, newSubmittedAt: Instant?) {
         this.score = newScore
         this.result = newResult
+        this.submittedAt = newSubmittedAt
     }
 }

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/storage/InterviewEvaluationEntity.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/storage/InterviewEvaluationEntity.kt
@@ -28,12 +28,16 @@ class InterviewEvaluationEntity(
     @Column(nullable = false)
     var result: InterviewResult = InterviewResult.PENDING,
 
+    @Column(name = "overall_comment", columnDefinition = "TEXT")
+    var overallComment: String? = null,
+
     @Column(name = "submitted_at")
     var submittedAt: Instant? = null
 ) {
-    fun updateEvaluation(newScore: Int, newResult: InterviewResult, newSubmittedAt: Instant?) {
+    fun updateEvaluation(newScore: Int, newResult: InterviewResult, newOverallComment: String?, newSubmittedAt: Instant?) {
         this.score = newScore
         this.result = newResult
+        this.overallComment = newOverallComment
         this.submittedAt = newSubmittedAt
     }
 }

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/storage/InterviewEvaluationEntity.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/storage/InterviewEvaluationEntity.kt
@@ -1,8 +1,6 @@
 package com.yourssu.scouter.recruiting.evaluation.storage
 
-import com.yourssu.scouter.recruiting.evaluation.implement.InterviewResult
 import jakarta.persistence.*
-import java.time.Instant
 
 @Entity
 @Table(name = "interview_evaluation")
@@ -22,22 +20,10 @@ class InterviewEvaluationEntity(
     val memberId: Long, // 평가자 ID
 
     @Column(nullable = false)
-    var score: Int,
-
-    @Enumerated(EnumType.STRING)
-    @Column(nullable = false)
-    var result: InterviewResult = InterviewResult.PENDING,
-
-    @Column(name = "overall_comment", columnDefinition = "TEXT")
-    var overallComment: String? = null,
-
-    @Column(name = "submitted_at")
-    var submittedAt: Instant? = null
+    var score: Int
 ) {
-    fun updateEvaluation(newScore: Int, newResult: InterviewResult, newOverallComment: String?, newSubmittedAt: Instant?) {
+    fun updateEvaluation(newScore: Int) {
         this.score = newScore
-        this.result = newResult
-        this.overallComment = newOverallComment
-        this.submittedAt = newSubmittedAt
     }
 }
+

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/storage/InterviewEvaluationItemEntity.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/storage/InterviewEvaluationItemEntity.kt
@@ -1,0 +1,27 @@
+package com.yourssu.scouter.recruiting.evaluation.storage
+
+import com.yourssu.scouter.recruiting.rubric.implement.RubricGroupType
+import com.yourssu.scouter.recruiting.rubric.storage.InterviewRubricEntity
+import jakarta.persistence.*
+
+@Entity
+@Table(name = "interview_evaluation_item")
+class InterviewEvaluationItemEntity(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0L,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "interview_rubric_id", nullable = false)
+    var interviewRubric: InterviewRubricEntity,
+
+    @Column(nullable = false)
+    var keyword: String,
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "rubric_type", nullable = false)
+    var rubricType: RubricGroupType,
+
+    @Column(name = "max_score", nullable = false)
+    var maxScore: Int
+)

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/storage/InterviewEvaluationRepositoryImpl.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/storage/InterviewEvaluationRepositoryImpl.kt
@@ -75,9 +75,9 @@ class InterviewEvaluationRepositoryImpl(
         evaluatorUserId: Long,
         entities: List<InterviewEvaluationEntity>
     ): InterviewEvaluation {
-        val first = entities.first()
+        val first = entities.firstOrNull()
         return InterviewEvaluation(
-            id = first.id, // Using first entity's ID or similar reference
+            id = first?.id,
             applicantId = applicantId,
             evaluatorUserId = evaluatorUserId,
             items = entities.map { entity ->

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/storage/InterviewEvaluationRepositoryImpl.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/storage/InterviewEvaluationRepositoryImpl.kt
@@ -12,7 +12,7 @@ class InterviewEvaluationRepositoryImpl(
 ) : InterviewEvaluationRepository {
 
     override fun save(evaluation: InterviewEvaluation): InterviewEvaluation {
-        val existingEntities = jpaInterviewEvaluationRepository.findAllByApplicantIdAndMemberId(
+        val existingEntities = jpaInterviewEvaluationRepository.findAllByApplicantIdAndUserId(
             evaluation.applicantId,
             evaluation.evaluatorUserId
         ).associateBy { it.interviewEvaluationItem.id }
@@ -21,7 +21,7 @@ class InterviewEvaluationRepositoryImpl(
             val entity = existingEntities[item.evaluationItemId] ?: InterviewEvaluationEntity(
                 applicantId = evaluation.applicantId,
                 interviewEvaluationItem = jpaInterviewEvaluationItemRepository.getReferenceById(item.evaluationItemId),
-                memberId = evaluation.evaluatorUserId,
+                userId = evaluation.evaluatorUserId,
                 score = item.score
             )
             entity.updateEvaluation(item.score)
@@ -38,7 +38,7 @@ class InterviewEvaluationRepositoryImpl(
     }
 
     override fun findByApplicantIdAndEvaluatorUserId(applicantId: Long, evaluatorUserId: Long): InterviewEvaluation? {
-        val entities = jpaInterviewEvaluationRepository.findAllByApplicantIdAndMemberId(applicantId, evaluatorUserId)
+        val entities = jpaInterviewEvaluationRepository.findAllByApplicantIdAndUserId(applicantId, evaluatorUserId)
         if (entities.isEmpty()) {
             return null
         }
@@ -47,7 +47,7 @@ class InterviewEvaluationRepositoryImpl(
 
     override fun findAllByApplicantId(applicantId: Long): List<InterviewEvaluation> {
         val entities = jpaInterviewEvaluationRepository.findAllByApplicantId(applicantId)
-        return entities.groupBy { it.memberId }.map { (evaluatorUserId, userEntities) ->
+        return entities.groupBy { it.userId }.map { (evaluatorUserId, userEntities) ->
             toDomain(applicantId, evaluatorUserId, userEntities)
         }
     }
@@ -57,7 +57,7 @@ class InterviewEvaluationRepositoryImpl(
             return emptyList()
         }
         val entities = jpaInterviewEvaluationRepository.findAllByApplicantIdIn(applicantIds)
-        return entities.groupBy { it.applicantId to it.memberId }.map { (key, groupEntities) ->
+        return entities.groupBy { it.applicantId to it.userId }.map { (key, groupEntities) ->
             val (applicantId, evaluatorUserId) = key
             toDomain(applicantId, evaluatorUserId, groupEntities)
         }

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/storage/InterviewEvaluationRepositoryImpl.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/storage/InterviewEvaluationRepositoryImpl.kt
@@ -22,12 +22,9 @@ class InterviewEvaluationRepositoryImpl(
                 applicantId = evaluation.applicantId,
                 interviewEvaluationItem = jpaInterviewEvaluationItemRepository.getReferenceById(item.evaluationItemId),
                 memberId = evaluation.evaluatorUserId,
-                score = item.score,
-                result = evaluation.result,
-                overallComment = evaluation.overallComment,
-                submittedAt = evaluation.submittedAt
+                score = item.score
             )
-            entity.updateEvaluation(item.score, evaluation.result, evaluation.overallComment, evaluation.submittedAt)
+            entity.updateEvaluation(item.score)
             jpaInterviewEvaluationRepository.save(entity)
         }
 
@@ -89,10 +86,8 @@ class InterviewEvaluationRepositoryImpl(
                     evaluationItemId = entity.interviewEvaluationItem.id,
                     score = entity.score
                 )
-            },
-            overallComment = first.overallComment ?: "",
-            result = first.result,
-            submittedAt = first.submittedAt
+            }
         )
     }
 }
+

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/storage/InterviewEvaluationRepositoryImpl.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/storage/InterviewEvaluationRepositoryImpl.kt
@@ -1,0 +1,89 @@
+package com.yourssu.scouter.recruiting.evaluation.storage
+
+import com.yourssu.scouter.recruiting.evaluation.implement.InterviewEvaluation
+import com.yourssu.scouter.recruiting.evaluation.implement.InterviewEvaluationRepository
+import com.yourssu.scouter.recruiting.evaluation.implement.InterviewEvaluationScoreItem
+import org.springframework.stereotype.Repository
+
+@Repository
+class InterviewEvaluationRepositoryImpl(
+    private val jpaInterviewEvaluationRepository: JpaInterviewEvaluationRepository,
+    private val jpaInterviewEvaluationItemRepository: JpaInterviewEvaluationItemRepository,
+) : InterviewEvaluationRepository {
+
+    override fun save(evaluation: InterviewEvaluation): InterviewEvaluation {
+        val existingEntities = jpaInterviewEvaluationRepository.findAllByApplicantIdAndMemberId(
+            evaluation.applicantId,
+            evaluation.evaluatorUserId
+        ).associateBy { it.interviewEvaluationItem.id }
+
+        val savedEntities = evaluation.items.map { item ->
+            val entity = existingEntities[item.evaluationItemId] ?: InterviewEvaluationEntity(
+                applicantId = evaluation.applicantId,
+                interviewEvaluationItem = jpaInterviewEvaluationItemRepository.getReferenceById(item.evaluationItemId),
+                memberId = evaluation.evaluatorUserId,
+                score = item.score,
+                result = evaluation.result,
+                submittedAt = evaluation.submittedAt
+            )
+            entity.updateEvaluation(item.score, evaluation.result, evaluation.submittedAt)
+            jpaInterviewEvaluationRepository.save(entity)
+        }
+
+        // Delete any items that are no longer present in the updated list
+        val updatedItemIds = evaluation.items.map { it.evaluationItemId }.toSet()
+        existingEntities.values.filter { it.interviewEvaluationItem.id !in updatedItemIds }.forEach {
+            jpaInterviewEvaluationRepository.delete(it)
+        }
+
+        return toDomain(evaluation.applicantId, evaluation.evaluatorUserId, savedEntities)
+    }
+
+    override fun findByApplicantIdAndEvaluatorUserId(applicantId: Long, evaluatorUserId: Long): InterviewEvaluation? {
+        val entities = jpaInterviewEvaluationRepository.findAllByApplicantIdAndMemberId(applicantId, evaluatorUserId)
+        if (entities.isEmpty()) {
+            return null
+        }
+        return toDomain(applicantId, evaluatorUserId, entities)
+    }
+
+    override fun findAllByApplicantId(applicantId: Long): List<InterviewEvaluation> {
+        val entities = jpaInterviewEvaluationRepository.findAllByApplicantId(applicantId)
+        return entities.groupBy { it.memberId }.map { (evaluatorUserId, userEntities) ->
+            toDomain(applicantId, evaluatorUserId, userEntities)
+        }
+    }
+
+    override fun findAllByApplicantIdIn(applicantIds: List<Long>): List<InterviewEvaluation> {
+        if (applicantIds.isEmpty()) {
+            return emptyList()
+        }
+        val entities = jpaInterviewEvaluationRepository.findAllByApplicantIdIn(applicantIds)
+        return entities.groupBy { it.applicantId to it.memberId }.map { (key, groupEntities) ->
+            val (applicantId, evaluatorUserId) = key
+            toDomain(applicantId, evaluatorUserId, groupEntities)
+        }
+    }
+
+    private fun toDomain(
+        applicantId: Long,
+        evaluatorUserId: Long,
+        entities: List<InterviewEvaluationEntity>
+    ): InterviewEvaluation {
+        val first = entities.first()
+        return InterviewEvaluation(
+            id = first.id, // Using first entity's ID or similar reference
+            applicantId = applicantId,
+            evaluatorUserId = evaluatorUserId,
+            items = entities.map { entity ->
+                InterviewEvaluationScoreItem(
+                    id = entity.id,
+                    evaluationItemId = entity.interviewEvaluationItem.id,
+                    score = entity.score
+                )
+            },
+            result = first.result,
+            submittedAt = first.submittedAt
+        )
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/storage/InterviewEvaluationRepositoryImpl.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/storage/InterviewEvaluationRepositoryImpl.kt
@@ -63,6 +63,11 @@ class InterviewEvaluationRepositoryImpl(
             val (applicantId, evaluatorUserId) = key
             toDomain(applicantId, evaluatorUserId, groupEntities)
         }
+    override fun existsByInterviewEvaluationItemIdIn(itemIds: List<Long>): Boolean {
+        if (itemIds.isEmpty()) {
+            return false
+        }
+        return jpaInterviewEvaluationRepository.existsByInterviewEvaluationItemIdIn(itemIds)
     }
 
     private fun toDomain(

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/storage/InterviewEvaluationRepositoryImpl.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/storage/InterviewEvaluationRepositoryImpl.kt
@@ -24,9 +24,10 @@ class InterviewEvaluationRepositoryImpl(
                 memberId = evaluation.evaluatorUserId,
                 score = item.score,
                 result = evaluation.result,
+                overallComment = evaluation.overallComment,
                 submittedAt = evaluation.submittedAt
             )
-            entity.updateEvaluation(item.score, evaluation.result, evaluation.submittedAt)
+            entity.updateEvaluation(item.score, evaluation.result, evaluation.overallComment, evaluation.submittedAt)
             jpaInterviewEvaluationRepository.save(entity)
         }
 
@@ -89,6 +90,7 @@ class InterviewEvaluationRepositoryImpl(
                     score = entity.score
                 )
             },
+            overallComment = first.overallComment ?: "",
             result = first.result,
             submittedAt = first.submittedAt
         )

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/storage/InterviewEvaluationRepositoryImpl.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/storage/InterviewEvaluationRepositoryImpl.kt
@@ -63,6 +63,8 @@ class InterviewEvaluationRepositoryImpl(
             val (applicantId, evaluatorUserId) = key
             toDomain(applicantId, evaluatorUserId, groupEntities)
         }
+    }
+
     override fun existsByInterviewEvaluationItemIdIn(itemIds: List<Long>): Boolean {
         if (itemIds.isEmpty()) {
             return false

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/storage/JpaFinalEvaluationRepository.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/storage/JpaFinalEvaluationRepository.kt
@@ -1,0 +1,9 @@
+package com.yourssu.scouter.recruiting.evaluation.storage
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface JpaFinalEvaluationRepository : JpaRepository<FinalEvaluationEntity, Long> {
+    fun findByApplicantIdAndMemberId(applicantId: Long, memberId: Long): FinalEvaluationEntity?
+    fun findAllByApplicantId(applicantId: Long): List<FinalEvaluationEntity>
+    fun findAllByApplicantIdIn(applicantIds: List<Long>): List<FinalEvaluationEntity>
+}

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/storage/JpaFinalEvaluationRepository.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/storage/JpaFinalEvaluationRepository.kt
@@ -3,7 +3,7 @@ package com.yourssu.scouter.recruiting.evaluation.storage
 import org.springframework.data.jpa.repository.JpaRepository
 
 interface JpaFinalEvaluationRepository : JpaRepository<FinalEvaluationEntity, Long> {
-    fun findByApplicantIdAndMemberId(applicantId: Long, memberId: Long): FinalEvaluationEntity?
+    fun findByApplicantIdAndUserId(applicantId: Long, userId: Long): FinalEvaluationEntity?
     fun findAllByApplicantId(applicantId: Long): List<FinalEvaluationEntity>
     fun findAllByApplicantIdIn(applicantIds: List<Long>): List<FinalEvaluationEntity>
 }

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/storage/JpaInterviewEvaluationItemRepository.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/storage/JpaInterviewEvaluationItemRepository.kt
@@ -1,0 +1,5 @@
+package com.yourssu.scouter.recruiting.evaluation.storage
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface JpaInterviewEvaluationItemRepository : JpaRepository<InterviewEvaluationItemEntity, Long>

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/storage/JpaInterviewEvaluationRepository.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/storage/JpaInterviewEvaluationRepository.kt
@@ -1,0 +1,10 @@
+package com.yourssu.scouter.recruiting.evaluation.storage
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface JpaInterviewEvaluationRepository : JpaRepository<InterviewEvaluationEntity, Long> {
+    fun findAllByApplicantIdAndMemberId(applicantId: Long, memberId: Long): List<InterviewEvaluationEntity>
+    fun findAllByApplicantId(applicantId: Long): List<InterviewEvaluationEntity>
+    fun findAllByApplicantIdIn(applicantIds: List<Long>): List<InterviewEvaluationEntity>
+    fun deleteAllByApplicantIdAndMemberId(applicantId: Long, memberId: Long)
+}

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/storage/JpaInterviewEvaluationRepository.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/storage/JpaInterviewEvaluationRepository.kt
@@ -3,7 +3,7 @@ package com.yourssu.scouter.recruiting.evaluation.storage
 import org.springframework.data.jpa.repository.JpaRepository
 
 interface JpaInterviewEvaluationRepository : JpaRepository<InterviewEvaluationEntity, Long> {
-    fun findAllByApplicantIdAndMemberId(applicantId: Long, memberId: Long): List<InterviewEvaluationEntity>
+    fun findAllByApplicantIdAndUserId(applicantId: Long, userId: Long): List<InterviewEvaluationEntity>
     fun findAllByApplicantId(applicantId: Long): List<InterviewEvaluationEntity>
     fun findAllByApplicantIdIn(applicantIds: List<Long>): List<InterviewEvaluationEntity>
     fun existsByInterviewEvaluationItemIdIn(itemIds: List<Long>): Boolean

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/storage/JpaInterviewEvaluationRepository.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/storage/JpaInterviewEvaluationRepository.kt
@@ -6,5 +6,5 @@ interface JpaInterviewEvaluationRepository : JpaRepository<InterviewEvaluationEn
     fun findAllByApplicantIdAndMemberId(applicantId: Long, memberId: Long): List<InterviewEvaluationEntity>
     fun findAllByApplicantId(applicantId: Long): List<InterviewEvaluationEntity>
     fun findAllByApplicantIdIn(applicantIds: List<Long>): List<InterviewEvaluationEntity>
-    fun deleteAllByApplicantIdAndMemberId(applicantId: Long, memberId: Long)
+    fun existsByInterviewEvaluationItemIdIn(itemIds: List<Long>): Boolean
 }

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/rubric/application/InterviewRubricController.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/rubric/application/InterviewRubricController.kt
@@ -43,7 +43,7 @@ class InterviewRubricController(
     )
 
     @Operation(
-        summary = "학기별 면접 평가 루브릭 등록 또는 수정",
+        summary = "학기별 면접 평가 루브릭 등록 또는 수정(어드민)",
         description = "해당 파트·학기에 루브릭이 없으면 생성하고, 있으면 항목 전체를 교체합니다. 잠긴 루브릭은 수정할 수 없으며 모든 항목의 maxScore 합계는 100이어야 합니다.",
         requestBody = io.swagger.v3.oas.annotations.parameters.RequestBody(
             required = true,
@@ -52,7 +52,6 @@ class InterviewRubricController(
                 schema = Schema(implementation = InterviewRubricUpdateRequest::class),
                 examples = [ExampleObject(value = """{
   "deadline": "2026-08-01T09:00:00Z",
-  "interviewerCount": 2,
   "groups": [
     {
       "group": "CULTURE_FIT",

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/rubric/application/InterviewRubricController.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/rubric/application/InterviewRubricController.kt
@@ -53,9 +53,25 @@ class InterviewRubricController(
                 examples = [ExampleObject(value = """{
   "deadline": "2026-08-01T09:00:00Z",
   "interviewerCount": 2,
-  "items": [
-    { "keyword": "직무 역량", "group": "JOB", "maxScore": 60 },
-    { "keyword": "협업 역량", "group": "TEAM", "maxScore": 40 }
+  "groups": [
+    {
+      "group": "CULTURE_FIT",
+      "items": [
+        { "title": "주도성, 실행력", "maxScore": 10 }
+      ]
+    },
+    {
+      "group": "TEAM_FIT",
+      "items": [
+        { "title": "팀 목표 이해", "maxScore": 10 }
+      ]
+    },
+    {
+      "group": "JOB_FIT",
+      "items": [
+        { "title": "파트 핵심 역량", "maxScore": 80 }
+      ]
+    }
   ]
 }""")],
             )],
@@ -69,7 +85,7 @@ class InterviewRubricController(
     @PutMapping("/parts/{partId}/interviews/rubrics/{semester}")
     fun upsert(
         @Parameter(description = "파트 ID", example = "3") @PathVariable partId: Long,
-        @Parameter(description = "학기 식별자. YYYY-1 또는 YYYY-2 형식", example = "2026-1") @PathVariable @Pattern(regexp = "^\\d{4}-[12]$", message = "semester must use YYYY-1 or YYYY-2 format") semester: String,
+        @Parameter(description = "학기 식별자. YYYY-1 또는 YYYY-2 형식", example = "2026-2") @PathVariable @Pattern(regexp = "^\\d{4}-[12]$", message = "semester must use YYYY-1 or YYYY-2 format") semester: String,
         @RequestBody @Valid request: InterviewRubricUpdateRequest,
     ): ResponseEntity<InterviewRubricResponse> = ResponseEntity.ok(
         InterviewRubricResponse.from(interviewRubricService.upsert(request.toCommand(partId, semester))),

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/rubric/application/InterviewRubricController.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/rubric/application/InterviewRubricController.kt
@@ -1,0 +1,77 @@
+package com.yourssu.scouter.recruiting.rubric.application
+
+import com.yourssu.scouter.recruiting.rubric.application.dto.InterviewRubricResponse
+import com.yourssu.scouter.recruiting.rubric.application.dto.InterviewRubricUpdateRequest
+import com.yourssu.scouter.recruiting.rubric.business.InterviewRubricService
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.ExampleObject
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.validation.Valid
+import jakarta.validation.constraints.Pattern
+import org.springframework.http.ResponseEntity
+import org.springframework.validation.annotation.Validated
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RestController
+
+@Tag(name = "면접 평가 루브릭", description = "파트와 학기별 면접 평가 루브릭 관리 API")
+@RestController
+@Validated
+class InterviewRubricController(
+    private val interviewRubricService: InterviewRubricService,
+) {
+
+    @Operation(summary = "학기별 면접 평가 루브릭 조회", description = "파트와 학기에 해당하는 면접 평가 루브릭을 조회합니다.")
+    @ApiResponses(value = [
+        ApiResponse(responseCode = "200", description = "조회 성공", content = [Content(schema = Schema(implementation = InterviewRubricResponse::class))]),
+        ApiResponse(responseCode = "400", description = "루브릭이 없거나 요청 값이 올바르지 않음"),
+        ApiResponse(responseCode = "404", description = "파트를 찾을 수 없음"),
+    ])
+    @GetMapping("/parts/{partId}/interviews/rubrics/{semester}")
+    fun readByPartIdAndSemester(
+        @Parameter(description = "파트 ID", example = "3") @PathVariable partId: Long,
+        @Parameter(description = "학기 식별자. YYYY-1 또는 YYYY-2 형식", example = "2026-1") @PathVariable @Pattern(regexp = "^\\d{4}-[12]$", message = "semester must use YYYY-1 or YYYY-2 format") semester: String,
+    ): ResponseEntity<InterviewRubricResponse> = ResponseEntity.ok(
+        InterviewRubricResponse.from(interviewRubricService.readByPartIdAndSemester(partId, semester)),
+    )
+
+    @Operation(
+        summary = "학기별 면접 평가 루브릭 등록 또는 수정",
+        description = "해당 파트·학기에 루브릭이 없으면 생성하고, 있으면 항목 전체를 교체합니다. 잠긴 루브릭은 수정할 수 없으며 모든 항목의 maxScore 합계는 100이어야 합니다.",
+        requestBody = io.swagger.v3.oas.annotations.parameters.RequestBody(
+            required = true,
+            description = "학기는 URL 경로에서 지정합니다.",
+            content = [Content(
+                schema = Schema(implementation = InterviewRubricUpdateRequest::class),
+                examples = [ExampleObject(value = """{
+  "deadline": "2026-08-01T09:00:00Z",
+  "interviewerCount": 2,
+  "items": [
+    { "keyword": "직무 역량", "group": "JOB", "maxScore": 60 },
+    { "keyword": "협업 역량", "group": "TEAM", "maxScore": 40 }
+  ]
+}""")],
+            )],
+        ),
+    )
+    @ApiResponses(value = [
+        ApiResponse(responseCode = "200", description = "생성 또는 수정 성공", content = [Content(schema = Schema(implementation = InterviewRubricResponse::class))]),
+        ApiResponse(responseCode = "400", description = "요청 형식이 올바르지 않거나 배점 합계가 100이 아님"),
+        ApiResponse(responseCode = "404", description = "파트를 찾을 수 없음"),
+    ])
+    @PutMapping("/parts/{partId}/interviews/rubrics/{semester}")
+    fun upsert(
+        @Parameter(description = "파트 ID", example = "3") @PathVariable partId: Long,
+        @Parameter(description = "학기 식별자. YYYY-1 또는 YYYY-2 형식", example = "2026-1") @PathVariable @Pattern(regexp = "^\\d{4}-[12]$", message = "semester must use YYYY-1 or YYYY-2 format") semester: String,
+        @RequestBody @Valid request: InterviewRubricUpdateRequest,
+    ): ResponseEntity<InterviewRubricResponse> = ResponseEntity.ok(
+        InterviewRubricResponse.from(interviewRubricService.upsert(request.toCommand(partId, semester))),
+    )
+}

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/rubric/application/dto/InterviewRubricResponse.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/rubric/application/dto/InterviewRubricResponse.kt
@@ -19,23 +19,51 @@ data class InterviewRubricResponse(
     val isLocked: Boolean,
     @field:Schema(description = "지원자 한 명을 평가할 면접관 수", example = "2")
     val interviewerCount: Int,
-    @field:Schema(description = "평가 항목 목록")
-    val items: List<ItemResponse>
+    @field:Schema(description = "평가 항목 그룹 목록")
+    val groups: List<GroupResponse>
 ) {
+    @Schema(description = "면접 루브릭 평가 항목 그룹 응답")
+    data class GroupResponse(
+        @field:Schema(description = "평가 그룹", example = "CULTURE_FIT", allowableValues = ["JOB_FIT", "CULTURE_FIT", "TEAM_FIT"])
+        val group: String,
+        @field:Schema(description = "그룹 합계 배점", example = "30")
+        val groupMaxScore: Int,
+        @field:Schema(description = "평가 항목 목록")
+        val items: List<ItemResponse>
+    )
+
     @Schema(description = "면접 루브릭 평가 항목 응답")
     data class ItemResponse(
-        @field:Schema(description = "평가 항목 ID", example = "10")
-        val id: Long,
-        @field:Schema(description = "평가 항목명", example = "직무 역량")
-        val keyword: String,
-        @field:Schema(description = "평가 그룹", example = "JOB", allowableValues = ["JOB", "CULTURE", "TEAM"])
-        val group: RubricGroupType,
-        @field:Schema(description = "항목 최대 배점", example = "60")
+        @field:Schema(description = "평가 항목 ID", example = "1")
+        val itemId: Long,
+        @field:Schema(description = "평가 항목명", example = "주도성, 실행력")
+        val title: String,
+        @field:Schema(description = "항목 최대 배점", example = "10")
         val maxScore: Int
     )
 
     companion object {
         fun from(result: InterviewRubricResult): InterviewRubricResponse {
+            val itemsByGroup = result.items.groupBy { it.rubricType }
+            val groups = listOf(RubricGroupType.CULTURE, RubricGroupType.TEAM, RubricGroupType.JOB).map { groupType ->
+                val items = itemsByGroup[groupType] ?: emptyList()
+                GroupResponse(
+                    group = when(groupType) {
+                        RubricGroupType.CULTURE -> "CULTURE_FIT"
+                        RubricGroupType.TEAM -> "TEAM_FIT"
+                        RubricGroupType.JOB -> "JOB_FIT"
+                    },
+                    groupMaxScore = items.sumOf { it.maxScore },
+                    items = items.map {
+                        ItemResponse(
+                            itemId = it.id ?: 0L,
+                            title = it.keyword,
+                            maxScore = it.maxScore
+                        )
+                    }
+                )
+            }
+
             return InterviewRubricResponse(
                 id = result.id,
                 partId = result.partId,
@@ -43,14 +71,7 @@ data class InterviewRubricResponse(
                 deadline = result.deadline,
                 isLocked = result.isLocked,
                 interviewerCount = result.interviewerCount,
-                items = result.items.map {
-                    ItemResponse(
-                        id = it.id,
-                        keyword = it.keyword,
-                        group = it.rubricType,
-                        maxScore = it.maxScore
-                    )
-                }
+                groups = groups
             )
         }
     }

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/rubric/application/dto/InterviewRubricResponse.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/rubric/application/dto/InterviewRubricResponse.kt
@@ -17,8 +17,6 @@ data class InterviewRubricResponse(
     val deadline: Instant,
     @field:Schema(description = "잠금 여부. true이면 수정 불가", example = "false")
     val isLocked: Boolean,
-    @field:Schema(description = "지원자 한 명을 평가할 면접관 수", example = "2")
-    val interviewerCount: Int,
     @field:Schema(description = "평가 항목 그룹 목록")
     val groups: List<GroupResponse>
 ) {
@@ -70,7 +68,6 @@ data class InterviewRubricResponse(
                 semester = result.semester,
                 deadline = result.deadline,
                 isLocked = result.isLocked,
-                interviewerCount = result.interviewerCount,
                 groups = groups
             )
         }

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/rubric/application/dto/InterviewRubricResponse.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/rubric/application/dto/InterviewRubricResponse.kt
@@ -1,0 +1,57 @@
+package com.yourssu.scouter.recruiting.rubric.application.dto
+
+import com.yourssu.scouter.recruiting.rubric.business.dto.InterviewRubricResult
+import com.yourssu.scouter.recruiting.rubric.implement.RubricGroupType
+import java.time.Instant
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "면접 루브릭 조회 또는 저장 응답")
+data class InterviewRubricResponse(
+    @field:Schema(description = "루브릭 ID", example = "1")
+    val id: Long,
+    @field:Schema(description = "파트 ID", example = "3")
+    val partId: Long,
+    @field:Schema(description = "학기 식별자", example = "2026-1")
+    val semester: String,
+    @field:Schema(description = "루브릭 수정 마감 시각(UTC ISO-8601)", example = "2026-08-01T09:00:00Z", type = "string", format = "date-time")
+    val deadline: Instant,
+    @field:Schema(description = "잠금 여부. true이면 수정 불가", example = "false")
+    val isLocked: Boolean,
+    @field:Schema(description = "지원자 한 명을 평가할 면접관 수", example = "2")
+    val interviewerCount: Int,
+    @field:Schema(description = "평가 항목 목록")
+    val items: List<ItemResponse>
+) {
+    @Schema(description = "면접 루브릭 평가 항목 응답")
+    data class ItemResponse(
+        @field:Schema(description = "평가 항목 ID", example = "10")
+        val id: Long,
+        @field:Schema(description = "평가 항목명", example = "직무 역량")
+        val keyword: String,
+        @field:Schema(description = "평가 그룹", example = "JOB", allowableValues = ["JOB", "CULTURE", "TEAM"])
+        val group: RubricGroupType,
+        @field:Schema(description = "항목 최대 배점", example = "60")
+        val maxScore: Int
+    )
+
+    companion object {
+        fun from(result: InterviewRubricResult): InterviewRubricResponse {
+            return InterviewRubricResponse(
+                id = result.id,
+                partId = result.partId,
+                semester = result.semester,
+                deadline = result.deadline,
+                isLocked = result.isLocked,
+                interviewerCount = result.interviewerCount,
+                items = result.items.map {
+                    ItemResponse(
+                        id = it.id,
+                        keyword = it.keyword,
+                        group = it.rubricType,
+                        maxScore = it.maxScore
+                    )
+                }
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/rubric/application/dto/InterviewRubricUpdateRequest.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/rubric/application/dto/InterviewRubricUpdateRequest.kt
@@ -16,10 +16,6 @@ data class InterviewRubricUpdateRequest(
     @field:Schema(description = "루브릭 수정 마감 시각(UTC ISO-8601)", example = "2026-08-01T09:00:00Z", type = "string", format = "date-time")
     val deadline: Instant,
 
-    @field:Min(1)
-    @field:Schema(description = "지원자 한 명을 평가할 면접관 수. 1 이상", example = "2")
-    val interviewerCount: Int,
-
     @field:NotEmpty
     @field:Valid
     @field:Schema(description = "평가 항목 그룹 목록")
@@ -72,7 +68,6 @@ data class InterviewRubricUpdateRequest(
             partId = partId,
             semester = semester,
             deadline = deadline,
-            interviewerCount = interviewerCount,
             items = commandItems
         )
     }

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/rubric/application/dto/InterviewRubricUpdateRequest.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/rubric/application/dto/InterviewRubricUpdateRequest.kt
@@ -10,7 +10,6 @@ import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.NotEmpty
 import jakarta.validation.constraints.NotNull
 
-
 @Schema(description = "면접 루브릭 등록 또는 수정 요청")
 data class InterviewRubricUpdateRequest(
     @field:NotNull
@@ -23,41 +22,58 @@ data class InterviewRubricUpdateRequest(
 
     @field:NotEmpty
     @field:Valid
-    @field:Schema(description = "평가 항목 목록. 항목의 maxScore 합계는 반드시 100")
-    val items: List<ItemRequest>
+    @field:Schema(description = "평가 항목 그룹 목록")
+    val groups: List<GroupRequest>
 ) {
-    @Schema(description = "면접 루브릭 평가 항목")
+    @Schema(description = "면접 루브릭 평가 항목 그룹 요청")
+    data class GroupRequest(
+        @field:NotBlank
+        @field:Schema(description = "평가 그룹", example = "CULTURE_FIT", allowableValues = ["JOB_FIT", "CULTURE_FIT", "TEAM_FIT"])
+        val group: String,
+
+        @field:NotEmpty
+        @field:Valid
+        @field:Schema(description = "평가 항목 목록")
+        val items: List<ItemRequest>
+    )
+
+    @Schema(description = "면접 루브릭 평가 항목 요청")
     data class ItemRequest(
         @field:Schema(description = "기존 항목 수정 시 해당 항목 ID. 새 항목이면 생략", example = "10", nullable = true)
-        val id: Long? = null,
+        val itemId: Long? = null,
 
         @field:NotBlank
-        @field:Schema(description = "평가 항목명", example = "직무 역량")
-        val keyword: String,
-
-        @field:NotNull
-        @field:Schema(description = "평가 그룹", example = "JOB", allowableValues = ["JOB", "CULTURE", "TEAM"])
-        val group: RubricGroupType,
+        @field:Schema(description = "평가 항목명", example = "주도성, 실행력")
+        val title: String,
 
         @field:Min(0)
-        @field:Schema(description = "항목의 최대 배점. 0 이상이며 전체 항목의 합계는 100", example = "60")
+        @field:Schema(description = "항목의 최대 배점. 0 이상", example = "10")
         val maxScore: Int
     )
 
     fun toCommand(partId: Long, semester: String): UpdateInterviewRubricCommand {
+        val commandItems = groups.flatMap { groupReq ->
+            val rubricType = when(groupReq.group) {
+                "CULTURE_FIT" -> RubricGroupType.CULTURE
+                "TEAM_FIT" -> RubricGroupType.TEAM
+                "JOB_FIT" -> RubricGroupType.JOB
+                else -> throw IllegalArgumentException("유효하지 않은 평가 그룹입니다: ${groupReq.group}")
+            }
+            groupReq.items.map { itemReq ->
+                UpdateInterviewRubricCommand.ItemCommand(
+                    id = itemReq.itemId,
+                    keyword = itemReq.title,
+                    rubricType = rubricType,
+                    maxScore = itemReq.maxScore
+                )
+            }
+        }
         return UpdateInterviewRubricCommand(
             partId = partId,
             semester = semester,
             deadline = deadline,
             interviewerCount = interviewerCount,
-            items = items.map {
-                UpdateInterviewRubricCommand.ItemCommand(
-                    id = it.id,
-                    keyword = it.keyword,
-                    rubricType = it.group,
-                    maxScore = it.maxScore
-                )
-            }
+            items = commandItems
         )
     }
 }

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/rubric/application/dto/InterviewRubricUpdateRequest.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/rubric/application/dto/InterviewRubricUpdateRequest.kt
@@ -1,0 +1,63 @@
+package com.yourssu.scouter.recruiting.rubric.application.dto
+
+import com.yourssu.scouter.recruiting.rubric.business.dto.UpdateInterviewRubricCommand
+import com.yourssu.scouter.recruiting.rubric.implement.RubricGroupType
+import java.time.Instant
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.Valid
+import jakarta.validation.constraints.Min
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotEmpty
+import jakarta.validation.constraints.NotNull
+
+
+@Schema(description = "면접 루브릭 등록 또는 수정 요청")
+data class InterviewRubricUpdateRequest(
+    @field:NotNull
+    @field:Schema(description = "루브릭 수정 마감 시각(UTC ISO-8601)", example = "2026-08-01T09:00:00Z", type = "string", format = "date-time")
+    val deadline: Instant,
+
+    @field:Min(1)
+    @field:Schema(description = "지원자 한 명을 평가할 면접관 수. 1 이상", example = "2")
+    val interviewerCount: Int,
+
+    @field:NotEmpty
+    @field:Valid
+    @field:Schema(description = "평가 항목 목록. 항목의 maxScore 합계는 반드시 100")
+    val items: List<ItemRequest>
+) {
+    @Schema(description = "면접 루브릭 평가 항목")
+    data class ItemRequest(
+        @field:Schema(description = "기존 항목 수정 시 해당 항목 ID. 새 항목이면 생략", example = "10", nullable = true)
+        val id: Long? = null,
+
+        @field:NotBlank
+        @field:Schema(description = "평가 항목명", example = "직무 역량")
+        val keyword: String,
+
+        @field:NotNull
+        @field:Schema(description = "평가 그룹", example = "JOB", allowableValues = ["JOB", "CULTURE", "TEAM"])
+        val group: RubricGroupType,
+
+        @field:Min(0)
+        @field:Schema(description = "항목의 최대 배점. 0 이상이며 전체 항목의 합계는 100", example = "60")
+        val maxScore: Int
+    )
+
+    fun toCommand(partId: Long, semester: String): UpdateInterviewRubricCommand {
+        return UpdateInterviewRubricCommand(
+            partId = partId,
+            semester = semester,
+            deadline = deadline,
+            interviewerCount = interviewerCount,
+            items = items.map {
+                UpdateInterviewRubricCommand.ItemCommand(
+                    id = it.id,
+                    keyword = it.keyword,
+                    rubricType = it.group,
+                    maxScore = it.maxScore
+                )
+            }
+        )
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/rubric/business/InterviewRubricService.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/rubric/business/InterviewRubricService.kt
@@ -1,0 +1,41 @@
+package com.yourssu.scouter.recruiting.rubric.business
+
+import com.yourssu.scouter.common.part.implement.PartReader
+import com.yourssu.scouter.recruiting.rubric.business.dto.InterviewRubricResult
+import com.yourssu.scouter.recruiting.rubric.business.dto.UpdateInterviewRubricCommand
+import com.yourssu.scouter.recruiting.rubric.implement.InterviewRubricReader
+import com.yourssu.scouter.recruiting.rubric.implement.InterviewRubricWriter
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class InterviewRubricService(
+    private val interviewRubricReader: InterviewRubricReader,
+    private val interviewRubricWriter: InterviewRubricWriter,
+    private val partReader: PartReader,
+) {
+
+    @Transactional(readOnly = true)
+    fun readByPartIdAndSemester(partId: Long, semester: String): InterviewRubricResult {
+        partReader.readById(partId)
+
+        return InterviewRubricResult.from(interviewRubricReader.getByPartIdAndSemester(partId, semester))
+    }
+
+    @Transactional
+    fun upsert(command: UpdateInterviewRubricCommand): InterviewRubricResult {
+        partReader.readById(command.partId)
+
+        val existing = interviewRubricReader.findByPartIdAndSemester(command.partId, command.semester)
+        existing?.validateEditable()
+
+        val saved = interviewRubricWriter.save(
+            command.toDomain(
+                existingId = existing?.id,
+                isLocked = existing?.isLocked ?: false,
+            ),
+        )
+
+        return InterviewRubricResult.from(saved)
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/rubric/business/InterviewRubricService.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/rubric/business/InterviewRubricService.kt
@@ -1,6 +1,7 @@
 package com.yourssu.scouter.recruiting.rubric.business
 
 import com.yourssu.scouter.common.part.implement.PartReader
+import com.yourssu.scouter.common.semester.implement.Semester
 import com.yourssu.scouter.recruiting.evaluation.implement.InterviewEvaluationReader
 import com.yourssu.scouter.recruiting.rubric.business.dto.InterviewRubricResult
 import com.yourssu.scouter.recruiting.rubric.business.dto.UpdateInterviewRubricCommand
@@ -22,14 +23,14 @@ class InterviewRubricService(
     fun readByPartIdAndSemester(partId: Long, semester: String): InterviewRubricResult {
         partReader.readById(partId)
 
-        return InterviewRubricResult.from(interviewRubricReader.getByPartIdAndSemester(partId, semester))
+        return InterviewRubricResult.from(interviewRubricReader.getByPartIdAndSemester(partId, Semester.of(semester)))
     }
 
     @Transactional
     fun upsert(command: UpdateInterviewRubricCommand): InterviewRubricResult {
         partReader.readById(command.partId)
 
-        val existing = interviewRubricReader.findByPartIdAndSemester(command.partId, command.semester)
+        val existing = interviewRubricReader.findByPartIdAndSemester(command.partId, Semester.of(command.semester))
         existing?.validateEditable()
 
         if (existing != null && existing.items.isNotEmpty()) {

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/rubric/business/InterviewRubricService.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/rubric/business/InterviewRubricService.kt
@@ -1,10 +1,12 @@
 package com.yourssu.scouter.recruiting.rubric.business
 
 import com.yourssu.scouter.common.part.implement.PartReader
+import com.yourssu.scouter.recruiting.evaluation.implement.InterviewEvaluationReader
 import com.yourssu.scouter.recruiting.rubric.business.dto.InterviewRubricResult
 import com.yourssu.scouter.recruiting.rubric.business.dto.UpdateInterviewRubricCommand
 import com.yourssu.scouter.recruiting.rubric.implement.InterviewRubricReader
 import com.yourssu.scouter.recruiting.rubric.implement.InterviewRubricWriter
+import com.yourssu.scouter.recruiting.support.implement.exception.RubricLockedException
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -12,6 +14,7 @@ import org.springframework.transaction.annotation.Transactional
 class InterviewRubricService(
     private val interviewRubricReader: InterviewRubricReader,
     private val interviewRubricWriter: InterviewRubricWriter,
+    private val interviewEvaluationReader: InterviewEvaluationReader,
     private val partReader: PartReader,
 ) {
 
@@ -28,6 +31,13 @@ class InterviewRubricService(
 
         val existing = interviewRubricReader.findByPartIdAndSemester(command.partId, command.semester)
         existing?.validateEditable()
+
+        if (existing != null && existing.items.isNotEmpty()) {
+            val itemIds = existing.items.mapNotNull { it.id }
+            if (interviewEvaluationReader.existsByInterviewEvaluationItemIdIn(itemIds)) {
+                throw RubricLockedException("해당 파트에 면접 평가(임시저장 포함)가 존재해 수정 불가")
+            }
+        }
 
         val saved = interviewRubricWriter.save(
             command.toDomain(

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/rubric/business/dto/InterviewRubricCommand.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/rubric/business/dto/InterviewRubricCommand.kt
@@ -1,5 +1,6 @@
 package com.yourssu.scouter.recruiting.rubric.business.dto
 
+import com.yourssu.scouter.common.semester.implement.Semester
 import com.yourssu.scouter.recruiting.evaluation.implement.InterviewEvaluationItem
 import com.yourssu.scouter.recruiting.rubric.implement.InterviewRubric
 import com.yourssu.scouter.recruiting.rubric.implement.RubricGroupType
@@ -22,7 +23,7 @@ data class UpdateInterviewRubricCommand(
         return InterviewRubric(
             id = existingId,
             partId = partId,
-            semester = semester,
+            semester = Semester.of(semester),
             deadline = deadline,
             isLocked = isLocked,
             items = items.map {

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/rubric/business/dto/InterviewRubricCommand.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/rubric/business/dto/InterviewRubricCommand.kt
@@ -9,7 +9,6 @@ data class UpdateInterviewRubricCommand(
     val partId: Long,
     val semester: String,
     val deadline: Instant,
-    val interviewerCount: Int,
     val items: List<ItemCommand>
 ) {
     data class ItemCommand(
@@ -26,7 +25,6 @@ data class UpdateInterviewRubricCommand(
             semester = semester,
             deadline = deadline,
             isLocked = isLocked,
-            interviewerCount = interviewerCount,
             items = items.map {
                 InterviewEvaluationItem(
                     id = it.id,

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/rubric/business/dto/InterviewRubricCommand.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/rubric/business/dto/InterviewRubricCommand.kt
@@ -1,0 +1,40 @@
+package com.yourssu.scouter.recruiting.rubric.business.dto
+
+import com.yourssu.scouter.recruiting.evaluation.implement.InterviewEvaluationItem
+import com.yourssu.scouter.recruiting.rubric.implement.InterviewRubric
+import com.yourssu.scouter.recruiting.rubric.implement.RubricGroupType
+import java.time.Instant
+
+data class UpdateInterviewRubricCommand(
+    val partId: Long,
+    val semester: String,
+    val deadline: Instant,
+    val interviewerCount: Int,
+    val items: List<ItemCommand>
+) {
+    data class ItemCommand(
+        val id: Long? = null,
+        val keyword: String,
+        val rubricType: RubricGroupType,
+        val maxScore: Int
+    )
+
+    fun toDomain(existingId: Long?, isLocked: Boolean = false): InterviewRubric {
+        return InterviewRubric(
+            id = existingId,
+            partId = partId,
+            semester = semester,
+            deadline = deadline,
+            isLocked = isLocked,
+            interviewerCount = interviewerCount,
+            items = items.map {
+                InterviewEvaluationItem(
+                    id = it.id,
+                    keyword = it.keyword,
+                    rubricType = it.rubricType,
+                    maxScore = it.maxScore
+                )
+            }
+        )
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/rubric/business/dto/InterviewRubricResult.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/rubric/business/dto/InterviewRubricResult.kt
@@ -25,7 +25,7 @@ data class InterviewRubricResult(
             return InterviewRubricResult(
                 id = domain.id ?: 0L,
                 partId = domain.partId,
-                semester = domain.semester,
+                semester = "${domain.semester.year.value}-${domain.semester.term.intValue}",
                 deadline = domain.deadline,
                 isLocked = domain.isLocked,
                 items = domain.items.map {

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/rubric/business/dto/InterviewRubricResult.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/rubric/business/dto/InterviewRubricResult.kt
@@ -11,7 +11,6 @@ data class InterviewRubricResult(
     val semester: String,
     val deadline: Instant,
     val isLocked: Boolean,
-    val interviewerCount: Int,
     val items: List<ItemResult>
 ) {
     data class ItemResult(
@@ -29,7 +28,6 @@ data class InterviewRubricResult(
                 semester = domain.semester,
                 deadline = domain.deadline,
                 isLocked = domain.isLocked,
-                interviewerCount = domain.interviewerCount,
                 items = domain.items.map {
                     ItemResult(
                         id = it.id ?: 0L,

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/rubric/business/dto/InterviewRubricResult.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/rubric/business/dto/InterviewRubricResult.kt
@@ -1,0 +1,44 @@
+package com.yourssu.scouter.recruiting.rubric.business.dto
+
+
+import com.yourssu.scouter.recruiting.rubric.implement.InterviewRubric
+import com.yourssu.scouter.recruiting.rubric.implement.RubricGroupType
+import java.time.Instant
+
+data class InterviewRubricResult(
+    val id: Long,
+    val partId: Long,
+    val semester: String,
+    val deadline: Instant,
+    val isLocked: Boolean,
+    val interviewerCount: Int,
+    val items: List<ItemResult>
+) {
+    data class ItemResult(
+        val id: Long,
+        val keyword: String,
+        val rubricType: RubricGroupType,
+        val maxScore: Int
+    )
+
+    companion object {
+        fun from(domain: InterviewRubric): InterviewRubricResult {
+            return InterviewRubricResult(
+                id = domain.id ?: 0L,
+                partId = domain.partId,
+                semester = domain.semester,
+                deadline = domain.deadline,
+                isLocked = domain.isLocked,
+                interviewerCount = domain.interviewerCount,
+                items = domain.items.map {
+                    ItemResult(
+                        id = it.id ?: 0L,
+                        keyword = it.keyword,
+                        rubricType = it.rubricType,
+                        maxScore = it.maxScore
+                    )
+                }
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/rubric/implement/InterviewRubric.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/rubric/implement/InterviewRubric.kt
@@ -1,0 +1,60 @@
+package com.yourssu.scouter.recruiting.rubric.implement
+
+import com.yourssu.scouter.recruiting.evaluation.implement.InterviewEvaluationItem
+import java.time.Instant
+
+class InterviewRubric(
+    val id: Long? = null,
+    val partId: Long,
+    val semester: String,
+    val deadline: Instant,
+    val isLocked: Boolean = false,
+    val interviewerCount: Int,
+    val items: List<InterviewEvaluationItem>,
+) {
+
+    init {
+        // 배점 합계 100점 비즈니스 검증
+        val totalScore = items.sumOf { it.maxScore }
+        require(totalScore == 100) {
+            "면접 평가 항목의 총 배점은 100점이어야 합니다. (현재 합계: ${totalScore}점)"
+        }
+    }
+
+    fun validateEditable() {
+        check(!isLocked) { "이미 평가가 진행 중이거나 잠긴 루브릭은 수정할 수 없습니다." }
+    }
+
+
+    fun update(
+        semester: String,
+        deadline: Instant,
+        interviewerCount: Int,
+        items: List<InterviewEvaluationItem>
+    ): InterviewRubric {
+        validateEditable()
+
+        return InterviewRubric(
+            id = this.id,
+            partId = this.partId,
+            semester = semester,
+            deadline = deadline,
+            isLocked = this.isLocked,
+            interviewerCount = interviewerCount,
+            items = items
+        )
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as InterviewRubric
+
+        return id == other.id
+    }
+
+    override fun hashCode(): Int {
+        return id?.hashCode() ?: 0
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/rubric/implement/InterviewRubric.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/rubric/implement/InterviewRubric.kt
@@ -1,12 +1,13 @@
 package com.yourssu.scouter.recruiting.rubric.implement
 
+import com.yourssu.scouter.common.semester.implement.Semester
 import com.yourssu.scouter.recruiting.evaluation.implement.InterviewEvaluationItem
 import java.time.Instant
 
 class InterviewRubric(
     val id: Long? = null,
     val partId: Long,
-    val semester: String,
+    val semester: Semester,
     val deadline: Instant,
     val isLocked: Boolean = false,
     val items: List<InterviewEvaluationItem>,
@@ -26,7 +27,7 @@ class InterviewRubric(
 
 
     fun update(
-        semester: String,
+        semester: Semester,
         deadline: Instant,
         items: List<InterviewEvaluationItem>
     ): InterviewRubric {

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/rubric/implement/InterviewRubric.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/rubric/implement/InterviewRubric.kt
@@ -9,7 +9,6 @@ class InterviewRubric(
     val semester: String,
     val deadline: Instant,
     val isLocked: Boolean = false,
-    val interviewerCount: Int,
     val items: List<InterviewEvaluationItem>,
 ) {
 
@@ -29,7 +28,6 @@ class InterviewRubric(
     fun update(
         semester: String,
         deadline: Instant,
-        interviewerCount: Int,
         items: List<InterviewEvaluationItem>
     ): InterviewRubric {
         validateEditable()
@@ -40,7 +38,6 @@ class InterviewRubric(
             semester = semester,
             deadline = deadline,
             isLocked = this.isLocked,
-            interviewerCount = interviewerCount,
             items = items
         )
     }

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/rubric/implement/InterviewRubricMapper.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/rubric/implement/InterviewRubricMapper.kt
@@ -51,7 +51,7 @@ class InterviewRubricMapper {
                 rubricType = itemDomain.rubricType,
                 maxScore = itemDomain.maxScore
             )
-            entity.items.add(itemEntity)
+            entity.addItem(itemEntity)
         }
 
         return entity

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/rubric/implement/InterviewRubricMapper.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/rubric/implement/InterviewRubricMapper.kt
@@ -21,7 +21,6 @@ class InterviewRubricMapper {
             semester = entity.semester,
             deadline = entity.deadline.toInstant(ZoneOffset.UTC),
             isLocked = entity.isLocked,
-            interviewerCount = entity.interviewerCount,
             items = entity.items.map { itemEntity ->
                 InterviewEvaluationItem(
                     id = itemEntity.id,
@@ -39,8 +38,7 @@ class InterviewRubricMapper {
             semester = domain.semester,
             deadline = LocalDateTime.ofInstant(domain.deadline, ZoneOffset.UTC), // Instant -> LocalDateTime
             part = partEntity,
-            isLocked = domain.isLocked,
-            interviewerCount = domain.interviewerCount
+            isLocked = domain.isLocked
         )
 
         domain.items.forEach { itemDomain ->

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/rubric/implement/InterviewRubricMapper.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/rubric/implement/InterviewRubricMapper.kt
@@ -1,0 +1,59 @@
+package com.yourssu.scouter.recruiting.rubric.implement
+
+import com.yourssu.scouter.common.part.storage.PartEntity
+import com.yourssu.scouter.recruiting.evaluation.implement.InterviewEvaluationItem
+import com.yourssu.scouter.recruiting.evaluation.storage.InterviewEvaluationItemEntity
+import com.yourssu.scouter.recruiting.rubric.storage.InterviewRubricEntity
+import org.springframework.stereotype.Component
+import java.time.LocalDateTime
+import java.time.ZoneOffset
+import kotlin.collections.map
+
+@Component
+class InterviewRubricMapper {
+
+    fun toDomain(entity: InterviewRubricEntity): InterviewRubric {
+        val partId = entity.part.id
+            ?: throw IllegalStateException("Rubric에 연관된 PartEntity의 ID가 null일 수 없습니다. rubricId=${entity.id}")
+        return InterviewRubric(
+            id = entity.id,
+            partId = partId,
+            semester = entity.semester,
+            deadline = entity.deadline.toInstant(ZoneOffset.UTC),
+            isLocked = entity.isLocked,
+            interviewerCount = entity.interviewerCount,
+            items = entity.items.map { itemEntity ->
+                InterviewEvaluationItem(
+                    id = itemEntity.id,
+                    keyword = itemEntity.keyword,
+                    rubricType = itemEntity.rubricType,
+                    maxScore = itemEntity.maxScore
+                )
+            }
+        )
+    }
+
+    fun toEntity(domain: InterviewRubric, partEntity: PartEntity): InterviewRubricEntity {
+        val entity = InterviewRubricEntity(
+            id = domain.id ?: 0L,
+            semester = domain.semester,
+            deadline = LocalDateTime.ofInstant(domain.deadline, ZoneOffset.UTC), // Instant -> LocalDateTime
+            part = partEntity,
+            isLocked = domain.isLocked,
+            interviewerCount = domain.interviewerCount
+        )
+
+        domain.items.forEach { itemDomain ->
+            val itemEntity = InterviewEvaluationItemEntity(
+                id = itemDomain.id ?: 0L,
+                interviewRubric = entity,
+                keyword = itemDomain.keyword,
+                rubricType = itemDomain.rubricType,
+                maxScore = itemDomain.maxScore
+            )
+            entity.items.add(itemEntity)
+        }
+
+        return entity
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/rubric/implement/InterviewRubricMapper.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/rubric/implement/InterviewRubricMapper.kt
@@ -1,6 +1,7 @@
 package com.yourssu.scouter.recruiting.rubric.implement
 
 import com.yourssu.scouter.common.part.storage.PartEntity
+import com.yourssu.scouter.common.semester.storage.SemesterEntity
 import com.yourssu.scouter.recruiting.evaluation.implement.InterviewEvaluationItem
 import com.yourssu.scouter.recruiting.evaluation.storage.InterviewEvaluationItemEntity
 import com.yourssu.scouter.recruiting.rubric.storage.InterviewRubricEntity
@@ -18,7 +19,7 @@ class InterviewRubricMapper {
         return InterviewRubric(
             id = entity.id,
             partId = partId,
-            semester = entity.semester,
+            semester = entity.semester.toDomain(),
             deadline = entity.deadline.toInstant(ZoneOffset.UTC),
             isLocked = entity.isLocked,
             items = entity.items.map { itemEntity ->
@@ -35,7 +36,7 @@ class InterviewRubricMapper {
     fun toEntity(domain: InterviewRubric, partEntity: PartEntity): InterviewRubricEntity {
         val entity = InterviewRubricEntity(
             id = domain.id ?: 0L,
-            semester = domain.semester,
+            semester = SemesterEntity.from(domain.semester),
             deadline = LocalDateTime.ofInstant(domain.deadline, ZoneOffset.UTC), // Instant -> LocalDateTime
             part = partEntity,
             isLocked = domain.isLocked

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/rubric/implement/InterviewRubricReader.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/rubric/implement/InterviewRubricReader.kt
@@ -1,0 +1,6 @@
+package com.yourssu.scouter.recruiting.rubric.implement
+
+interface InterviewRubricReader {
+    fun getByPartIdAndSemester(partId: Long, semester: String): InterviewRubric
+    fun findByPartIdAndSemester(partId: Long, semester: String): InterviewRubric?
+}

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/rubric/implement/InterviewRubricReader.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/rubric/implement/InterviewRubricReader.kt
@@ -1,6 +1,8 @@
 package com.yourssu.scouter.recruiting.rubric.implement
 
+import com.yourssu.scouter.common.semester.implement.Semester
+
 interface InterviewRubricReader {
-    fun getByPartIdAndSemester(partId: Long, semester: String): InterviewRubric
-    fun findByPartIdAndSemester(partId: Long, semester: String): InterviewRubric?
+    fun getByPartIdAndSemester(partId: Long, semester: Semester): InterviewRubric
+    fun findByPartIdAndSemester(partId: Long, semester: Semester): InterviewRubric?
 }

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/rubric/implement/InterviewRubricWriter.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/rubric/implement/InterviewRubricWriter.kt
@@ -1,0 +1,5 @@
+package com.yourssu.scouter.recruiting.rubric.implement
+
+interface InterviewRubricWriter {
+    fun save(interviewRubric: InterviewRubric): InterviewRubric
+}

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/rubric/implement/RubricGroupType.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/rubric/implement/RubricGroupType.kt
@@ -1,0 +1,7 @@
+package com.yourssu.scouter.recruiting.rubric.implement
+
+enum class RubricGroupType {
+    JOB,
+    CULTURE,
+    TEAM
+}

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/rubric/storage/InterviewRubricEntity.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/rubric/storage/InterviewRubricEntity.kt
@@ -29,9 +29,6 @@ class InterviewRubricEntity(
     @Column(name = "is_locked", nullable = false)
     var isLocked: Boolean = false,
 
-    @Column(name = "interviewer_count", nullable = false)
-    var interviewerCount: Int,
-
     @OneToMany(mappedBy = "interviewRubric", cascade = [CascadeType.ALL], orphanRemoval = true)
     val items: MutableList<InterviewEvaluationItemEntity> = mutableListOf()
 ) {

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/rubric/storage/InterviewRubricEntity.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/rubric/storage/InterviewRubricEntity.kt
@@ -1,0 +1,46 @@
+package com.yourssu.scouter.recruiting.rubric.storage
+
+import com.yourssu.scouter.common.part.implement.Part
+import com.yourssu.scouter.common.part.storage.PartEntity
+import com.yourssu.scouter.recruiting.evaluation.storage.InterviewEvaluationItemEntity
+import jakarta.persistence.*
+import java.time.LocalDateTime
+
+@Entity
+@Table(
+    name = "interview_rubric",
+    uniqueConstraints = [UniqueConstraint(name = "uk_interview_rubric_part_semester", columnNames = ["part_id", "semester"])],
+)
+class InterviewRubricEntity(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0L,
+
+    @Column(nullable = false)
+    var semester: String,
+
+    @Column(nullable = false)
+    var deadline: LocalDateTime,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "part_id", nullable = false)
+    var part: PartEntity,
+
+    @Column(name = "is_locked", nullable = false)
+    var isLocked: Boolean = false,
+
+    @Column(name = "interviewer_count", nullable = false)
+    var interviewerCount: Int,
+
+    @OneToMany(mappedBy = "interviewRubric", cascade = [CascadeType.ALL], orphanRemoval = true)
+    val items: MutableList<InterviewEvaluationItemEntity> = mutableListOf()
+) {
+    fun lock() {
+        this.isLocked = true
+    }
+
+    fun addItem(item: InterviewEvaluationItemEntity) {
+        items.add(item)
+        item.interviewRubric = this
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/rubric/storage/InterviewRubricEntity.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/rubric/storage/InterviewRubricEntity.kt
@@ -2,6 +2,7 @@ package com.yourssu.scouter.recruiting.rubric.storage
 
 import com.yourssu.scouter.common.part.implement.Part
 import com.yourssu.scouter.common.part.storage.PartEntity
+import com.yourssu.scouter.common.semester.storage.SemesterEntity
 import com.yourssu.scouter.recruiting.evaluation.storage.InterviewEvaluationItemEntity
 import jakarta.persistence.*
 import java.time.LocalDateTime
@@ -9,15 +10,16 @@ import java.time.LocalDateTime
 @Entity
 @Table(
     name = "interview_rubric",
-    uniqueConstraints = [UniqueConstraint(name = "uk_interview_rubric_part_semester", columnNames = ["part_id", "semester"])],
+    uniqueConstraints = [UniqueConstraint(name = "uk_interview_rubric_part_semester", columnNames = ["part_id", "semester_id"])],
 )
 class InterviewRubricEntity(
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     val id: Long = 0L,
 
-    @Column(nullable = false)
-    var semester: String,
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "semester_id", nullable = false)
+    var semester: SemesterEntity,
 
     @Column(nullable = false)
     var deadline: LocalDateTime,

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/rubric/storage/InterviewRubricRepositoryImpl.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/rubric/storage/InterviewRubricRepositoryImpl.kt
@@ -1,0 +1,34 @@
+package com.yourssu.scouter.recruiting.rubric.storage
+
+import com.yourssu.scouter.common.part.storage.JpaPartRepository
+import com.yourssu.scouter.recruiting.rubric.implement.InterviewRubric
+import com.yourssu.scouter.recruiting.rubric.implement.InterviewRubricMapper
+import com.yourssu.scouter.recruiting.rubric.implement.InterviewRubricReader
+import com.yourssu.scouter.recruiting.rubric.implement.InterviewRubricWriter
+import org.springframework.stereotype.Repository
+@Repository
+class InterviewRubricRepositoryImpl(
+    private val jpaRepository: JpaInterviewRubricRepository,
+    private val jpaPartRepository: JpaPartRepository,
+    private val mapper: InterviewRubricMapper
+) : InterviewRubricReader, InterviewRubricWriter {
+
+    override fun getByPartIdAndSemester(partId: Long, semester: String): InterviewRubric {
+        val entity = jpaRepository.findByPartIdAndSemester(partId, semester)
+            ?: throw IllegalArgumentException("해당 파트의 면접 루브릭을 찾을 수 없습니다. partId=$partId")
+        return mapper.toDomain(entity)
+    }
+
+    override fun findByPartIdAndSemester(partId: Long, semester: String): InterviewRubric? {
+        return jpaRepository.findByPartIdAndSemester(partId, semester)?.let { mapper.toDomain(it) }
+    }
+
+    override fun save(interviewRubric: InterviewRubric): InterviewRubric {
+        val entity = mapper.toEntity(
+            domain = interviewRubric,
+            partEntity = jpaPartRepository.getReferenceById(interviewRubric.partId)
+        )
+        val savedEntity = jpaRepository.save(entity)
+        return mapper.toDomain(savedEntity)
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/rubric/storage/InterviewRubricRepositoryImpl.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/rubric/storage/InterviewRubricRepositoryImpl.kt
@@ -1,33 +1,46 @@
 package com.yourssu.scouter.recruiting.rubric.storage
 
 import com.yourssu.scouter.common.part.storage.JpaPartRepository
+import com.yourssu.scouter.common.semester.implement.Semester
+import com.yourssu.scouter.common.semester.storage.JpaSemesterRepository
+import com.yourssu.scouter.common.semester.storage.SemesterEntity
 import com.yourssu.scouter.recruiting.rubric.implement.InterviewRubric
 import com.yourssu.scouter.recruiting.rubric.implement.InterviewRubricMapper
 import com.yourssu.scouter.recruiting.rubric.implement.InterviewRubricReader
 import com.yourssu.scouter.recruiting.rubric.implement.InterviewRubricWriter
+import com.yourssu.scouter.common.support.implement.exception.SemesterNotFoundException
+import com.yourssu.scouter.recruiting.support.implement.exception.InterviewRubricNotFoundException
 import org.springframework.stereotype.Repository
+
 @Repository
 class InterviewRubricRepositoryImpl(
     private val jpaRepository: JpaInterviewRubricRepository,
     private val jpaPartRepository: JpaPartRepository,
+    private val jpaSemesterRepository: JpaSemesterRepository,
     private val mapper: InterviewRubricMapper
 ) : InterviewRubricReader, InterviewRubricWriter {
 
-    override fun getByPartIdAndSemester(partId: Long, semester: String): InterviewRubric {
-        val entity = jpaRepository.findByPartIdAndSemester(partId, semester)
-            ?: throw IllegalArgumentException("해당 파트의 면접 루브릭을 찾을 수 없습니다. partId=$partId")
+    override fun getByPartIdAndSemester(partId: Long, semester: Semester): InterviewRubric {
+        val semesterEntity = jpaSemesterRepository.findByYearAndTerm(semester.year, semester.term)
+            ?: throw SemesterNotFoundException("해당 학기 정보를 찾을 수 없습니다: ${semester.year}-${semester.term.intValue}")
+        val entity = jpaRepository.findByPartIdAndSemester(partId, semesterEntity)
+            ?: throw InterviewRubricNotFoundException("해당 파트의 면접 루브릭을 찾을 수 없습니다. partId=$partId")
         return mapper.toDomain(entity)
     }
 
-    override fun findByPartIdAndSemester(partId: Long, semester: String): InterviewRubric? {
-        return jpaRepository.findByPartIdAndSemester(partId, semester)?.let { mapper.toDomain(it) }
+    override fun findByPartIdAndSemester(partId: Long, semester: Semester): InterviewRubric? {
+        val semesterEntity = jpaSemesterRepository.findByYearAndTerm(semester.year, semester.term) ?: return null
+        return jpaRepository.findByPartIdAndSemester(partId, semesterEntity)?.let { mapper.toDomain(it) }
     }
 
     override fun save(interviewRubric: InterviewRubric): InterviewRubric {
+        val semesterEntity = jpaSemesterRepository.findByYearAndTerm(interviewRubric.semester.year, interviewRubric.semester.term)
+            ?: throw IllegalArgumentException("해당 학기 정보를 찾을 수 없습니다: ${interviewRubric.semester.year}-${interviewRubric.semester.term.intValue}")
         val entity = mapper.toEntity(
             domain = interviewRubric,
             partEntity = jpaPartRepository.getReferenceById(interviewRubric.partId)
         )
+        entity.semester = semesterEntity
         val savedEntity = jpaRepository.save(entity)
         return mapper.toDomain(savedEntity)
     }

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/rubric/storage/JpaInterviewRubricRepository.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/rubric/storage/JpaInterviewRubricRepository.kt
@@ -1,8 +1,9 @@
 package com.yourssu.scouter.recruiting.rubric.storage
 
+import com.yourssu.scouter.common.semester.storage.SemesterEntity
 import org.springframework.data.jpa.repository.JpaRepository
 
 interface JpaInterviewRubricRepository : JpaRepository<InterviewRubricEntity, Long> {
 
-    fun findByPartIdAndSemester(partId: Long, semester: String): InterviewRubricEntity?
+    fun findByPartIdAndSemester(partId: Long, semester: SemesterEntity): InterviewRubricEntity?
 }

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/rubric/storage/JpaInterviewRubricRepository.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/rubric/storage/JpaInterviewRubricRepository.kt
@@ -1,0 +1,8 @@
+package com.yourssu.scouter.recruiting.rubric.storage
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface JpaInterviewRubricRepository : JpaRepository<InterviewRubricEntity, Long> {
+
+    fun findByPartIdAndSemester(partId: Long, semester: String): InterviewRubricEntity?
+}

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/support/implement/exception/InterviewEvaluationAccessDeniedException.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/support/implement/exception/InterviewEvaluationAccessDeniedException.kt
@@ -1,0 +1,8 @@
+package com.yourssu.scouter.recruiting.support.implement.exception
+
+import com.yourssu.scouter.common.support.implement.exception.CustomException
+import org.springframework.http.HttpStatus
+
+class InterviewEvaluationAccessDeniedException(
+    message: String,
+) : CustomException(message, "InterviewEvaluation-003", HttpStatus.FORBIDDEN)

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/support/implement/exception/InterviewEvaluationAccessDeniedException.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/support/implement/exception/InterviewEvaluationAccessDeniedException.kt
@@ -1,8 +1,0 @@
-package com.yourssu.scouter.recruiting.support.implement.exception
-
-import com.yourssu.scouter.common.support.implement.exception.CustomException
-import org.springframework.http.HttpStatus
-
-class InterviewEvaluationAccessDeniedException(
-    message: String,
-) : CustomException(message, "InterviewEvaluation-003", HttpStatus.FORBIDDEN)

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/support/implement/exception/InterviewEvaluationInvalidScoreException.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/support/implement/exception/InterviewEvaluationInvalidScoreException.kt
@@ -1,0 +1,8 @@
+package com.yourssu.scouter.recruiting.support.implement.exception
+
+import com.yourssu.scouter.common.support.implement.exception.CustomException
+import org.springframework.http.HttpStatus
+
+class InterviewEvaluationInvalidScoreException(
+    message: String,
+) : CustomException(message, "InterviewEvaluation-001", HttpStatus.BAD_REQUEST)

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/support/implement/exception/InterviewEvaluationItemNotFoundException.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/support/implement/exception/InterviewEvaluationItemNotFoundException.kt
@@ -1,0 +1,8 @@
+package com.yourssu.scouter.recruiting.support.implement.exception
+
+import com.yourssu.scouter.common.support.implement.exception.CustomException
+import org.springframework.http.HttpStatus
+
+class InterviewEvaluationItemNotFoundException(
+    message: String,
+) : CustomException(message, "InterviewEvaluation-002", HttpStatus.NOT_FOUND)

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/support/implement/exception/InterviewRubricNotFoundException.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/support/implement/exception/InterviewRubricNotFoundException.kt
@@ -1,0 +1,8 @@
+package com.yourssu.scouter.recruiting.support.implement.exception
+
+import com.yourssu.scouter.common.support.implement.exception.CustomException
+import org.springframework.http.HttpStatus
+
+class InterviewRubricNotFoundException(
+    message: String,
+) : CustomException(message, "InterviewRubric-001", HttpStatus.NOT_FOUND)

--- a/src/main/resources/db/migration/V28__create_interview_evaluation_tables.sql
+++ b/src/main/resources/db/migration/V28__create_interview_evaluation_tables.sql
@@ -30,6 +30,7 @@ CREATE TABLE interview_evaluation (
                                       member_id                BIGINT      NOT NULL,
                                       score                    INT         NOT NULL,
                                       result                   VARCHAR(30) NOT NULL DEFAULT 'PENDING', -- PENDING, FINAL_PASS, INTERVIEW_FAIL
+                                      submitted_at             DATETIME(6)  NULL,
 
                                       CONSTRAINT fk_interview_evaluation_applicant FOREIGN KEY (applicant_id) REFERENCES applicant (id),
                                       CONSTRAINT fk_interview_evaluation_item FOREIGN KEY (interview_evaluation_item_id) REFERENCES interview_evaluation_item (id)

--- a/src/main/resources/db/migration/V28__create_interview_evaluation_tables.sql
+++ b/src/main/resources/db/migration/V28__create_interview_evaluation_tables.sql
@@ -29,10 +29,25 @@ CREATE TABLE interview_evaluation (
                                       interview_evaluation_item_id BIGINT  NOT NULL,
                                       member_id                BIGINT      NOT NULL,
                                       score                    INT         NOT NULL,
-                                      result                   VARCHAR(30) NOT NULL DEFAULT 'PENDING', -- PENDING, FINAL_PASS, INTERVIEW_FAIL
-                                      overall_comment          TEXT        NULL,
-                                      submitted_at             DATETIME(6)  NULL,
 
                                       CONSTRAINT fk_interview_evaluation_applicant FOREIGN KEY (applicant_id) REFERENCES applicant (id),
                                       CONSTRAINT fk_interview_evaluation_item FOREIGN KEY (interview_evaluation_item_id) REFERENCES interview_evaluation_item (id)
 );
+
+-- 4. Final Evaluation (최종 평가 결과)
+CREATE TABLE final_evaluation (
+                                  id                  BIGINT AUTO_INCREMENT PRIMARY KEY,
+                                  member_id           BIGINT      NOT NULL,
+                                  interview_rubric_id BIGINT      NOT NULL,
+                                  applicant_id        BIGINT      NOT NULL,
+                                  overall_comment     TEXT        NULL,
+                                  interview_result    VARCHAR(30) NOT NULL DEFAULT 'PENDING',
+                                  score               INT         NOT NULL,
+                                  submit              BOOLEAN     NOT NULL DEFAULT FALSE,
+                                  submitted_at        DATETIME(6) NULL,
+
+                                  CONSTRAINT fk_final_evaluation_member FOREIGN KEY (member_id) REFERENCES member (id),
+                                  CONSTRAINT fk_final_evaluation_rubric FOREIGN KEY (interview_rubric_id) REFERENCES interview_rubric (id),
+                                  CONSTRAINT fk_final_evaluation_applicant FOREIGN KEY (applicant_id) REFERENCES applicant (id)
+);
+

--- a/src/main/resources/db/migration/V28__create_interview_evaluation_tables.sql
+++ b/src/main/resources/db/migration/V28__create_interview_evaluation_tables.sql
@@ -5,7 +5,6 @@ CREATE TABLE interview_rubric (
                                   deadline          DATETIME(6)  NOT NULL,
                                   part_id           BIGINT       NOT NULL,
                                   is_locked         BOOLEAN      NOT NULL DEFAULT FALSE,
-                                  interviewer_count INT          NOT NULL,
 
                                   CONSTRAINT fk_interview_rubric_part FOREIGN KEY (part_id) REFERENCES part (id),
                                   CONSTRAINT uk_interview_rubric_part_semester UNIQUE (part_id, semester)

--- a/src/main/resources/db/migration/V28__create_interview_evaluation_tables.sql
+++ b/src/main/resources/db/migration/V28__create_interview_evaluation_tables.sql
@@ -30,6 +30,7 @@ CREATE TABLE interview_evaluation (
                                       member_id                BIGINT      NOT NULL,
                                       score                    INT         NOT NULL,
                                       result                   VARCHAR(30) NOT NULL DEFAULT 'PENDING', -- PENDING, FINAL_PASS, INTERVIEW_FAIL
+                                      overall_comment          TEXT        NULL,
                                       submitted_at             DATETIME(6)  NULL,
 
                                       CONSTRAINT fk_interview_evaluation_applicant FOREIGN KEY (applicant_id) REFERENCES applicant (id),

--- a/src/main/resources/db/migration/V28__create_interview_evaluation_tables.sql
+++ b/src/main/resources/db/migration/V28__create_interview_evaluation_tables.sql
@@ -1,13 +1,14 @@
 -- 1. Interview Rubric (루브릭 헤더)
 CREATE TABLE interview_rubric (
                                   id                BIGINT AUTO_INCREMENT PRIMARY KEY,
-                                  semester          VARCHAR(255) NOT NULL,
+                                  semester_id       BIGINT       NOT NULL,
                                   deadline          DATETIME(6)  NOT NULL,
                                   part_id           BIGINT       NOT NULL,
                                   is_locked         BOOLEAN      NOT NULL DEFAULT FALSE,
 
+                                  CONSTRAINT fk_interview_rubric_semester FOREIGN KEY (semester_id) REFERENCES semester (id),
                                   CONSTRAINT fk_interview_rubric_part FOREIGN KEY (part_id) REFERENCES part (id),
-                                  CONSTRAINT uk_interview_rubric_part_semester UNIQUE (part_id, semester)
+                                  CONSTRAINT uk_interview_rubric_part_semester UNIQUE (part_id, semester_id)
 );
 
 -- 2. Interview Rubric Item (루브릭 항목)
@@ -26,7 +27,7 @@ CREATE TABLE interview_evaluation (
                                       id                       BIGINT AUTO_INCREMENT PRIMARY KEY,
                                       applicant_id             BIGINT      NOT NULL,
                                       interview_evaluation_item_id BIGINT  NOT NULL,
-                                      member_id                BIGINT      NOT NULL,
+                                      user_id                  BIGINT      NOT NULL,
                                       score                    INT         NOT NULL,
 
                                       CONSTRAINT fk_interview_evaluation_applicant FOREIGN KEY (applicant_id) REFERENCES applicant (id),
@@ -36,7 +37,7 @@ CREATE TABLE interview_evaluation (
 -- 4. Final Evaluation (최종 평가 결과)
 CREATE TABLE final_evaluation (
                                   id                  BIGINT AUTO_INCREMENT PRIMARY KEY,
-                                  member_id           BIGINT      NOT NULL,
+                                  user_id             BIGINT      NOT NULL,
                                   interview_rubric_id BIGINT      NOT NULL,
                                   applicant_id        BIGINT      NOT NULL,
                                   overall_comment     TEXT        NULL,
@@ -45,8 +46,7 @@ CREATE TABLE final_evaluation (
                                   submit              BOOLEAN     NOT NULL DEFAULT FALSE,
                                   submitted_at        DATETIME(6) NULL,
 
-                                  CONSTRAINT fk_final_evaluation_member FOREIGN KEY (member_id) REFERENCES member (id),
+                                  CONSTRAINT fk_final_evaluation_member FOREIGN KEY (user_id) REFERENCES member (id),
                                   CONSTRAINT fk_final_evaluation_rubric FOREIGN KEY (interview_rubric_id) REFERENCES interview_rubric (id),
                                   CONSTRAINT fk_final_evaluation_applicant FOREIGN KEY (applicant_id) REFERENCES applicant (id)
 );
-

--- a/src/main/resources/db/migration/V28__create_interview_evaluation_tables.sql
+++ b/src/main/resources/db/migration/V28__create_interview_evaluation_tables.sql
@@ -1,0 +1,36 @@
+-- 1. Interview Rubric (루브릭 헤더)
+CREATE TABLE interview_rubric (
+                                  id                BIGINT AUTO_INCREMENT PRIMARY KEY,
+                                  semester          VARCHAR(255) NOT NULL,
+                                  deadline          DATETIME(6)  NOT NULL,
+                                  part_id           BIGINT       NOT NULL,
+                                  is_locked         BOOLEAN      NOT NULL DEFAULT FALSE,
+                                  interviewer_count INT          NOT NULL,
+
+                                  CONSTRAINT fk_interview_rubric_part FOREIGN KEY (part_id) REFERENCES part (id),
+                                  CONSTRAINT uk_interview_rubric_part_semester UNIQUE (part_id, semester)
+);
+
+-- 2. Interview Rubric Item (루브릭 항목)
+CREATE TABLE interview_evaluation_item (
+                                       id                      BIGINT AUTO_INCREMENT PRIMARY KEY,
+                                       interview_rubric_id     BIGINT       NOT NULL,
+                                       keyword                 VARCHAR(255) NOT NULL,
+                                       rubric_type             VARCHAR(50)  NOT NULL,
+                                       max_score               INT          NOT NULL,
+
+                                       CONSTRAINT fk_interview_rubric_item_rubric FOREIGN KEY (interview_rubric_id) REFERENCES interview_rubric (id) ON DELETE CASCADE
+);
+
+-- 3. Interview Evaluation (평가 결과)
+CREATE TABLE interview_evaluation (
+                                      id                       BIGINT AUTO_INCREMENT PRIMARY KEY,
+                                      applicant_id             BIGINT      NOT NULL,
+                                      interview_evaluation_item_id BIGINT  NOT NULL,
+                                      member_id                BIGINT      NOT NULL,
+                                      score                    INT         NOT NULL,
+                                      result                   VARCHAR(30) NOT NULL DEFAULT 'PENDING', -- PENDING, FINAL_PASS, INTERVIEW_FAIL
+
+                                      CONSTRAINT fk_interview_evaluation_applicant FOREIGN KEY (applicant_id) REFERENCES applicant (id),
+                                      CONSTRAINT fk_interview_evaluation_item FOREIGN KEY (interview_evaluation_item_id) REFERENCES interview_evaluation_item (id)
+);

--- a/src/test/kotlin/com/yourssu/scouter/recruiting/rubric/storage/InterviewRubricRepositoryImplTest.kt
+++ b/src/test/kotlin/com/yourssu/scouter/recruiting/rubric/storage/InterviewRubricRepositoryImplTest.kt
@@ -2,6 +2,9 @@ package com.yourssu.scouter.recruiting.rubric.storage
 
 import com.yourssu.scouter.common.division.storage.DivisionEntity
 import com.yourssu.scouter.common.part.storage.PartEntity
+import com.yourssu.scouter.common.semester.implement.Semester
+import com.yourssu.scouter.common.semester.implement.Term
+import com.yourssu.scouter.common.semester.storage.SemesterEntity
 import com.yourssu.scouter.recruiting.evaluation.implement.InterviewEvaluationItem
 import com.yourssu.scouter.recruiting.rubric.implement.InterviewRubric
 import com.yourssu.scouter.recruiting.rubric.implement.InterviewRubricMapper
@@ -14,6 +17,7 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager
 import org.springframework.context.annotation.Import
 import java.time.Instant
+import java.time.Year
 
 @DataJpaTest
 @Import(InterviewRubricRepositoryImpl::class, InterviewRubricMapper::class)
@@ -32,6 +36,11 @@ class InterviewRubricRepositoryImplTest {
         val division = entityManager.persist(DivisionEntity(null, "개발", 1))
         val part = entityManager.persist(PartEntity(null, division, "PM", 1))
         partId = part.id!!
+        
+        // Persist SemesterEntities to satisfy FK constraint
+        entityManager.persist(SemesterEntity(null, Year.of(2026), Term.SPRING))
+        entityManager.persist(SemesterEntity(null, Year.of(2026), Term.FALL))
+        
         entityManager.flush()
         entityManager.clear()
     }
@@ -43,7 +52,7 @@ class InterviewRubricRepositoryImplTest {
         entityManager.flush()
         entityManager.clear()
 
-        val found = interviewRubricRepository.getByPartIdAndSemester(partId, "2026-2")
+        val found = interviewRubricRepository.getByPartIdAndSemester(partId, Semester.of("2026-2"))
 
         assertThat(found.id).isEqualTo(saved.id)
         assertThat(found.partId).isEqualTo(partId)
@@ -53,19 +62,19 @@ class InterviewRubricRepositoryImplTest {
 
     @Test
     fun `같은 파트라도 학기별 루브릭을 각각 조회한다`() {
-        interviewRubricRepository.save(rubric("2026-1"))
-        interviewRubricRepository.save(rubric("2026-2"))
+        interviewRubricRepository.save(rubric(Semester.of("2026-1")))
+        interviewRubricRepository.save(rubric(Semester.of("2026-2")))
 
         entityManager.flush()
         entityManager.clear()
 
-        assertThat(interviewRubricRepository.getByPartIdAndSemester(partId, "2026-1").semester)
-            .isEqualTo("2026-1")
-        assertThat(interviewRubricRepository.getByPartIdAndSemester(partId, "2026-2").semester)
-            .isEqualTo("2026-2")
+        assertThat(interviewRubricRepository.getByPartIdAndSemester(partId, Semester.of("2026-1")).semester)
+            .isEqualByComparingTo(Semester.of("2026-1"))
+        assertThat(interviewRubricRepository.getByPartIdAndSemester(partId, Semester.of("2026-2")).semester)
+            .isEqualByComparingTo(Semester.of("2026-2"))
     }
 
-    private fun rubric(semester: String = "2026-2") = InterviewRubric(
+    private fun rubric(semester: Semester = Semester.of("2026-2")) = InterviewRubric(
         partId = partId,
         semester = semester,
         deadline = Instant.parse("2026-08-01T00:00:00Z"),

--- a/src/test/kotlin/com/yourssu/scouter/recruiting/rubric/storage/InterviewRubricRepositoryImplTest.kt
+++ b/src/test/kotlin/com/yourssu/scouter/recruiting/rubric/storage/InterviewRubricRepositoryImplTest.kt
@@ -69,7 +69,6 @@ class InterviewRubricRepositoryImplTest {
         partId = partId,
         semester = semester,
         deadline = Instant.parse("2026-08-01T00:00:00Z"),
-        interviewerCount = 2,
         items = listOf(
             InterviewEvaluationItem(keyword = "직무 역량", rubricType = RubricGroupType.JOB, maxScore = 60),
             InterviewEvaluationItem(keyword = "협업 역량", rubricType = RubricGroupType.TEAM, maxScore = 40),

--- a/src/test/kotlin/com/yourssu/scouter/recruiting/rubric/storage/InterviewRubricRepositoryImplTest.kt
+++ b/src/test/kotlin/com/yourssu/scouter/recruiting/rubric/storage/InterviewRubricRepositoryImplTest.kt
@@ -1,0 +1,78 @@
+package com.yourssu.scouter.recruiting.rubric.storage
+
+import com.yourssu.scouter.common.division.storage.DivisionEntity
+import com.yourssu.scouter.common.part.storage.PartEntity
+import com.yourssu.scouter.recruiting.evaluation.implement.InterviewEvaluationItem
+import com.yourssu.scouter.recruiting.rubric.implement.InterviewRubric
+import com.yourssu.scouter.recruiting.rubric.implement.InterviewRubricMapper
+import com.yourssu.scouter.recruiting.rubric.implement.RubricGroupType
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager
+import org.springframework.context.annotation.Import
+import java.time.Instant
+
+@DataJpaTest
+@Import(InterviewRubricRepositoryImpl::class, InterviewRubricMapper::class)
+class InterviewRubricRepositoryImplTest {
+
+    @Autowired
+    lateinit var interviewRubricRepository: InterviewRubricRepositoryImpl
+
+    @Autowired
+    lateinit var entityManager: TestEntityManager
+
+    private var partId: Long = 0
+
+    @BeforeEach
+    fun setUp() {
+        val division = entityManager.persist(DivisionEntity(null, "개발", 1))
+        val part = entityManager.persist(PartEntity(null, division, "PM", 1))
+        partId = part.id!!
+        entityManager.flush()
+        entityManager.clear()
+    }
+
+    @Test
+    fun `루브릭과 평가 항목을 저장한 뒤 파트 ID로 조회한다`() {
+        val saved = interviewRubricRepository.save(rubric())
+
+        entityManager.flush()
+        entityManager.clear()
+
+        val found = interviewRubricRepository.getByPartIdAndSemester(partId, "2026-2")
+
+        assertThat(found.id).isEqualTo(saved.id)
+        assertThat(found.partId).isEqualTo(partId)
+        assertThat(found.items).extracting<String> { it.keyword }
+            .containsExactly("직무 역량", "협업 역량")
+    }
+
+    @Test
+    fun `같은 파트라도 학기별 루브릭을 각각 조회한다`() {
+        interviewRubricRepository.save(rubric("2026-1"))
+        interviewRubricRepository.save(rubric("2026-2"))
+
+        entityManager.flush()
+        entityManager.clear()
+
+        assertThat(interviewRubricRepository.getByPartIdAndSemester(partId, "2026-1").semester)
+            .isEqualTo("2026-1")
+        assertThat(interviewRubricRepository.getByPartIdAndSemester(partId, "2026-2").semester)
+            .isEqualTo("2026-2")
+    }
+
+    private fun rubric(semester: String = "2026-2") = InterviewRubric(
+        partId = partId,
+        semester = semester,
+        deadline = Instant.parse("2026-08-01T00:00:00Z"),
+        interviewerCount = 2,
+        items = listOf(
+            InterviewEvaluationItem(keyword = "직무 역량", rubricType = RubricGroupType.JOB, maxScore = 60),
+            InterviewEvaluationItem(keyword = "협업 역량", rubricType = RubricGroupType.TEAM, maxScore = 40),
+        ),
+    )
+}


### PR DESCRIPTION
## 📌 주요 변경 사항                                                                                                                                                
<img width="1770" height="926" alt="image" src="https://github.com/user-attachments/assets/2e175253-74d0-4287-bfca-b0b7f3a12f2f" />

<img width="2108" height="1290" alt="image" src="https://github.com/user-attachments/assets/908442df-e392-4b22-aa60-17b3befe0435" />


### 1. 데이터베이스 스키마 및 마이그레이션 (recruiting/rubric, recruiting/evaluation)                                                                               
                                                                                                                                                                  
• V28 마이그레이션 스크립트:                                                                                                                                   
  • 면접 평가 루브릭 테이블 (interview_rubric, interview_evaluation_item) 생성                                                                                    
  • 면접 평가 테이블 (interview_evaluation)과 팀원별 면접 최종 평가 결과(final_evaluation)에 최종 제출 일시(submitted_at) 및 종합 코멘트(overall_comment) 컬럼을 반영
                                            
              
                                                                                                                                                                  
### 2. 면접 평가 루브릭 API (GET/PUT /parts/{partId}/interviews/rubrics/{semester})                                                                                 
                                                                                                                                                                  
• 수정 및 조회 계층 구조화: CULTURE_FIT / TEAM_FIT / JOB_FIT 그룹으로 나누고 그룹별 최대 배점(groupMaxScore)을 계산하도록 응답 DTO를 설계했습니다.                  
• 수정 시 정합성 검증:                                                                                                                                              
  • 전체 문항 배점 합계가 100점인지 검증합니다.                                                                                                                   
  • [A1] 해당 파트/학기에 작성된 면접 평가(임시저장 포함)가 존재하면 루브릭을 수정할 수 없도록 차단하고 409 Conflict (RubricLockedException)를 반환합니다.        
                                                                                                                                                                  
                                                                                                                                                                  
### 3. 면접 평가 API                                                                                                                                                
                                                                                                                                                                  
• GET /applicants/{applicantId}/interviews/evaluations (본인 평가 조회)                                                                                             
  • 로그인한 면접관 본인의 임시저장/최종제출 면접 평가 내역을 그룹 구조로 정렬하여 반환합니다.                                                                    
• PUT /applicants/{applicantId}/interviews/evaluations (본인 평가 저장/수정)                                                                                        
  • submit: true 시 최종 제출 처리 및 시각(Instant.now())을 기록하며, false인 경우 임시저장으로 동작합니다. (제출 상태에서도 재수정 가능)                         
  • 요청된 score가 해당 항목의 배점(maxScore)을 초과하는지 유효성 검증을 거칩니다.                                                                                
• GET /applicants/{applicantId}/interviews/evaluations/others (타인 평가 결과 조회)                                                                                 
  • [A5] 블라인드 정책에 따라 조회자가 본인 평가를 제출하지 않은 상태라면 타 면접관의 종합 의견(overallComment)을 빈 문자열("")로 마스킹하여 반환합니다. (점수 및 
  결과는 공개)                                                                                                                                                    
• GET /applicants/{applicantId}/interviews/evaluations/status (면접 평가자 상태 목록 조회)                                                                          
  • 지원자 파트의 활동 멤버 전원을 면접관으로 간주하여 각 평가자의 진행 상태(NOT_STARTED, IN_PROGRESS, SUBMITTED)를 반환합니다.                                   
                                                                                                                                                                  
──────                                                                                                                                                              
## 🧪 테스트 결과                                                                                                                                                   
                                                                                                                                                                  
• ./gradlew test를 수행하여 변경 사항 및 신규 로직을 포함한 전체 유닛/통합 테스트가 성공적으로 동작함을 검증 완료했습니다.                                          
  • Test Result: BUILD SUCCESSFUL       
