### PR TITLE
[#317]; feat: 고정 질문 + 면접 질문지 API 구현

### DIFF
--- a/src/main/kotlin/com/yourssu/scouter/recruiting/question/application/FixedQuestionController.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/question/application/FixedQuestionController.kt
@@ -1,0 +1,27 @@
+package com.yourssu.scouter.recruiting.question.application
+
+import com.yourssu.scouter.recruiting.question.application.dto.ReadFixedQuestionResponse
+import com.yourssu.scouter.recruiting.question.business.FixedQuestionService
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RestController
+
+@Tag(name = "고정 질문")
+@RestController
+class FixedQuestionController(
+    private val fixedQuestionService: FixedQuestionService,
+) {
+
+    @Operation(summary = "고정 질문 전역 풀 조회")
+    @GetMapping("/parts/{partId}/interviews/questions/fixed")
+    fun readAll(
+        @PathVariable partId: Long,
+    ): ResponseEntity<List<ReadFixedQuestionResponse>> {
+        val questions = fixedQuestionService.readAll(partId)
+
+        return ResponseEntity.ok(questions.map(ReadFixedQuestionResponse::from))
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/question/application/QuestionnaireController.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/question/application/QuestionnaireController.kt
@@ -1,0 +1,40 @@
+package com.yourssu.scouter.recruiting.question.application
+
+import com.yourssu.scouter.recruiting.question.application.dto.ReadQuestionnaireResponse
+import com.yourssu.scouter.recruiting.question.application.dto.SaveQuestionnaireRequest
+import com.yourssu.scouter.recruiting.question.business.QuestionnaireService
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.validation.Valid
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RestController
+
+@Tag(name = "면접 질문지")
+@RestController
+class QuestionnaireController(
+    private val questionnaireService: QuestionnaireService,
+) {
+
+    @Operation(summary = "지원자별 면접 질문지 조회")
+    @GetMapping("/applicants/{applicantId}/interviews/questionnaires")
+    fun read(
+        @PathVariable applicantId: Long,
+    ): ResponseEntity<ReadQuestionnaireResponse> {
+        return ResponseEntity.ok(ReadQuestionnaireResponse.from(questionnaireService.readByApplicantId(applicantId)))
+    }
+
+    @Operation(summary = "지원자별 면접 질문지 수정", description = "요청 바디의 문항 목록으로 기존 질문지를 전체 치환합니다.")
+    @PutMapping("/applicants/{applicantId}/interviews/questionnaires")
+    fun upsert(
+        @PathVariable applicantId: Long,
+        @RequestBody @Valid request: SaveQuestionnaireRequest,
+    ): ResponseEntity<ReadQuestionnaireResponse> {
+        val result = questionnaireService.upsert(applicantId, request.toCommand())
+
+        return ResponseEntity.ok(ReadQuestionnaireResponse.from(result))
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/question/application/dto/ReadFixedQuestionResponse.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/question/application/dto/ReadFixedQuestionResponse.kt
@@ -1,0 +1,20 @@
+package com.yourssu.scouter.recruiting.question.application.dto
+
+import com.yourssu.scouter.recruiting.question.business.dto.FixedQuestionDto
+import com.yourssu.scouter.recruiting.question.implement.FixedQuestionCategory
+
+data class ReadFixedQuestionResponse(
+    val id: Long,
+    val category: FixedQuestionCategory,
+    val content: String,
+    val sortOrder: Int,
+) {
+    companion object {
+        fun from(dto: FixedQuestionDto): ReadFixedQuestionResponse = ReadFixedQuestionResponse(
+            id = dto.id,
+            category = dto.category,
+            content = dto.content,
+            sortOrder = dto.sortOrder,
+        )
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/question/application/dto/ReadQuestionnaireQuestionResponse.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/question/application/dto/ReadQuestionnaireQuestionResponse.kt
@@ -1,0 +1,20 @@
+package com.yourssu.scouter.recruiting.question.application.dto
+
+import com.yourssu.scouter.recruiting.question.business.dto.QuestionnaireQuestionDto
+import com.yourssu.scouter.recruiting.question.implement.QuestionGroup
+
+data class ReadQuestionnaireQuestionResponse(
+    val id: Long,
+    val group: QuestionGroup,
+    val sourceQuestionId: Long?,
+    val content: String,
+) {
+    companion object {
+        fun from(dto: QuestionnaireQuestionDto): ReadQuestionnaireQuestionResponse = ReadQuestionnaireQuestionResponse(
+            id = dto.id,
+            group = dto.group,
+            sourceQuestionId = dto.sourceQuestionId,
+            content = dto.content,
+        )
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/question/application/dto/ReadQuestionnaireResponse.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/question/application/dto/ReadQuestionnaireResponse.kt
@@ -1,0 +1,15 @@
+package com.yourssu.scouter.recruiting.question.application.dto
+
+import com.yourssu.scouter.recruiting.question.business.dto.QuestionnaireDto
+
+data class ReadQuestionnaireResponse(
+    val assignedInterviewerUserId: Long?,
+    val questions: List<ReadQuestionnaireQuestionResponse>,
+) {
+    companion object {
+        fun from(dto: QuestionnaireDto): ReadQuestionnaireResponse = ReadQuestionnaireResponse(
+            assignedInterviewerUserId = dto.assignedInterviewerUserId,
+            questions = dto.questions.map(ReadQuestionnaireQuestionResponse::from),
+        )
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/question/application/dto/SaveQuestionnaireQuestionRequest.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/question/application/dto/SaveQuestionnaireQuestionRequest.kt
@@ -1,0 +1,21 @@
+package com.yourssu.scouter.recruiting.question.application.dto
+
+import com.yourssu.scouter.recruiting.question.business.dto.SaveQuestionnaireQuestionCommand
+import com.yourssu.scouter.recruiting.question.implement.QuestionGroup
+import jakarta.validation.constraints.NotNull
+
+data class SaveQuestionnaireQuestionRequest(
+
+    @field:NotNull
+    val group: QuestionGroup?,
+
+    val sourceQuestionId: Long?,
+
+    val content: String?,
+) {
+    fun toCommand(): SaveQuestionnaireQuestionCommand = SaveQuestionnaireQuestionCommand(
+        group = group!!,
+        sourceQuestionId = sourceQuestionId,
+        content = content,
+    )
+}

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/question/application/dto/SaveQuestionnaireRequest.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/question/application/dto/SaveQuestionnaireRequest.kt
@@ -1,0 +1,19 @@
+package com.yourssu.scouter.recruiting.question.application.dto
+
+import com.yourssu.scouter.recruiting.question.business.dto.SaveQuestionnaireCommand
+import jakarta.validation.Valid
+import jakarta.validation.constraints.NotNull
+
+data class SaveQuestionnaireRequest(
+
+    @field:NotNull
+    val assignedInterviewerUserId: Long?,
+
+    @field:Valid
+    val questions: List<SaveQuestionnaireQuestionRequest>,
+) {
+    fun toCommand(): SaveQuestionnaireCommand = SaveQuestionnaireCommand(
+        assignedInterviewerUserId = assignedInterviewerUserId!!,
+        questions = questions.map { it.toCommand() },
+    )
+}

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/question/business/FixedQuestionService.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/question/business/FixedQuestionService.kt
@@ -1,0 +1,19 @@
+package com.yourssu.scouter.recruiting.question.business
+
+import com.yourssu.scouter.common.part.implement.PartReader
+import com.yourssu.scouter.recruiting.question.business.dto.FixedQuestionDto
+import com.yourssu.scouter.recruiting.question.implement.FixedQuestionReader
+import org.springframework.stereotype.Service
+
+@Service
+class FixedQuestionService(
+    private val fixedQuestionReader: FixedQuestionReader,
+    private val partReader: PartReader,
+) {
+
+    fun readAll(partId: Long): List<FixedQuestionDto> {
+        partReader.readById(partId)
+
+        return fixedQuestionReader.readAll().map(FixedQuestionDto::from)
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/question/business/QuestionnaireService.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/question/business/QuestionnaireService.kt
@@ -1,0 +1,90 @@
+package com.yourssu.scouter.recruiting.question.business
+
+import com.yourssu.scouter.auth.user.implement.UserReader
+import com.yourssu.scouter.recruiting.applicant.implement.ApplicantReader
+import com.yourssu.scouter.recruiting.question.business.dto.QuestionnaireDto
+import com.yourssu.scouter.recruiting.question.business.dto.QuestionnaireQuestionDto
+import com.yourssu.scouter.recruiting.question.business.dto.SaveQuestionnaireCommand
+import com.yourssu.scouter.recruiting.question.implement.FixedQuestion
+import com.yourssu.scouter.recruiting.question.implement.FixedQuestionReader
+import com.yourssu.scouter.recruiting.question.implement.Questionnaire
+import com.yourssu.scouter.recruiting.question.implement.QuestionnaireQuestion
+import com.yourssu.scouter.recruiting.question.implement.QuestionnaireValidator
+import com.yourssu.scouter.recruiting.question.implement.QuestionnaireReader
+import com.yourssu.scouter.recruiting.question.implement.QuestionnaireWriter
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class QuestionnaireService(
+    private val questionnaireReader: QuestionnaireReader,
+    private val questionnaireWriter: QuestionnaireWriter,
+    private val fixedQuestionReader: FixedQuestionReader,
+    private val questionnaireValidator: QuestionnaireValidator,
+    private val applicantReader: ApplicantReader,
+    private val userReader: UserReader,
+) {
+
+    fun readByApplicantId(applicantId: Long): QuestionnaireDto {
+        applicantReader.readById(applicantId)
+
+        val questionnaire = questionnaireReader.readByApplicantId(applicantId)
+        val questions = questionnaireReader.readQuestionsByApplicantId(applicantId)
+        val fixedQuestionsById = readFixedQuestionsById(questions)
+
+        return QuestionnaireDto(
+            applicantId = applicantId,
+            assignedInterviewerUserId = questionnaire?.assignedInterviewerUserId,
+            questions = questions
+                .sortedBy { it.sortOrder }
+                .map { it.toDto(fixedQuestionsById) },
+        )
+    }
+
+    @Transactional
+    fun upsert(applicantId: Long, command: SaveQuestionnaireCommand): QuestionnaireDto {
+        applicantReader.readById(applicantId)
+        userReader.readById(command.assignedInterviewerUserId)
+
+        val questions = command.questions.mapIndexed { index, question ->
+            QuestionnaireQuestion(
+                questionnaireId = applicantId,
+                group = question.group,
+                sourceQuestionId = question.sourceQuestionId,
+                content = question.content,
+                sortOrder = index,
+            )
+        }
+        val fixedQuestionsById = readFixedQuestionsById(questions)
+        questionnaireValidator.validate(questions, fixedQuestionsById)
+
+        val saved = questionnaireWriter.upsert(
+            Questionnaire(applicantId = applicantId, assignedInterviewerUserId = command.assignedInterviewerUserId),
+            questions,
+        )
+
+        return QuestionnaireDto(
+            applicantId = applicantId,
+            assignedInterviewerUserId = command.assignedInterviewerUserId,
+            questions = saved
+                .sortedBy { it.sortOrder }
+                .map { it.toDto(fixedQuestionsById) },
+        )
+    }
+
+    private fun readFixedQuestionsById(questions: List<QuestionnaireQuestion>): Map<Long?, FixedQuestion> {
+        return fixedQuestionReader
+            .readAllByIdIn(questions.mapNotNull { it.sourceQuestionId })
+            .associateBy { it.id }
+    }
+
+    private fun QuestionnaireQuestion.toDto(
+        fixedQuestionsById: Map<Long?, FixedQuestion>,
+    ): QuestionnaireQuestionDto = QuestionnaireQuestionDto(
+        id = id!!,
+        group = group,
+        sourceQuestionId = sourceQuestionId,
+        content = content ?: fixedQuestionsById[sourceQuestionId]?.content.orEmpty(),
+        sortOrder = sortOrder,
+    )
+}

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/question/business/dto/FixedQuestionDto.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/question/business/dto/FixedQuestionDto.kt
@@ -1,0 +1,20 @@
+package com.yourssu.scouter.recruiting.question.business.dto
+
+import com.yourssu.scouter.recruiting.question.implement.FixedQuestion
+import com.yourssu.scouter.recruiting.question.implement.FixedQuestionCategory
+
+data class FixedQuestionDto(
+    val id: Long,
+    val category: FixedQuestionCategory,
+    val content: String,
+    val sortOrder: Int,
+) {
+    companion object {
+        fun from(fixedQuestion: FixedQuestion): FixedQuestionDto = FixedQuestionDto(
+            id = fixedQuestion.id!!,
+            category = fixedQuestion.category,
+            content = fixedQuestion.content,
+            sortOrder = fixedQuestion.sortOrder,
+        )
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/question/business/dto/QuestionnaireDto.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/question/business/dto/QuestionnaireDto.kt
@@ -1,0 +1,7 @@
+package com.yourssu.scouter.recruiting.question.business.dto
+
+data class QuestionnaireDto(
+    val applicantId: Long,
+    val assignedInterviewerUserId: Long?,
+    val questions: List<QuestionnaireQuestionDto>,
+)

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/question/business/dto/QuestionnaireQuestionDto.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/question/business/dto/QuestionnaireQuestionDto.kt
@@ -1,0 +1,11 @@
+package com.yourssu.scouter.recruiting.question.business.dto
+
+import com.yourssu.scouter.recruiting.question.implement.QuestionGroup
+
+data class QuestionnaireQuestionDto(
+    val id: Long,
+    val group: QuestionGroup,
+    val sourceQuestionId: Long?,
+    val content: String,
+    val sortOrder: Int,
+)

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/question/business/dto/SaveQuestionnaireCommand.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/question/business/dto/SaveQuestionnaireCommand.kt
@@ -1,0 +1,6 @@
+package com.yourssu.scouter.recruiting.question.business.dto
+
+data class SaveQuestionnaireCommand(
+    val assignedInterviewerUserId: Long,
+    val questions: List<SaveQuestionnaireQuestionCommand>,
+)

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/question/business/dto/SaveQuestionnaireQuestionCommand.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/question/business/dto/SaveQuestionnaireQuestionCommand.kt
@@ -1,0 +1,9 @@
+package com.yourssu.scouter.recruiting.question.business.dto
+
+import com.yourssu.scouter.recruiting.question.implement.QuestionGroup
+
+data class SaveQuestionnaireQuestionCommand(
+    val group: QuestionGroup,
+    val sourceQuestionId: Long?,
+    val content: String?,
+)

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/question/implement/FixedQuestion.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/question/implement/FixedQuestion.kt
@@ -5,18 +5,4 @@ class FixedQuestion(
     val category: FixedQuestionCategory,
     val content: String,
     val sortOrder: Int,
-) {
-
-    override fun equals(other: Any?): Boolean {
-        if (this === other) return true
-        if (javaClass != other?.javaClass) return false
-
-        other as FixedQuestion
-
-        return id == other.id
-    }
-
-    override fun hashCode(): Int {
-        return id?.hashCode() ?: 0
-    }
-}
+)

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/question/implement/FixedQuestion.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/question/implement/FixedQuestion.kt
@@ -1,0 +1,22 @@
+package com.yourssu.scouter.recruiting.question.implement
+
+class FixedQuestion(
+    val id: Long? = null,
+    val category: FixedQuestionCategory,
+    val content: String,
+    val sortOrder: Int,
+) {
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as FixedQuestion
+
+        return id == other.id
+    }
+
+    override fun hashCode(): Int {
+        return id?.hashCode() ?: 0
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/question/implement/FixedQuestionCategory.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/question/implement/FixedQuestionCategory.kt
@@ -1,0 +1,7 @@
+package com.yourssu.scouter.recruiting.question.implement
+
+enum class FixedQuestionCategory {
+    REQUIRED,
+    CULTURE_FIT,
+    CLOSING,
+}

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/question/implement/FixedQuestionReader.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/question/implement/FixedQuestionReader.kt
@@ -1,0 +1,19 @@
+package com.yourssu.scouter.recruiting.question.implement
+
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+
+@Component
+@Transactional(readOnly = true)
+class FixedQuestionReader(
+    private val fixedQuestionRepository: FixedQuestionRepository,
+) {
+
+    fun readAll(): List<FixedQuestion> {
+        return fixedQuestionRepository.findAll().sortedWith(compareBy({ it.category }, { it.sortOrder }))
+    }
+
+    fun readAllByIdIn(ids: Collection<Long>): List<FixedQuestion> {
+        return fixedQuestionRepository.findAllByIdIn(ids)
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/question/implement/FixedQuestionRepository.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/question/implement/FixedQuestionRepository.kt
@@ -1,0 +1,8 @@
+package com.yourssu.scouter.recruiting.question.implement
+
+interface FixedQuestionRepository {
+
+    fun findAll(): List<FixedQuestion>
+
+    fun findAllByIdIn(ids: Collection<Long>): List<FixedQuestion>
+}

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/question/implement/QuestionGroup.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/question/implement/QuestionGroup.kt
@@ -1,0 +1,10 @@
+package com.yourssu.scouter.recruiting.question.implement
+
+enum class QuestionGroup(val isFixed: Boolean) {
+    REQUIRED(true),
+    CULTURE_FIT(true),
+    CLOSING(true),
+    PERSONAL(false),
+    TEAM_FIT(false),
+    JOB_FIT(false),
+}

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/question/implement/Questionnaire.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/question/implement/Questionnaire.kt
@@ -1,0 +1,6 @@
+package com.yourssu.scouter.recruiting.question.implement
+
+class Questionnaire(
+    val applicantId: Long,
+    val assignedInterviewerUserId: Long,
+)

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/question/implement/QuestionnaireQuestion.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/question/implement/QuestionnaireQuestion.kt
@@ -22,17 +22,4 @@ class QuestionnaireQuestion(
             }
         }
     }
-
-    override fun equals(other: Any?): Boolean {
-        if (this === other) return true
-        if (javaClass != other?.javaClass) return false
-
-        other as QuestionnaireQuestion
-
-        return id == other.id
-    }
-
-    override fun hashCode(): Int {
-        return id?.hashCode() ?: 0
-    }
 }

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/question/implement/QuestionnaireQuestion.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/question/implement/QuestionnaireQuestion.kt
@@ -1,0 +1,38 @@
+package com.yourssu.scouter.recruiting.question.implement
+
+import com.yourssu.scouter.recruiting.support.implement.exception.QuestionnaireGroupInvalidException
+
+class QuestionnaireQuestion(
+    val id: Long? = null,
+    val questionnaireId: Long,
+    val group: QuestionGroup,
+    val sourceQuestionId: Long?,
+    val content: String?,
+    val sortOrder: Int,
+) {
+
+    init {
+        if (group.isFixed) {
+            if (sourceQuestionId == null) {
+                throw QuestionnaireGroupInvalidException("고정 그룹($group) 문항은 sourceQuestionId가 필요합니다.")
+            }
+        } else {
+            if (content.isNullOrBlank()) {
+                throw QuestionnaireGroupInvalidException("자유 그룹($group) 문항은 content가 필요합니다.")
+            }
+        }
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as QuestionnaireQuestion
+
+        return id == other.id
+    }
+
+    override fun hashCode(): Int {
+        return id?.hashCode() ?: 0
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/question/implement/QuestionnaireQuestionRepository.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/question/implement/QuestionnaireQuestionRepository.kt
@@ -1,0 +1,8 @@
+package com.yourssu.scouter.recruiting.question.implement
+
+interface QuestionnaireQuestionRepository {
+
+    fun findAllByQuestionnaireId(questionnaireId: Long): List<QuestionnaireQuestion>
+
+    fun replaceAll(questionnaireId: Long, questions: List<QuestionnaireQuestion>): List<QuestionnaireQuestion>
+}

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/question/implement/QuestionnaireReader.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/question/implement/QuestionnaireReader.kt
@@ -1,0 +1,20 @@
+package com.yourssu.scouter.recruiting.question.implement
+
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+
+@Component
+@Transactional(readOnly = true)
+class QuestionnaireReader(
+    private val questionnaireRepository: QuestionnaireRepository,
+    private val questionnaireQuestionRepository: QuestionnaireQuestionRepository,
+) {
+
+    fun readByApplicantId(applicantId: Long): Questionnaire? {
+        return questionnaireRepository.findByApplicantId(applicantId)
+    }
+
+    fun readQuestionsByApplicantId(applicantId: Long): List<QuestionnaireQuestion> {
+        return questionnaireQuestionRepository.findAllByQuestionnaireId(applicantId)
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/question/implement/QuestionnaireRepository.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/question/implement/QuestionnaireRepository.kt
@@ -1,0 +1,8 @@
+package com.yourssu.scouter.recruiting.question.implement
+
+interface QuestionnaireRepository {
+
+    fun findByApplicantId(applicantId: Long): Questionnaire?
+
+    fun upsert(questionnaire: Questionnaire): Questionnaire
+}

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/question/implement/QuestionnaireValidator.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/question/implement/QuestionnaireValidator.kt
@@ -1,0 +1,31 @@
+package com.yourssu.scouter.recruiting.question.implement
+
+import com.yourssu.scouter.recruiting.support.implement.exception.FixedQuestionNotFoundException
+import com.yourssu.scouter.recruiting.support.implement.exception.QuestionnaireGroupInvalidException
+import org.springframework.stereotype.Component
+
+@Component
+class QuestionnaireValidator {
+
+    private companion object {
+        const val MIN_CULTURE_FIT_QUESTIONS = 2
+    }
+
+    fun validate(questions: List<QuestionnaireQuestion>, fixedQuestionsById: Map<Long?, FixedQuestion>) {
+        val cultureFitCount = questions.count { it.group == QuestionGroup.CULTURE_FIT }
+        if (cultureFitCount < MIN_CULTURE_FIT_QUESTIONS) {
+            throw QuestionnaireGroupInvalidException("CULTURE_FIT 그룹 문항은 최소 ${MIN_CULTURE_FIT_QUESTIONS}개 이상이어야 합니다.")
+        }
+
+        questions.filter { it.group.isFixed }.forEach { question ->
+            val fixedQuestion = fixedQuestionsById[question.sourceQuestionId]
+                ?: throw FixedQuestionNotFoundException("존재하지 않는 고정 질문입니다: ${question.sourceQuestionId}")
+
+            if (fixedQuestion.category.name != question.group.name) {
+                throw QuestionnaireGroupInvalidException(
+                    "고정 질문의 카테고리(${fixedQuestion.category})가 그룹(${question.group})과 일치하지 않습니다.",
+                )
+            }
+        }
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/question/implement/QuestionnaireWriter.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/question/implement/QuestionnaireWriter.kt
@@ -1,0 +1,18 @@
+package com.yourssu.scouter.recruiting.question.implement
+
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+
+@Component
+@Transactional
+class QuestionnaireWriter(
+    private val questionnaireRepository: QuestionnaireRepository,
+    private val questionnaireQuestionRepository: QuestionnaireQuestionRepository,
+) {
+
+    fun upsert(questionnaire: Questionnaire, questions: List<QuestionnaireQuestion>): List<QuestionnaireQuestion> {
+        val saved = questionnaireRepository.upsert(questionnaire)
+
+        return questionnaireQuestionRepository.replaceAll(saved.applicantId, questions)
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/question/storage/FixedQuestionEntity.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/question/storage/FixedQuestionEntity.kt
@@ -36,17 +36,4 @@ class FixedQuestionEntity(
         content = content,
         sortOrder = sortOrder,
     )
-
-    override fun equals(other: Any?): Boolean {
-        if (this === other) return true
-        if (javaClass != other?.javaClass) return false
-
-        other as FixedQuestionEntity
-
-        return id == other.id
-    }
-
-    override fun hashCode(): Int {
-        return id?.hashCode() ?: 0
-    }
 }

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/question/storage/FixedQuestionEntity.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/question/storage/FixedQuestionEntity.kt
@@ -1,0 +1,52 @@
+package com.yourssu.scouter.recruiting.question.storage
+
+import com.yourssu.scouter.recruiting.question.implement.FixedQuestion
+import com.yourssu.scouter.recruiting.question.implement.FixedQuestionCategory
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+
+@Entity
+@Table(name = "fixed_question")
+class FixedQuestionEntity(
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long? = null,
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    val category: FixedQuestionCategory,
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    val content: String,
+
+    @Column(nullable = false)
+    val sortOrder: Int,
+) {
+
+    fun toDomain(): FixedQuestion = FixedQuestion(
+        id = id,
+        category = category,
+        content = content,
+        sortOrder = sortOrder,
+    )
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as FixedQuestionEntity
+
+        return id == other.id
+    }
+
+    override fun hashCode(): Int {
+        return id?.hashCode() ?: 0
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/question/storage/FixedQuestionRepositoryImpl.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/question/storage/FixedQuestionRepositoryImpl.kt
@@ -1,0 +1,19 @@
+package com.yourssu.scouter.recruiting.question.storage
+
+import com.yourssu.scouter.recruiting.question.implement.FixedQuestion
+import com.yourssu.scouter.recruiting.question.implement.FixedQuestionRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+class FixedQuestionRepositoryImpl(
+    private val jpaFixedQuestionRepository: JpaFixedQuestionRepository,
+) : FixedQuestionRepository {
+
+    override fun findAll(): List<FixedQuestion> {
+        return jpaFixedQuestionRepository.findAll().map { it.toDomain() }
+    }
+
+    override fun findAllByIdIn(ids: Collection<Long>): List<FixedQuestion> {
+        return jpaFixedQuestionRepository.findAllByIdIn(ids).map { it.toDomain() }
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/question/storage/JpaFixedQuestionRepository.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/question/storage/JpaFixedQuestionRepository.kt
@@ -1,0 +1,8 @@
+package com.yourssu.scouter.recruiting.question.storage
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface JpaFixedQuestionRepository : JpaRepository<FixedQuestionEntity, Long> {
+
+    fun findAllByIdIn(ids: Collection<Long>): List<FixedQuestionEntity>
+}

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/question/storage/JpaQuestionnaireQuestionRepository.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/question/storage/JpaQuestionnaireQuestionRepository.kt
@@ -1,0 +1,10 @@
+package com.yourssu.scouter.recruiting.question.storage
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface JpaQuestionnaireQuestionRepository : JpaRepository<QuestionnaireQuestionEntity, Long> {
+
+    fun findAllByQuestionnaireId(questionnaireId: Long): List<QuestionnaireQuestionEntity>
+
+    fun deleteAllByQuestionnaireId(questionnaireId: Long)
+}

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/question/storage/JpaQuestionnaireRepository.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/question/storage/JpaQuestionnaireRepository.kt
@@ -1,0 +1,5 @@
+package com.yourssu.scouter.recruiting.question.storage
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface JpaQuestionnaireRepository : JpaRepository<QuestionnaireEntity, Long>

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/question/storage/QuestionnaireEntity.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/question/storage/QuestionnaireEntity.kt
@@ -1,0 +1,25 @@
+package com.yourssu.scouter.recruiting.question.storage
+
+import com.yourssu.scouter.recruiting.question.implement.Questionnaire
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+
+@Entity
+@Table(name = "questionnaire")
+class QuestionnaireEntity(
+
+    @Id
+    @Column(name = "applicant_id")
+    val applicantId: Long,
+
+    @Column(name = "assigned_interviewer_user_id", nullable = false)
+    val assignedInterviewerUserId: Long,
+) {
+
+    fun toDomain(): Questionnaire = Questionnaire(
+        applicantId = applicantId,
+        assignedInterviewerUserId = assignedInterviewerUserId,
+    )
+}

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/question/storage/QuestionnaireQuestionEntity.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/question/storage/QuestionnaireQuestionEntity.kt
@@ -1,0 +1,60 @@
+package com.yourssu.scouter.recruiting.question.storage
+
+import com.yourssu.scouter.recruiting.question.implement.QuestionGroup
+import com.yourssu.scouter.recruiting.question.implement.QuestionnaireQuestion
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+
+@Entity
+@Table(name = "questionnaire_question")
+class QuestionnaireQuestionEntity(
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long? = null,
+
+    @Column(name = "questionnaire_id", nullable = false)
+    val questionnaireId: Long,
+
+    @Column(name = "question_group", nullable = false)
+    @Enumerated(EnumType.STRING)
+    val group: QuestionGroup,
+
+    @Column(name = "source_question_id")
+    val sourceQuestionId: Long?,
+
+    @Column(columnDefinition = "TEXT")
+    val content: String?,
+
+    @Column(nullable = false)
+    val sortOrder: Int,
+) {
+
+    fun toDomain(): QuestionnaireQuestion = QuestionnaireQuestion(
+        id = id,
+        questionnaireId = questionnaireId,
+        group = group,
+        sourceQuestionId = sourceQuestionId,
+        content = content,
+        sortOrder = sortOrder,
+    )
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as QuestionnaireQuestionEntity
+
+        return id == other.id
+    }
+
+    override fun hashCode(): Int {
+        return id?.hashCode() ?: 0
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/question/storage/QuestionnaireQuestionEntity.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/question/storage/QuestionnaireQuestionEntity.kt
@@ -44,17 +44,4 @@ class QuestionnaireQuestionEntity(
         content = content,
         sortOrder = sortOrder,
     )
-
-    override fun equals(other: Any?): Boolean {
-        if (this === other) return true
-        if (javaClass != other?.javaClass) return false
-
-        other as QuestionnaireQuestionEntity
-
-        return id == other.id
-    }
-
-    override fun hashCode(): Int {
-        return id?.hashCode() ?: 0
-    }
 }

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/question/storage/QuestionnaireQuestionRepositoryImpl.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/question/storage/QuestionnaireQuestionRepositoryImpl.kt
@@ -1,0 +1,31 @@
+package com.yourssu.scouter.recruiting.question.storage
+
+import com.yourssu.scouter.recruiting.question.implement.QuestionnaireQuestion
+import com.yourssu.scouter.recruiting.question.implement.QuestionnaireQuestionRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+class QuestionnaireQuestionRepositoryImpl(
+    private val jpaQuestionnaireQuestionRepository: JpaQuestionnaireQuestionRepository,
+) : QuestionnaireQuestionRepository {
+
+    override fun findAllByQuestionnaireId(questionnaireId: Long): List<QuestionnaireQuestion> {
+        return jpaQuestionnaireQuestionRepository.findAllByQuestionnaireId(questionnaireId).map { it.toDomain() }
+    }
+
+    override fun replaceAll(questionnaireId: Long, questions: List<QuestionnaireQuestion>): List<QuestionnaireQuestion> {
+        jpaQuestionnaireQuestionRepository.deleteAllByQuestionnaireId(questionnaireId)
+
+        val entities = questions.map { question ->
+            QuestionnaireQuestionEntity(
+                questionnaireId = questionnaireId,
+                group = question.group,
+                sourceQuestionId = question.sourceQuestionId,
+                content = question.content,
+                sortOrder = question.sortOrder,
+            )
+        }
+
+        return jpaQuestionnaireQuestionRepository.saveAll(entities).map { it.toDomain() }
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/question/storage/QuestionnaireRepositoryImpl.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/question/storage/QuestionnaireRepositoryImpl.kt
@@ -1,0 +1,25 @@
+package com.yourssu.scouter.recruiting.question.storage
+
+import com.yourssu.scouter.recruiting.question.implement.Questionnaire
+import com.yourssu.scouter.recruiting.question.implement.QuestionnaireRepository
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Repository
+
+@Repository
+class QuestionnaireRepositoryImpl(
+    private val jpaQuestionnaireRepository: JpaQuestionnaireRepository,
+) : QuestionnaireRepository {
+
+    override fun findByApplicantId(applicantId: Long): Questionnaire? {
+        return jpaQuestionnaireRepository.findByIdOrNull(applicantId)?.toDomain()
+    }
+
+    override fun upsert(questionnaire: Questionnaire): Questionnaire {
+        val entity = QuestionnaireEntity(
+            applicantId = questionnaire.applicantId,
+            assignedInterviewerUserId = questionnaire.assignedInterviewerUserId,
+        )
+
+        return jpaQuestionnaireRepository.save(entity).toDomain()
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/support/implement/exception/FixedQuestionNotFoundException.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/support/implement/exception/FixedQuestionNotFoundException.kt
@@ -1,0 +1,8 @@
+package com.yourssu.scouter.recruiting.support.implement.exception
+
+import com.yourssu.scouter.common.support.implement.exception.CustomException
+import org.springframework.http.HttpStatus
+
+class FixedQuestionNotFoundException(
+    message: String,
+) : CustomException(message, "Question-001", HttpStatus.NOT_FOUND)

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/support/implement/exception/QuestionnaireGroupInvalidException.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/support/implement/exception/QuestionnaireGroupInvalidException.kt
@@ -1,0 +1,8 @@
+package com.yourssu.scouter.recruiting.support.implement.exception
+
+import com.yourssu.scouter.common.support.implement.exception.CustomException
+import org.springframework.http.HttpStatus
+
+class QuestionnaireGroupInvalidException(
+    message: String,
+) : CustomException(message, "Question-002", HttpStatus.BAD_REQUEST)

--- a/src/main/resources/db/migration/V29__create_fixed_question_table.sql
+++ b/src/main/resources/db/migration/V29__create_fixed_question_table.sql
@@ -1,0 +1,13 @@
+CREATE TABLE fixed_question (
+    id         BIGINT AUTO_INCREMENT PRIMARY KEY,
+    category   VARCHAR(20) NOT NULL,
+    content    TEXT        NOT NULL,
+    sort_order INT         NOT NULL
+);
+
+INSERT INTO fixed_question (category, content, sort_order) VALUES
+    ('REQUIRED', '자기소개를 해주세요.', 1),
+    ('REQUIRED', '지원 동기를 말씀해주세요.', 2),
+    ('CULTURE_FIT', '유어슈에서 가장 기대되는 활동은 무엇인가요?', 1),
+    ('CULTURE_FIT', '팀 활동 중 갈등을 해결했던 경험이 있나요?', 2),
+    ('CLOSING', '마지막으로 하고 싶은 말이 있나요?', 1);

--- a/src/main/resources/db/migration/V30__create_questionnaire_tables.sql
+++ b/src/main/resources/db/migration/V30__create_questionnaire_tables.sql
@@ -1,0 +1,21 @@
+CREATE TABLE questionnaire (
+    applicant_id                 BIGINT PRIMARY KEY,
+    assigned_interviewer_user_id BIGINT NOT NULL,
+    CONSTRAINT fk_questionnaire_applicant
+        FOREIGN KEY (applicant_id) REFERENCES applicant (id) ON DELETE CASCADE,
+    CONSTRAINT fk_questionnaire_assigned_interviewer
+        FOREIGN KEY (assigned_interviewer_user_id) REFERENCES users (id)
+);
+
+CREATE TABLE questionnaire_question (
+    id                 BIGINT AUTO_INCREMENT PRIMARY KEY,
+    questionnaire_id   BIGINT      NOT NULL,
+    question_group     VARCHAR(20) NOT NULL,
+    source_question_id BIGINT      NULL,
+    content            TEXT        NULL,
+    sort_order         INT         NOT NULL,
+    CONSTRAINT fk_questionnaire_question_questionnaire
+        FOREIGN KEY (questionnaire_id) REFERENCES questionnaire (applicant_id) ON DELETE CASCADE,
+    CONSTRAINT fk_questionnaire_question_source_question
+        FOREIGN KEY (source_question_id) REFERENCES fixed_question (id)
+);

--- a/src/test/kotlin/com/yourssu/scouter/recruiting/question/business/QuestionnaireServiceTest.kt
+++ b/src/test/kotlin/com/yourssu/scouter/recruiting/question/business/QuestionnaireServiceTest.kt
@@ -1,0 +1,181 @@
+package com.yourssu.scouter.recruiting.question.business
+
+import com.yourssu.scouter.auth.authentication.implement.OAuth2Type
+import com.yourssu.scouter.auth.support.implement.exception.UserNotFoundException
+import com.yourssu.scouter.auth.user.implement.TokenInfo
+import com.yourssu.scouter.auth.user.implement.User
+import com.yourssu.scouter.auth.user.implement.UserInfo
+import com.yourssu.scouter.auth.user.implement.UserReader
+import com.yourssu.scouter.recruiting.applicant.implement.ApplicantReader
+import com.yourssu.scouter.recruiting.applicant.implement.fixture.ApplicantFixtureBuilder
+import com.yourssu.scouter.recruiting.question.business.dto.SaveQuestionnaireCommand
+import com.yourssu.scouter.recruiting.question.business.dto.SaveQuestionnaireQuestionCommand
+import com.yourssu.scouter.recruiting.question.implement.FixedQuestion
+import com.yourssu.scouter.recruiting.question.implement.FixedQuestionCategory
+import com.yourssu.scouter.recruiting.question.implement.FixedQuestionReader
+import com.yourssu.scouter.recruiting.question.implement.QuestionGroup
+import com.yourssu.scouter.recruiting.question.implement.Questionnaire
+import com.yourssu.scouter.recruiting.question.implement.QuestionnaireQuestion
+import com.yourssu.scouter.recruiting.question.implement.QuestionnaireValidator
+import com.yourssu.scouter.recruiting.question.implement.QuestionnaireReader
+import com.yourssu.scouter.recruiting.question.implement.QuestionnaireWriter
+import com.yourssu.scouter.recruiting.support.implement.exception.ApplicantNotFoundException
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.mockito.kotlin.any
+import org.mockito.kotlin.whenever
+import java.time.Instant
+
+@Suppress("NonAsciiCharacters")
+class QuestionnaireServiceTest {
+
+    private lateinit var questionnaireReader: QuestionnaireReader
+    private lateinit var questionnaireWriter: QuestionnaireWriter
+    private lateinit var fixedQuestionReader: FixedQuestionReader
+    private lateinit var applicantReader: ApplicantReader
+    private lateinit var userReader: UserReader
+    private lateinit var questionnaireService: QuestionnaireService
+
+    private val applicantId = 1L
+    private val interviewerUserId = 10L
+
+    // 검증 로직 자체는 QuestionnaireValidatorTest/QuestionnaireQuestionTest에서 다루므로, 여기서는 순수 로직을 그대로 사용한다.
+    private val questionnaireValidator = QuestionnaireValidator()
+
+    private fun user(id: Long) = User(
+        id = id,
+        userInfo = UserInfo(
+            name = "면접관",
+            email = "interviewer@example.com",
+            profileImageUrl = "https://example.com/profile.png",
+            oauthId = "oauth-$id",
+            oauth2Type = OAuth2Type.GOOGLE,
+        ),
+        tokenInfo = TokenInfo(
+            tokenPrefix = "Bearer",
+            accessToken = "access-token",
+            refreshToken = "refresh-token",
+            accessTokenExpirationDateTime = Instant.now().plusSeconds(3600),
+        ),
+    )
+
+    private fun cultureFitFixed(sourceQuestionId: Long) = SaveQuestionnaireQuestionCommand(
+        group = QuestionGroup.CULTURE_FIT,
+        sourceQuestionId = sourceQuestionId,
+        content = null,
+    )
+
+    private fun freeQuestion(group: QuestionGroup, content: String?) = SaveQuestionnaireQuestionCommand(
+        group = group,
+        sourceQuestionId = null,
+        content = content,
+    )
+
+    @BeforeEach
+    fun setUp() {
+        questionnaireReader = mock(QuestionnaireReader::class.java)
+        questionnaireWriter = mock(QuestionnaireWriter::class.java)
+        fixedQuestionReader = mock(FixedQuestionReader::class.java)
+        applicantReader = mock(ApplicantReader::class.java)
+        userReader = mock(UserReader::class.java)
+
+        questionnaireService = QuestionnaireService(
+            questionnaireReader,
+            questionnaireWriter,
+            fixedQuestionReader,
+            questionnaireValidator,
+            applicantReader,
+            userReader,
+        )
+
+        whenever(applicantReader.readById(applicantId)).thenReturn(ApplicantFixtureBuilder().id(applicantId).build())
+        whenever(userReader.readById(interviewerUserId)).thenReturn(user(interviewerUserId))
+    }
+
+    @Nested
+    @DisplayName("readByApplicantId 메서드는")
+    inner class ReadByApplicantIdTests {
+
+        @Test
+        fun `존재하지 않는 지원자면 예외를 발생시킨다`() {
+            whenever(applicantReader.readById(999L)).thenThrow(ApplicantNotFoundException("지정한 지원자를 찾을 수 없습니다."))
+
+            assertThatThrownBy { questionnaireService.readByApplicantId(999L) }
+                .isInstanceOf(ApplicantNotFoundException::class.java)
+        }
+
+        @Test
+        fun `아직 질문지가 없으면 빈 응답을 반환한다`() {
+            whenever(questionnaireReader.readByApplicantId(applicantId)).thenReturn(null)
+            whenever(questionnaireReader.readQuestionsByApplicantId(applicantId)).thenReturn(emptyList())
+            whenever(fixedQuestionReader.readAllByIdIn(any())).thenReturn(emptyList())
+
+            val result = questionnaireService.readByApplicantId(applicantId)
+
+            assertThat(result.assignedInterviewerUserId).isNull()
+            assertThat(result.questions).isEmpty()
+        }
+    }
+
+    @Nested
+    @DisplayName("upsert 메서드는")
+    inner class UpsertTests {
+
+        @Test
+        fun `존재하지 않는 면접관이면 예외를 발생시킨다`() {
+            whenever(userReader.readById(999L)).thenThrow(UserNotFoundException("지정한 사용자를 찾을 수 없습니다."))
+            val command = SaveQuestionnaireCommand(
+                assignedInterviewerUserId = 999L,
+                questions = listOf(cultureFitFixed(1L), cultureFitFixed(2L)),
+            )
+
+            assertThatThrownBy { questionnaireService.upsert(applicantId, command) }
+                .isInstanceOf(UserNotFoundException::class.java)
+        }
+
+        @Test
+        fun `검증에 실패하면 저장하지 않고 예외를 전파한다`() {
+            whenever(fixedQuestionReader.readAllByIdIn(any())).thenReturn(emptyList())
+            val command = SaveQuestionnaireCommand(
+                assignedInterviewerUserId = interviewerUserId,
+                questions = listOf(cultureFitFixed(1L)),
+            )
+
+            assertThatThrownBy { questionnaireService.upsert(applicantId, command) }
+                .isInstanceOf(RuntimeException::class.java)
+        }
+
+        @Test
+        fun `검증을 통과하면 질문지를 저장하고 결과를 반환한다`() {
+            val fixedQuestions = listOf(
+                FixedQuestion(1L, FixedQuestionCategory.CULTURE_FIT, "고정질문1", 1),
+                FixedQuestion(2L, FixedQuestionCategory.CULTURE_FIT, "고정질문2", 2),
+            )
+            whenever(fixedQuestionReader.readAllByIdIn(any())).thenReturn(fixedQuestions)
+
+            val command = SaveQuestionnaireCommand(
+                assignedInterviewerUserId = interviewerUserId,
+                questions = listOf(cultureFitFixed(1L), cultureFitFixed(2L), freeQuestion(QuestionGroup.PERSONAL, "자유 문항")),
+            )
+
+            val savedQuestions = listOf(
+                QuestionnaireQuestion(1L, applicantId, QuestionGroup.CULTURE_FIT, 1L, null, 0),
+                QuestionnaireQuestion(2L, applicantId, QuestionGroup.CULTURE_FIT, 2L, null, 1),
+                QuestionnaireQuestion(3L, applicantId, QuestionGroup.PERSONAL, null, "자유 문항", 2),
+            )
+            whenever(questionnaireWriter.upsert(any<Questionnaire>(), any())).thenReturn(savedQuestions)
+
+            val result = questionnaireService.upsert(applicantId, command)
+
+            assertThat(result.assignedInterviewerUserId).isEqualTo(interviewerUserId)
+            assertThat(result.questions).hasSize(3)
+            assertThat(result.questions[0].content).isEqualTo("고정질문1")
+            assertThat(result.questions[2].content).isEqualTo("자유 문항")
+        }
+    }
+}

--- a/src/test/kotlin/com/yourssu/scouter/recruiting/question/implement/QuestionnaireQuestionTest.kt
+++ b/src/test/kotlin/com/yourssu/scouter/recruiting/question/implement/QuestionnaireQuestionTest.kt
@@ -1,0 +1,64 @@
+package com.yourssu.scouter.recruiting.question.implement
+
+import com.yourssu.scouter.recruiting.support.implement.exception.QuestionnaireGroupInvalidException
+import org.assertj.core.api.Assertions.assertThatCode
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+
+@Suppress("NonAsciiCharacters")
+class QuestionnaireQuestionTest {
+
+    private val applicantId = 1L
+
+    @Test
+    fun `고정 그룹 문항에 sourceQuestionId가 없으면 예외를 발생시킨다`() {
+        assertThatThrownBy {
+            QuestionnaireQuestion(
+                questionnaireId = applicantId,
+                group = QuestionGroup.CULTURE_FIT,
+                sourceQuestionId = null,
+                content = null,
+                sortOrder = 0,
+            )
+        }.isInstanceOf(QuestionnaireGroupInvalidException::class.java)
+    }
+
+    @Test
+    fun `자유 그룹 문항에 content가 없으면 예외를 발생시킨다`() {
+        assertThatThrownBy {
+            QuestionnaireQuestion(
+                questionnaireId = applicantId,
+                group = QuestionGroup.PERSONAL,
+                sourceQuestionId = null,
+                content = " ",
+                sortOrder = 0,
+            )
+        }.isInstanceOf(QuestionnaireGroupInvalidException::class.java)
+    }
+
+    @Test
+    fun `고정 그룹 문항에 sourceQuestionId가 있으면 정상 생성된다`() {
+        assertThatCode {
+            QuestionnaireQuestion(
+                questionnaireId = applicantId,
+                group = QuestionGroup.CULTURE_FIT,
+                sourceQuestionId = 1L,
+                content = null,
+                sortOrder = 0,
+            )
+        }.doesNotThrowAnyException()
+    }
+
+    @Test
+    fun `자유 그룹 문항에 content가 있으면 정상 생성된다`() {
+        assertThatCode {
+            QuestionnaireQuestion(
+                questionnaireId = applicantId,
+                group = QuestionGroup.PERSONAL,
+                sourceQuestionId = null,
+                content = "자유 문항",
+                sortOrder = 0,
+            )
+        }.doesNotThrowAnyException()
+    }
+}

--- a/src/test/kotlin/com/yourssu/scouter/recruiting/question/implement/QuestionnaireValidatorTest.kt
+++ b/src/test/kotlin/com/yourssu/scouter/recruiting/question/implement/QuestionnaireValidatorTest.kt
@@ -1,0 +1,72 @@
+package com.yourssu.scouter.recruiting.question.implement
+
+import com.yourssu.scouter.recruiting.support.implement.exception.FixedQuestionNotFoundException
+import com.yourssu.scouter.recruiting.support.implement.exception.QuestionnaireGroupInvalidException
+import org.assertj.core.api.Assertions.assertThatCode
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+
+@Suppress("NonAsciiCharacters")
+class QuestionnaireValidatorTest {
+
+    private val validator = QuestionnaireValidator()
+
+    private val applicantId = 1L
+
+    private fun cultureFitFixed(sourceQuestionId: Long) = QuestionnaireQuestion(
+        questionnaireId = applicantId,
+        group = QuestionGroup.CULTURE_FIT,
+        sourceQuestionId = sourceQuestionId,
+        content = null,
+        sortOrder = 0,
+    )
+
+    private fun freeQuestion(group: QuestionGroup, content: String) = QuestionnaireQuestion(
+        questionnaireId = applicantId,
+        group = group,
+        sourceQuestionId = null,
+        content = content,
+        sortOrder = 0,
+    )
+
+    @Test
+    fun `CULTURE_FIT 문항이 2개 미만이면 예외를 발생시킨다`() {
+        val fixedQuestionsById = mapOf<Long?, FixedQuestion>(
+            1L to FixedQuestion(1L, FixedQuestionCategory.CULTURE_FIT, "질문", 1),
+        )
+
+        assertThatThrownBy { validator.validate(listOf(cultureFitFixed(1L)), fixedQuestionsById) }
+            .isInstanceOf(QuestionnaireGroupInvalidException::class.java)
+    }
+
+    @Test
+    fun `존재하지 않는 고정 질문을 참조하면 예외를 발생시킨다`() {
+        val questions = listOf(cultureFitFixed(1L), cultureFitFixed(2L))
+
+        assertThatThrownBy { validator.validate(questions, emptyMap()) }
+            .isInstanceOf(FixedQuestionNotFoundException::class.java)
+    }
+
+    @Test
+    fun `고정 질문의 카테고리가 그룹과 다르면 예외를 발생시킨다`() {
+        val fixedQuestionsById = mapOf<Long?, FixedQuestion>(
+            1L to FixedQuestion(1L, FixedQuestionCategory.REQUIRED, "질문1", 1),
+            2L to FixedQuestion(2L, FixedQuestionCategory.CULTURE_FIT, "질문2", 1),
+        )
+        val questions = listOf(cultureFitFixed(1L), cultureFitFixed(2L))
+
+        assertThatThrownBy { validator.validate(questions, fixedQuestionsById) }
+            .isInstanceOf(QuestionnaireGroupInvalidException::class.java)
+    }
+
+    @Test
+    fun `모든 조건을 만족하면 예외 없이 통과한다`() {
+        val fixedQuestionsById = mapOf<Long?, FixedQuestion>(
+            1L to FixedQuestion(1L, FixedQuestionCategory.CULTURE_FIT, "질문1", 1),
+            2L to FixedQuestion(2L, FixedQuestionCategory.CULTURE_FIT, "질문2", 2),
+        )
+        val questions = listOf(cultureFitFixed(1L), cultureFitFixed(2L), freeQuestion(QuestionGroup.PERSONAL, "자유 문항"))
+
+        assertThatCode { validator.validate(questions, fixedQuestionsById) }.doesNotThrowAnyException()
+    }
+}

--- a/src/test/kotlin/com/yourssu/scouter/recruiting/question/storage/FixedQuestionRepositoryImplTest.kt
+++ b/src/test/kotlin/com/yourssu/scouter/recruiting/question/storage/FixedQuestionRepositoryImplTest.kt
@@ -1,0 +1,63 @@
+package com.yourssu.scouter.recruiting.question.storage
+
+import com.yourssu.scouter.recruiting.question.implement.FixedQuestionCategory
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager
+import org.springframework.context.annotation.Import
+
+@DataJpaTest
+@Import(FixedQuestionRepositoryImpl::class)
+@Suppress("NonAsciiCharacters")
+class FixedQuestionRepositoryImplTest {
+
+    @Autowired
+    lateinit var fixedQuestionRepositoryImpl: FixedQuestionRepositoryImpl
+
+    @Autowired
+    lateinit var entityManager: TestEntityManager
+
+    private var requiredQuestionId: Long = 0
+    private var cultureFitQuestionId: Long = 0
+
+    @BeforeEach
+    fun setUp() {
+        val required = entityManager.persist(
+            FixedQuestionEntity(category = FixedQuestionCategory.REQUIRED, content = "자기소개를 해주세요.", sortOrder = 1),
+        )
+        val cultureFit = entityManager.persist(
+            FixedQuestionEntity(category = FixedQuestionCategory.CULTURE_FIT, content = "협업 경험을 말씀해주세요.", sortOrder = 1),
+        )
+        requiredQuestionId = required.id!!
+        cultureFitQuestionId = cultureFit.id!!
+
+        entityManager.flush()
+        entityManager.clear()
+    }
+
+    @Test
+    fun `저장된 고정 질문 전체를 조회한다`() {
+        val result = fixedQuestionRepositoryImpl.findAll()
+
+        assertThat(result).hasSize(2)
+        assertThat(result.map { it.content }).containsExactlyInAnyOrder("자기소개를 해주세요.", "협업 경험을 말씀해주세요.")
+    }
+
+    @Test
+    fun `id 목록으로 고정 질문을 조회한다`() {
+        val result = fixedQuestionRepositoryImpl.findAllByIdIn(listOf(requiredQuestionId))
+
+        assertThat(result).hasSize(1)
+        assertThat(result[0].category).isEqualTo(FixedQuestionCategory.REQUIRED)
+    }
+
+    @Test
+    fun `존재하지 않는 id 목록으로 조회하면 빈 리스트를 반환한다`() {
+        val result = fixedQuestionRepositoryImpl.findAllByIdIn(listOf(99999L))
+
+        assertThat(result).isEmpty()
+    }
+}

--- a/src/test/kotlin/com/yourssu/scouter/recruiting/question/storage/QuestionnaireRepositoryImplTest.kt
+++ b/src/test/kotlin/com/yourssu/scouter/recruiting/question/storage/QuestionnaireRepositoryImplTest.kt
@@ -1,0 +1,125 @@
+package com.yourssu.scouter.recruiting.question.storage
+
+import com.yourssu.scouter.auth.authentication.implement.OAuth2Type
+import com.yourssu.scouter.auth.user.storage.UserEntity
+import com.yourssu.scouter.common.division.storage.DivisionEntity
+import com.yourssu.scouter.common.part.storage.PartEntity
+import com.yourssu.scouter.common.semester.implement.Term
+import com.yourssu.scouter.common.semester.storage.SemesterEntity
+import com.yourssu.scouter.recruiting.applicant.implement.ApplicantState
+import com.yourssu.scouter.recruiting.applicant.storage.ApplicantEntity
+import com.yourssu.scouter.recruiting.question.implement.FixedQuestionCategory
+import com.yourssu.scouter.recruiting.question.implement.QuestionGroup
+import com.yourssu.scouter.recruiting.question.implement.Questionnaire
+import com.yourssu.scouter.recruiting.question.implement.QuestionnaireQuestion
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager
+import org.springframework.context.annotation.Import
+import java.time.Instant
+import java.time.Year
+
+@DataJpaTest
+@Import(QuestionnaireRepositoryImpl::class, QuestionnaireQuestionRepositoryImpl::class, FixedQuestionRepositoryImpl::class)
+@Suppress("NonAsciiCharacters")
+class QuestionnaireRepositoryImplTest {
+
+    @Autowired
+    lateinit var questionnaireRepositoryImpl: QuestionnaireRepositoryImpl
+
+    @Autowired
+    lateinit var questionnaireQuestionRepositoryImpl: QuestionnaireQuestionRepositoryImpl
+
+    @Autowired
+    lateinit var entityManager: TestEntityManager
+
+    private var applicantId: Long = 0
+    private var interviewerUserId: Long = 0
+    private var fixedQuestionId: Long = 0
+
+    @BeforeEach
+    fun setUp() {
+        val division = entityManager.persist(DivisionEntity(null, "개발", 1))
+        val part = entityManager.persist(PartEntity(null, division, "PM", 1))
+        val semester = entityManager.persist(SemesterEntity(null, Year.of(2025), Term.FALL))
+        val applicant = entityManager.persist(
+            ApplicantEntity(
+                id = null,
+                name = "지원자",
+                email = "applicant@example.com",
+                phoneNumber = "010-0000-0000",
+                age = "22",
+                department = "컴퓨터학부",
+                studentId = "202401002",
+                part = part,
+                state = ApplicantState.UNDER_REVIEW,
+                applicationDateTime = Instant.parse("2025-11-13T00:00:00Z"),
+                applicationSemester = semester,
+                academicSemester = "3-2",
+            ),
+        )
+        val interviewer = entityManager.persist(
+            UserEntity(
+                id = null,
+                name = "면접관",
+                email = "interviewer@example.com",
+                profileImageUrl = "",
+                oauthId = "oauth-interviewer",
+                oauth2Type = OAuth2Type.GOOGLE,
+                tokenPrefix = "Bearer",
+                accessToken = "dummy",
+                refreshToken = "dummy",
+                accessTokenExpirationDateTime = Instant.now().plusSeconds(3600),
+            ),
+        )
+        val fixedQuestion = entityManager.persist(
+            FixedQuestionEntity(category = FixedQuestionCategory.CULTURE_FIT, content = "협업 경험을 말씀해주세요.", sortOrder = 1),
+        )
+        applicantId = applicant.id!!
+        interviewerUserId = interviewer.id!!
+        fixedQuestionId = fixedQuestion.id!!
+
+        entityManager.flush()
+        entityManager.clear()
+    }
+
+    @Test
+    fun `질문지가 없으면 null을 반환한다`() {
+        val result = questionnaireRepositoryImpl.findByApplicantId(applicantId)
+
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `질문지를 처음 저장하면 조회할 수 있다`() {
+        questionnaireRepositoryImpl.upsert(Questionnaire(applicantId, interviewerUserId))
+
+        val found = questionnaireRepositoryImpl.findByApplicantId(applicantId)
+
+        assertThat(found).isNotNull
+        assertThat(found!!.assignedInterviewerUserId).isEqualTo(interviewerUserId)
+    }
+
+    @Test
+    fun `질문 목록을 전체 치환하면 이전 목록은 사라지고 새 목록만 남는다`() {
+        questionnaireRepositoryImpl.upsert(Questionnaire(applicantId, interviewerUserId))
+        questionnaireQuestionRepositoryImpl.replaceAll(
+            applicantId,
+            listOf(QuestionnaireQuestion(questionnaireId = applicantId, group = QuestionGroup.CULTURE_FIT, sourceQuestionId = fixedQuestionId, content = null, sortOrder = 0)),
+        )
+
+        val replaced = questionnaireQuestionRepositoryImpl.replaceAll(
+            applicantId,
+            listOf(QuestionnaireQuestion(questionnaireId = applicantId, group = QuestionGroup.PERSONAL, sourceQuestionId = null, content = "자유 문항", sortOrder = 0)),
+        )
+
+        val found = questionnaireQuestionRepositoryImpl.findAllByQuestionnaireId(applicantId)
+        assertThat(replaced).hasSize(1)
+        assertThat(found).hasSize(1)
+        assertThat(found[0].group).isEqualTo(QuestionGroup.PERSONAL)
+        assertThat(found[0].content).isEqualTo("자유 문항")
+    }
+}


### PR DESCRIPTION
## 📌 주요 변경 사항

이슈 #317 구현: 고정 질문 전역 풀 조회 API와 지원자별 면접 질문지 조회/수정 API.
문항 수정 잠금 정책([A1])은 이슈 본문대로 이번 범위에서 제외했습니다. 잠금이 참조할 `InterviewEvaluationItem`이 아직 develop에 없고(#341, `feat/319`가 머지되면 생김), 잠금은 그 이후 별도 이슈에서 처리합니다.

### 1. 마이그레이션
- V29: `fixed_question` 테이블 + 시드 데이터
- V30: `questionnaire`, `questionnaire_question` 테이블

### 2. 고정 질문 전역 풀 조회 API
- `GET /parts/{partId}/interviews/questions/fixed`

### 3. 면접 질문지 도메인
- `Questionnaire`/`QuestionnaireQuestion` 도메인 및 저장소
- 문항 단건 불변식(고정 그룹 sourceQuestionId 필수, 자유 그룹 content 필수)은 `QuestionnaireQuestion` 생성자에서 검증
- 집합 단위 검증(CULTURE_FIT 최소 2개, 고정 질문 카테고리 일치)은 `QuestionnaireValidator`에서 검증

### 4. 면접 질문지 조회/수정 API
- `GET/PUT /applicants/{applicantId}/interviews/questionnaires`
- PUT은 요청 바디 기준 전체 치환(delete + recreate) 방식

## 🧪 테스트 결과
`./gradlew test` 전체 통과 확인.

## 🙋🏻 참고 자료
- 이슈: #317
- 연관 PR: #341 (`feat/319`, 미머지 — 잠금 정책 후속 작업의 전제 조건)