### PR TITLE
[#318] 면접 메모 API 구현

### DIFF
--- a/src/main/kotlin/com/yourssu/scouter/recruiting/interview/application/InterviewMemoController.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/interview/application/InterviewMemoController.kt
@@ -1,0 +1,42 @@
+package com.yourssu.scouter.recruiting.interview.application
+
+import com.yourssu.scouter.recruiting.interview.application.dto.ReadInterviewMemoResponse
+import com.yourssu.scouter.recruiting.interview.application.dto.SaveInterviewMemoRequest
+import com.yourssu.scouter.recruiting.interview.business.InterviewMemoService
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.validation.Valid
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RestController
+
+@Tag(name = "면접 메모")
+@RestController
+class InterviewMemoController(
+    private val interviewMemoService: InterviewMemoService,
+) {
+
+    @Operation(summary = "지원자별 질문 메모 목록 조회")
+    @GetMapping("/applicants/{applicantId}/interviews/memos")
+    fun read(
+        @PathVariable applicantId: Long,
+    ): ResponseEntity<List<ReadInterviewMemoResponse>> {
+        val memos = interviewMemoService.readByApplicantId(applicantId)
+
+        return ResponseEntity.ok(memos.map(ReadInterviewMemoResponse::from))
+    }
+
+    @Operation(summary = "지원자별 질문 메모 일괄 수정", description = "요청 바디의 메모 목록으로 기존 메모를 전체 치환합니다.")
+    @PutMapping("/applicants/{applicantId}/interviews/memos")
+    fun upsert(
+        @PathVariable applicantId: Long,
+        @RequestBody @Valid requests: List<SaveInterviewMemoRequest>,
+    ): ResponseEntity<List<ReadInterviewMemoResponse>> {
+        val result = interviewMemoService.upsert(applicantId, requests.map { it.toCommand() })
+
+        return ResponseEntity.ok(result.map(ReadInterviewMemoResponse::from))
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/interview/application/dto/ReadInterviewMemoResponse.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/interview/application/dto/ReadInterviewMemoResponse.kt
@@ -1,0 +1,15 @@
+package com.yourssu.scouter.recruiting.interview.application.dto
+
+import com.yourssu.scouter.recruiting.interview.business.dto.InterviewMemoDto
+
+data class ReadInterviewMemoResponse(
+    val questionnaireQuestionId: Long,
+    val memo: String,
+) {
+    companion object {
+        fun from(dto: InterviewMemoDto): ReadInterviewMemoResponse = ReadInterviewMemoResponse(
+            questionnaireQuestionId = dto.questionnaireQuestionId,
+            memo = dto.memo,
+        )
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/interview/application/dto/SaveInterviewMemoRequest.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/interview/application/dto/SaveInterviewMemoRequest.kt
@@ -1,0 +1,18 @@
+package com.yourssu.scouter.recruiting.interview.application.dto
+
+import com.yourssu.scouter.recruiting.interview.business.dto.SaveInterviewMemoCommand
+import jakarta.validation.constraints.NotNull
+
+data class SaveInterviewMemoRequest(
+
+    @field:NotNull
+    val questionnaireQuestionId: Long?,
+
+    @field:NotNull
+    val memo: String?,
+) {
+    fun toCommand(): SaveInterviewMemoCommand = SaveInterviewMemoCommand(
+        questionnaireQuestionId = questionnaireQuestionId!!,
+        memo = memo!!,
+    )
+}

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/interview/business/InterviewMemoService.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/interview/business/InterviewMemoService.kt
@@ -1,0 +1,66 @@
+package com.yourssu.scouter.recruiting.interview.business
+
+import com.yourssu.scouter.recruiting.applicant.implement.ApplicantReader
+import com.yourssu.scouter.recruiting.interview.business.dto.InterviewMemoDto
+import com.yourssu.scouter.recruiting.interview.business.dto.SaveInterviewMemoCommand
+import com.yourssu.scouter.recruiting.interview.implement.InterviewMemo
+import com.yourssu.scouter.recruiting.interview.implement.InterviewMemoReader
+import com.yourssu.scouter.recruiting.interview.implement.InterviewMemoWriter
+import com.yourssu.scouter.recruiting.question.implement.QuestionnaireReader
+import com.yourssu.scouter.recruiting.support.implement.exception.QuestionnaireQuestionNotFoundException
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class InterviewMemoService(
+    private val applicantReader: ApplicantReader,
+    private val questionnaireReader: QuestionnaireReader,
+    private val interviewMemoReader: InterviewMemoReader,
+    private val interviewMemoWriter: InterviewMemoWriter,
+) {
+
+    fun readByApplicantId(applicantId: Long): List<InterviewMemoDto> {
+        applicantReader.readById(applicantId)
+
+        val questionIds = readQuestionnaireQuestionIds(applicantId)
+        val memosByQuestionId = interviewMemoReader
+            .readAllByQuestionnaireQuestionIdIn(questionIds)
+            .associateBy { it.questionnaireQuestionId }
+
+        return questionIds.map { questionId ->
+            InterviewMemoDto(
+                questionnaireQuestionId = questionId,
+                memo = memosByQuestionId[questionId]?.memo.orEmpty(),
+            )
+        }
+    }
+
+    @Transactional
+    fun upsert(applicantId: Long, commands: List<SaveInterviewMemoCommand>): List<InterviewMemoDto> {
+        applicantReader.readById(applicantId)
+
+        val questionIds = readQuestionnaireQuestionIds(applicantId).toSet()
+        commands.forEach { command ->
+            if (command.questionnaireQuestionId !in questionIds) {
+                throw QuestionnaireQuestionNotFoundException("해당 지원자의 질문지에 존재하지 않는 문항입니다: ${command.questionnaireQuestionId}")
+            }
+        }
+
+        val memos = commands.map { command ->
+            InterviewMemo(
+                questionnaireQuestionId = command.questionnaireQuestionId,
+                memo = command.memo,
+            )
+        }
+        val saved = interviewMemoWriter.replaceAll(questionIds.toList(), memos)
+
+        return saved.map { InterviewMemoDto(questionnaireQuestionId = it.questionnaireQuestionId, memo = it.memo) }
+    }
+
+    private fun readQuestionnaireQuestionIds(applicantId: Long): List<Long> {
+        return questionnaireReader
+            .readQuestionsByApplicantId(applicantId)
+            .sortedBy { it.sortOrder }
+            .map { it.id!! }
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/interview/business/dto/InterviewMemoDto.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/interview/business/dto/InterviewMemoDto.kt
@@ -1,0 +1,6 @@
+package com.yourssu.scouter.recruiting.interview.business.dto
+
+data class InterviewMemoDto(
+    val questionnaireQuestionId: Long,
+    val memo: String,
+)

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/interview/business/dto/SaveInterviewMemoCommand.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/interview/business/dto/SaveInterviewMemoCommand.kt
@@ -1,0 +1,6 @@
+package com.yourssu.scouter.recruiting.interview.business.dto
+
+data class SaveInterviewMemoCommand(
+    val questionnaireQuestionId: Long,
+    val memo: String,
+)

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/interview/implement/InterviewMemo.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/interview/implement/InterviewMemo.kt
@@ -1,0 +1,7 @@
+package com.yourssu.scouter.recruiting.interview.implement
+
+class InterviewMemo(
+    val id: Long? = null,
+    val questionnaireQuestionId: Long,
+    val memo: String,
+)

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/interview/implement/InterviewMemoReader.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/interview/implement/InterviewMemoReader.kt
@@ -1,0 +1,15 @@
+package com.yourssu.scouter.recruiting.interview.implement
+
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+
+@Component
+@Transactional(readOnly = true)
+class InterviewMemoReader(
+    private val interviewMemoRepository: InterviewMemoRepository,
+) {
+
+    fun readAllByQuestionnaireQuestionIdIn(questionnaireQuestionIds: List<Long>): List<InterviewMemo> {
+        return interviewMemoRepository.findAllByQuestionnaireQuestionIdIn(questionnaireQuestionIds)
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/interview/implement/InterviewMemoRepository.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/interview/implement/InterviewMemoRepository.kt
@@ -1,0 +1,8 @@
+package com.yourssu.scouter.recruiting.interview.implement
+
+interface InterviewMemoRepository {
+
+    fun findAllByQuestionnaireQuestionIdIn(questionnaireQuestionIds: List<Long>): List<InterviewMemo>
+
+    fun replaceAll(questionnaireQuestionIds: List<Long>, memos: List<InterviewMemo>): List<InterviewMemo>
+}

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/interview/implement/InterviewMemoWriter.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/interview/implement/InterviewMemoWriter.kt
@@ -1,0 +1,15 @@
+package com.yourssu.scouter.recruiting.interview.implement
+
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+
+@Component
+@Transactional
+class InterviewMemoWriter(
+    private val interviewMemoRepository: InterviewMemoRepository,
+) {
+
+    fun replaceAll(questionnaireQuestionIds: List<Long>, memos: List<InterviewMemo>): List<InterviewMemo> {
+        return interviewMemoRepository.replaceAll(questionnaireQuestionIds, memos)
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/interview/storage/InterviewMemoEntity.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/interview/storage/InterviewMemoEntity.kt
@@ -1,0 +1,31 @@
+package com.yourssu.scouter.recruiting.interview.storage
+
+import com.yourssu.scouter.recruiting.interview.implement.InterviewMemo
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+
+@Entity
+@Table(name = "interview_memo")
+class InterviewMemoEntity(
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long? = null,
+
+    @Column(name = "questionnaire_question_id", nullable = false)
+    val questionnaireQuestionId: Long,
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    val memo: String,
+) {
+
+    fun toDomain(): InterviewMemo = InterviewMemo(
+        id = id,
+        questionnaireQuestionId = questionnaireQuestionId,
+        memo = memo,
+    )
+}

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/interview/storage/InterviewMemoRepositoryImpl.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/interview/storage/InterviewMemoRepositoryImpl.kt
@@ -1,0 +1,28 @@
+package com.yourssu.scouter.recruiting.interview.storage
+
+import com.yourssu.scouter.recruiting.interview.implement.InterviewMemo
+import com.yourssu.scouter.recruiting.interview.implement.InterviewMemoRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+class InterviewMemoRepositoryImpl(
+    private val jpaInterviewMemoRepository: JpaInterviewMemoRepository,
+) : InterviewMemoRepository {
+
+    override fun findAllByQuestionnaireQuestionIdIn(questionnaireQuestionIds: List<Long>): List<InterviewMemo> {
+        return jpaInterviewMemoRepository.findAllByQuestionnaireQuestionIdIn(questionnaireQuestionIds).map { it.toDomain() }
+    }
+
+    override fun replaceAll(questionnaireQuestionIds: List<Long>, memos: List<InterviewMemo>): List<InterviewMemo> {
+        jpaInterviewMemoRepository.deleteAllByQuestionnaireQuestionIdIn(questionnaireQuestionIds)
+
+        val entities = memos.map { memo ->
+            InterviewMemoEntity(
+                questionnaireQuestionId = memo.questionnaireQuestionId,
+                memo = memo.memo,
+            )
+        }
+
+        return jpaInterviewMemoRepository.saveAll(entities).map { it.toDomain() }
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/interview/storage/JpaInterviewMemoRepository.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/interview/storage/JpaInterviewMemoRepository.kt
@@ -1,0 +1,10 @@
+package com.yourssu.scouter.recruiting.interview.storage
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface JpaInterviewMemoRepository : JpaRepository<InterviewMemoEntity, Long> {
+
+    fun findAllByQuestionnaireQuestionIdIn(questionnaireQuestionIds: List<Long>): List<InterviewMemoEntity>
+
+    fun deleteAllByQuestionnaireQuestionIdIn(questionnaireQuestionIds: List<Long>)
+}

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/support/implement/exception/QuestionnaireQuestionNotFoundException.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/support/implement/exception/QuestionnaireQuestionNotFoundException.kt
@@ -1,0 +1,8 @@
+package com.yourssu.scouter.recruiting.support.implement.exception
+
+import com.yourssu.scouter.common.support.implement.exception.CustomException
+import org.springframework.http.HttpStatus
+
+class QuestionnaireQuestionNotFoundException(
+    message: String,
+) : CustomException(message, "Question-003", HttpStatus.NOT_FOUND)

--- a/src/main/resources/db/migration/V32__create_interview_memo_table.sql
+++ b/src/main/resources/db/migration/V32__create_interview_memo_table.sql
@@ -1,0 +1,9 @@
+CREATE TABLE interview_memo (
+    id                         BIGINT AUTO_INCREMENT PRIMARY KEY,
+    questionnaire_question_id  BIGINT NOT NULL,
+    memo                       TEXT   NOT NULL,
+    CONSTRAINT uq_interview_memo_questionnaire_question
+        UNIQUE (questionnaire_question_id),
+    CONSTRAINT fk_interview_memo_questionnaire_question
+        FOREIGN KEY (questionnaire_question_id) REFERENCES questionnaire_question (id) ON DELETE CASCADE
+);

--- a/src/test/kotlin/com/yourssu/scouter/recruiting/interview/business/InterviewMemoServiceTest.kt
+++ b/src/test/kotlin/com/yourssu/scouter/recruiting/interview/business/InterviewMemoServiceTest.kt
@@ -1,0 +1,127 @@
+package com.yourssu.scouter.recruiting.interview.business
+
+import com.yourssu.scouter.recruiting.applicant.implement.ApplicantReader
+import com.yourssu.scouter.recruiting.applicant.implement.fixture.ApplicantFixtureBuilder
+import com.yourssu.scouter.recruiting.interview.business.dto.SaveInterviewMemoCommand
+import com.yourssu.scouter.recruiting.interview.implement.InterviewMemo
+import com.yourssu.scouter.recruiting.interview.implement.InterviewMemoReader
+import com.yourssu.scouter.recruiting.interview.implement.InterviewMemoWriter
+import com.yourssu.scouter.recruiting.question.implement.QuestionGroup
+import com.yourssu.scouter.recruiting.question.implement.QuestionnaireQuestion
+import com.yourssu.scouter.recruiting.question.implement.QuestionnaireReader
+import com.yourssu.scouter.recruiting.support.implement.exception.ApplicantNotFoundException
+import com.yourssu.scouter.recruiting.support.implement.exception.QuestionnaireQuestionNotFoundException
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.mockito.kotlin.any
+import org.mockito.kotlin.whenever
+
+@Suppress("NonAsciiCharacters")
+class InterviewMemoServiceTest {
+
+    private lateinit var applicantReader: ApplicantReader
+    private lateinit var questionnaireReader: QuestionnaireReader
+    private lateinit var interviewMemoReader: InterviewMemoReader
+    private lateinit var interviewMemoWriter: InterviewMemoWriter
+    private lateinit var interviewMemoService: InterviewMemoService
+
+    private val applicantId = 1L
+
+    private fun question(id: Long, sortOrder: Int) = QuestionnaireQuestion(
+        id = id,
+        questionnaireId = applicantId,
+        group = QuestionGroup.PERSONAL,
+        sourceQuestionId = null,
+        content = "질문 $id",
+        sortOrder = sortOrder,
+    )
+
+    @BeforeEach
+    fun setUp() {
+        applicantReader = mock(ApplicantReader::class.java)
+        questionnaireReader = mock(QuestionnaireReader::class.java)
+        interviewMemoReader = mock(InterviewMemoReader::class.java)
+        interviewMemoWriter = mock(InterviewMemoWriter::class.java)
+
+        interviewMemoService = InterviewMemoService(
+            applicantReader,
+            questionnaireReader,
+            interviewMemoReader,
+            interviewMemoWriter,
+        )
+
+        whenever(applicantReader.readById(applicantId)).thenReturn(ApplicantFixtureBuilder().id(applicantId).build())
+    }
+
+    @Nested
+    @DisplayName("readByApplicantId 메서드는")
+    inner class ReadByApplicantIdTests {
+
+        @Test
+        fun `존재하지 않는 지원자면 예외를 발생시킨다`() {
+            whenever(applicantReader.readById(999L)).thenThrow(ApplicantNotFoundException("지정한 지원자를 찾을 수 없습니다."))
+
+            assertThatThrownBy { interviewMemoService.readByApplicantId(999L) }
+                .isInstanceOf(ApplicantNotFoundException::class.java)
+        }
+
+        @Test
+        fun `메모가 없는 질문은 빈 문자열을 반환한다`() {
+            whenever(questionnaireReader.readQuestionsByApplicantId(applicantId))
+                .thenReturn(listOf(question(1L, 0), question(2L, 1)))
+            whenever(interviewMemoReader.readAllByQuestionnaireQuestionIdIn(listOf(1L, 2L)))
+                .thenReturn(listOf(InterviewMemo(id = 10L, questionnaireQuestionId = 1L, memo = "메모1")))
+
+            val result = interviewMemoService.readByApplicantId(applicantId)
+
+            assertThat(result).hasSize(2)
+            assertThat(result[0].questionnaireQuestionId).isEqualTo(1L)
+            assertThat(result[0].memo).isEqualTo("메모1")
+            assertThat(result[1].questionnaireQuestionId).isEqualTo(2L)
+            assertThat(result[1].memo).isEmpty()
+        }
+    }
+
+    @Nested
+    @DisplayName("upsert 메서드는")
+    inner class UpsertTests {
+
+        @Test
+        fun `해당 지원자의 질문지에 없는 문항이면 예외를 발생시킨다`() {
+            whenever(questionnaireReader.readQuestionsByApplicantId(applicantId))
+                .thenReturn(listOf(question(1L, 0)))
+
+            val commands = listOf(SaveInterviewMemoCommand(questionnaireQuestionId = 999L, memo = "메모"))
+
+            assertThatThrownBy { interviewMemoService.upsert(applicantId, commands) }
+                .isInstanceOf(QuestionnaireQuestionNotFoundException::class.java)
+        }
+
+        @Test
+        fun `검증을 통과하면 메모를 전체 치환하고 결과를 반환한다`() {
+            whenever(questionnaireReader.readQuestionsByApplicantId(applicantId))
+                .thenReturn(listOf(question(1L, 0), question(2L, 1)))
+
+            val commands = listOf(
+                SaveInterviewMemoCommand(questionnaireQuestionId = 1L, memo = "메모1"),
+                SaveInterviewMemoCommand(questionnaireQuestionId = 2L, memo = "메모2"),
+            )
+            val saved = listOf(
+                InterviewMemo(id = 10L, questionnaireQuestionId = 1L, memo = "메모1"),
+                InterviewMemo(id = 11L, questionnaireQuestionId = 2L, memo = "메모2"),
+            )
+            whenever(interviewMemoWriter.replaceAll(any(), any())).thenReturn(saved)
+
+            val result = interviewMemoService.upsert(applicantId, commands)
+
+            assertThat(result).hasSize(2)
+            assertThat(result[0].memo).isEqualTo("메모1")
+            assertThat(result[1].memo).isEqualTo("메모2")
+        }
+    }
+}

--- a/src/test/kotlin/com/yourssu/scouter/recruiting/interview/storage/InterviewMemoRepositoryImplTest.kt
+++ b/src/test/kotlin/com/yourssu/scouter/recruiting/interview/storage/InterviewMemoRepositoryImplTest.kt
@@ -1,0 +1,129 @@
+package com.yourssu.scouter.recruiting.interview.storage
+
+import com.yourssu.scouter.auth.authentication.implement.OAuth2Type
+import com.yourssu.scouter.auth.user.storage.UserEntity
+import com.yourssu.scouter.common.division.storage.DivisionEntity
+import com.yourssu.scouter.common.part.storage.PartEntity
+import com.yourssu.scouter.common.semester.implement.Term
+import com.yourssu.scouter.common.semester.storage.SemesterEntity
+import com.yourssu.scouter.recruiting.applicant.implement.ApplicantState
+import com.yourssu.scouter.recruiting.applicant.storage.ApplicantEntity
+import com.yourssu.scouter.recruiting.interview.implement.InterviewMemo
+import com.yourssu.scouter.recruiting.question.implement.QuestionGroup
+import com.yourssu.scouter.recruiting.question.storage.QuestionnaireEntity
+import com.yourssu.scouter.recruiting.question.storage.QuestionnaireQuestionEntity
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager
+import org.springframework.context.annotation.Import
+import java.time.Instant
+import java.time.Year
+
+@DataJpaTest
+@Import(InterviewMemoRepositoryImpl::class)
+@Suppress("NonAsciiCharacters")
+class InterviewMemoRepositoryImplTest {
+
+    @Autowired
+    lateinit var interviewMemoRepositoryImpl: InterviewMemoRepositoryImpl
+
+    @Autowired
+    lateinit var entityManager: TestEntityManager
+
+    private var questionId1: Long = 0
+    private var questionId2: Long = 0
+
+    @BeforeEach
+    fun setUp() {
+        val division = entityManager.persist(DivisionEntity(null, "개발", 1))
+        val part = entityManager.persist(PartEntity(null, division, "PM", 1))
+        val semester = entityManager.persist(SemesterEntity(null, Year.of(2025), Term.FALL))
+        val applicant = entityManager.persist(
+            ApplicantEntity(
+                id = null,
+                name = "지원자",
+                email = "applicant@example.com",
+                phoneNumber = "010-0000-0000",
+                age = "22",
+                department = "컴퓨터학부",
+                studentId = "202401002",
+                part = part,
+                state = ApplicantState.UNDER_REVIEW,
+                applicationDateTime = Instant.parse("2025-11-13T00:00:00Z"),
+                applicationSemester = semester,
+                academicSemester = "3-2",
+            ),
+        )
+        val interviewer = entityManager.persist(
+            UserEntity(
+                id = null,
+                name = "면접관",
+                email = "interviewer@example.com",
+                profileImageUrl = "",
+                oauthId = "oauth-interviewer",
+                oauth2Type = OAuth2Type.GOOGLE,
+                tokenPrefix = "Bearer",
+                accessToken = "dummy",
+                refreshToken = "dummy",
+                accessTokenExpirationDateTime = Instant.now().plusSeconds(3600),
+            ),
+        )
+        entityManager.persist(
+            QuestionnaireEntity(applicantId = applicant.id!!, assignedInterviewerUserId = interviewer.id!!),
+        )
+        val question1 = entityManager.persist(
+            QuestionnaireQuestionEntity(
+                questionnaireId = applicant.id!!,
+                group = QuestionGroup.PERSONAL,
+                sourceQuestionId = null,
+                content = "질문1",
+                sortOrder = 0,
+            ),
+        )
+        val question2 = entityManager.persist(
+            QuestionnaireQuestionEntity(
+                questionnaireId = applicant.id!!,
+                group = QuestionGroup.PERSONAL,
+                sourceQuestionId = null,
+                content = "질문2",
+                sortOrder = 1,
+            ),
+        )
+        questionId1 = question1.id!!
+        questionId2 = question2.id!!
+
+        entityManager.flush()
+        entityManager.clear()
+    }
+
+    @Test
+    fun `메모가 없으면 빈 목록을 반환한다`() {
+        val result = interviewMemoRepositoryImpl.findAllByQuestionnaireQuestionIdIn(listOf(questionId1, questionId2))
+
+        assertThat(result).isEmpty()
+    }
+
+    @Test
+    fun `메모 목록을 전체 치환하면 이전 목록은 사라지고 새 목록만 남는다`() {
+        interviewMemoRepositoryImpl.replaceAll(
+            listOf(questionId1, questionId2),
+            listOf(InterviewMemo(questionnaireQuestionId = questionId1, memo = "이전 메모")),
+        )
+
+        val replaced = interviewMemoRepositoryImpl.replaceAll(
+            listOf(questionId1, questionId2),
+            listOf(
+                InterviewMemo(questionnaireQuestionId = questionId1, memo = "메모1"),
+                InterviewMemo(questionnaireQuestionId = questionId2, memo = "메모2"),
+            ),
+        )
+
+        val found = interviewMemoRepositoryImpl.findAllByQuestionnaireQuestionIdIn(listOf(questionId1, questionId2))
+        assertThat(replaced).hasSize(2)
+        assertThat(found).hasSize(2)
+        assertThat(found.map { it.memo }).containsExactlyInAnyOrder("메모1", "메모2")
+    }
+}


### PR DESCRIPTION
## 개요
closes #318

질문당 자유 메모 API를 구현합니다. 답변 기록/꼬리질문/체크포인트는 별도 필드 없이 memo 하나로 통합 관리합니다([C5]).

## 작업 내용
- `GET /applicants/{applicantId}/interviews/memos` — 질문별 메모 목록 조회
- `PUT /applicants/{applicantId}/interviews/memos` — 메모 일괄 수정(전체 치환)
- `InterviewMemo`는 `QuestionnaireQuestion`(고정 질문/질문지)을 참조합니다.
- 지원자의 질문지에 속하지 않는 `questionnaireQuestionId`로 수정을 시도하면 예외가 발생합니다.

## 커밋 구성
1. `feat`: 면접 메모 도메인 및 저장소(implement/storage) 구현 + 마이그레이션(V32)
2. `feat`: 면접 메모 조회/수정 API(business/application) 구현
3. `test`: 서비스/저장소 단위 테스트 추가

## 테스트
- [x] `./gradlew compileKotlin compileTestKotlin`
- [x] `./gradlew test` — 전체 328개 테스트 통과 (스킵 4, 실패 0)
- [x] `InterviewMemoServiceTest`, `InterviewMemoRepositoryImplTest` 포함 신규 테스트 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)