### PR TITLE
[#345] 질문지 설계 api 인터페이스 수정 

### DIFF
--- a/src/main/kotlin/com/yourssu/scouter/recruiting/applicant/application/dto/ReadApplicantResponse.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/applicant/application/dto/ReadApplicantResponse.kt
@@ -36,6 +36,8 @@ data class ReadApplicantResponse(
     val documentAverageScore: Double?,
 
     val interviewAverageScore: Double?,
+
+    val partId: Long,
 ) {
 
     companion object {
@@ -55,6 +57,7 @@ data class ReadApplicantResponse(
             availableTimes = applicantDto.availableTimes,
             documentAverageScore = applicantDto.documentAverageScore,
             interviewAverageScore = applicantDto.interviewAverageScore,
+            partId = applicantDto.part.id,
         )
     }
 }

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/application/dto/ReadInterviewEvaluationResponse.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/application/dto/ReadInterviewEvaluationResponse.kt
@@ -35,6 +35,7 @@ data class ReadInterviewEvaluationResponse(
                         RubricGroupType.CULTURE -> "CULTURE_FIT"
                         RubricGroupType.TEAM -> "TEAM_FIT"
                         RubricGroupType.JOB -> "JOB_FIT"
+                        RubricGroupType.OTHER -> "OTHER"
                     },
                     items = items.map {
                         ReadInterviewEvaluationItemResponse(

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/interview/application/PartInterviewRequirementController.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/interview/application/PartInterviewRequirementController.kt
@@ -7,11 +7,14 @@ import com.yourssu.scouter.recruiting.interview.business.PartInterviewRequiremen
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.Valid
+import jakarta.validation.constraints.Pattern
 import org.springframework.http.ResponseEntity
+import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.*
 
 @Tag(name = "면접 요구조건")
 @RestController
+@Validated
 class PartInterviewRequirementController(
     private val partInterviewRequirementService: PartInterviewRequirementService,
 ) {
@@ -20,7 +23,7 @@ class PartInterviewRequirementController(
     @GetMapping("/parts/{partId}/interviews/requirements")
     fun readByPartId(
         @PathVariable partId: Long,
-        @RequestParam semester: String,
+        @RequestParam @Pattern(regexp = "^\\d{4}-[12]$", message = "semester must use YYYY-1 or YYYY-2 format") semester: String,
     ): ResponseEntity<ReadPartInterviewRequirementResponse> {
         val dto = partInterviewRequirementService.readByPartIdAndSemester(partId, Semester.of(semester))
         return ResponseEntity.ok(ReadPartInterviewRequirementResponse.from(dto))
@@ -30,7 +33,7 @@ class PartInterviewRequirementController(
     @PutMapping("/parts/{partId}/interviews/requirements")
     fun upsert(
         @PathVariable partId: Long,
-        @RequestParam semester: String,
+        @RequestParam @Pattern(regexp = "^\\d{4}-[12]$", message = "semester must use YYYY-1 or YYYY-2 format") semester: String,
         @RequestBody @Valid request: UpdatePartInterviewRequirementRequest,
     ): ResponseEntity<Unit> {
         partInterviewRequirementService.saveAll(partId, Semester.of(semester), request)

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/interview/application/PartInterviewRequirementController.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/interview/application/PartInterviewRequirementController.kt
@@ -1,5 +1,6 @@
 package com.yourssu.scouter.recruiting.interview.application
 
+import com.yourssu.scouter.common.semester.implement.Semester
 import com.yourssu.scouter.recruiting.interview.application.dto.ReadPartInterviewRequirementResponse
 import com.yourssu.scouter.recruiting.interview.application.dto.UpdatePartInterviewRequirementRequest
 import com.yourssu.scouter.recruiting.interview.business.PartInterviewRequirementService
@@ -7,11 +8,7 @@ import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.Valid
 import org.springframework.http.ResponseEntity
-import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.PathVariable
-import org.springframework.web.bind.annotation.PutMapping
-import org.springframework.web.bind.annotation.RequestBody
-import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.bind.annotation.*
 
 @Tag(name = "면접 요구조건")
 @RestController
@@ -23,20 +20,20 @@ class PartInterviewRequirementController(
     @GetMapping("/parts/{partId}/interviews/requirements")
     fun readByPartId(
         @PathVariable partId: Long,
+        @RequestParam semester: String,
     ): ResponseEntity<ReadPartInterviewRequirementResponse> {
-        return ResponseEntity.ok(
-            ReadPartInterviewRequirementResponse.from(partInterviewRequirementService.readByPartId(partId)),
-        )
+        val dto = partInterviewRequirementService.readByPartIdAndSemester(partId, Semester.of(semester))
+        return ResponseEntity.ok(ReadPartInterviewRequirementResponse.from(dto))
     }
 
     @Operation(summary = "파트별 면접 요구조건 수정")
     @PutMapping("/parts/{partId}/interviews/requirements")
     fun upsert(
         @PathVariable partId: Long,
+        @RequestParam semester: String,
         @RequestBody @Valid request: UpdatePartInterviewRequirementRequest,
     ): ResponseEntity<Unit> {
-        partInterviewRequirementService.upsert(partId, request.culture!!, request.team!!, request.job!!)
-
+        partInterviewRequirementService.saveAll(partId, Semester.of(semester), request)
         return ResponseEntity.ok().build()
     }
 }

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/interview/application/dto/ReadPartInterviewRequirementResponse.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/interview/application/dto/ReadPartInterviewRequirementResponse.kt
@@ -1,17 +1,20 @@
 package com.yourssu.scouter.recruiting.interview.application.dto
 
 import com.yourssu.scouter.recruiting.interview.business.dto.PartInterviewRequirementDto
+import com.yourssu.scouter.recruiting.interview.business.dto.PartInterviewRequirementItemDto
 
 data class ReadPartInterviewRequirementResponse(
-    val culture: String?,
-    val team: String?,
-    val job: String?,
+    val culture: List<PartInterviewRequirementItemDto>,
+    val team: List<PartInterviewRequirementItemDto>,
+    val job: List<PartInterviewRequirementItemDto>,
+    val other: List<PartInterviewRequirementItemDto>,
 ) {
     companion object {
         fun from(dto: PartInterviewRequirementDto): ReadPartInterviewRequirementResponse = ReadPartInterviewRequirementResponse(
             culture = dto.culture,
             team = dto.team,
             job = dto.job,
+            other = dto.other,
         )
     }
 }

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/interview/application/dto/ReadPartInterviewRequirementResponse.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/interview/application/dto/ReadPartInterviewRequirementResponse.kt
@@ -1,20 +1,24 @@
 package com.yourssu.scouter.recruiting.interview.application.dto
 
 import com.yourssu.scouter.recruiting.interview.business.dto.PartInterviewRequirementDto
-import com.yourssu.scouter.recruiting.interview.business.dto.PartInterviewRequirementItemDto
+
+data class ReadPartInterviewRequirementItemResponse(
+    val id: Long?,
+    val content: String,
+)
 
 data class ReadPartInterviewRequirementResponse(
-    val culture: List<PartInterviewRequirementItemDto>,
-    val team: List<PartInterviewRequirementItemDto>,
-    val job: List<PartInterviewRequirementItemDto>,
-    val other: List<PartInterviewRequirementItemDto>,
+    val culture: List<ReadPartInterviewRequirementItemResponse>,
+    val team: List<ReadPartInterviewRequirementItemResponse>,
+    val job: List<ReadPartInterviewRequirementItemResponse>,
+    val other: List<ReadPartInterviewRequirementItemResponse>,
 ) {
     companion object {
         fun from(dto: PartInterviewRequirementDto): ReadPartInterviewRequirementResponse = ReadPartInterviewRequirementResponse(
-            culture = dto.culture,
-            team = dto.team,
-            job = dto.job,
-            other = dto.other,
+            culture = dto.culture.map { ReadPartInterviewRequirementItemResponse(it.id, it.content) },
+            team = dto.team.map { ReadPartInterviewRequirementItemResponse(it.id, it.content) },
+            job = dto.job.map { ReadPartInterviewRequirementItemResponse(it.id, it.content) },
+            other = dto.other.map { ReadPartInterviewRequirementItemResponse(it.id, it.content) },
         )
     }
 }

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/interview/application/dto/UpdatePartInterviewRequirementRequest.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/interview/application/dto/UpdatePartInterviewRequirementRequest.kt
@@ -1,15 +1,22 @@
 package com.yourssu.scouter.recruiting.interview.application.dto
 
-import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotNull
+
+data class UpdatePartInterviewRequirementItemRequest(
+    val id: Long?,
+    val content: String,
+)
 
 data class UpdatePartInterviewRequirementRequest(
+    @field:NotNull
+    val culture: List<UpdatePartInterviewRequirementItemRequest>,
 
-    @field:NotBlank
-    val culture: String?,
+    @field:NotNull
+    val team: List<UpdatePartInterviewRequirementItemRequest>,
 
-    @field:NotBlank
-    val team: String?,
+    @field:NotNull
+    val job: List<UpdatePartInterviewRequirementItemRequest>,
 
-    @field:NotBlank
-    val job: String?,
+    @field:NotNull
+    val other: List<UpdatePartInterviewRequirementItemRequest>,
 )

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/interview/business/PartInterviewRequirementService.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/interview/business/PartInterviewRequirementService.kt
@@ -8,14 +8,27 @@ import com.yourssu.scouter.recruiting.interview.implement.PartInterviewRequireme
 import com.yourssu.scouter.recruiting.interview.implement.PartInterviewRequirementWriter
 import com.yourssu.scouter.recruiting.rubric.implement.RubricGroupType
 import com.yourssu.scouter.recruiting.interview.application.dto.UpdatePartInterviewRequirementRequest
+import com.yourssu.scouter.common.semester.implement.SemesterReader
+import com.yourssu.scouter.recruiting.rubric.implement.InterviewRubricReader
+import com.yourssu.scouter.recruiting.rubric.implement.InterviewRubricWriter
+import com.yourssu.scouter.recruiting.rubric.implement.InterviewRubric
+import com.yourssu.scouter.recruiting.evaluation.implement.InterviewEvaluationReader
+import com.yourssu.scouter.recruiting.evaluation.implement.InterviewEvaluationItem
+import com.yourssu.scouter.recruiting.support.implement.exception.RubricLockedException
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import java.time.Instant
+import java.time.Duration
 
 @Service
 class PartInterviewRequirementService(
     private val partInterviewRequirementReader: PartInterviewRequirementReader,
     private val partInterviewRequirementWriter: PartInterviewRequirementWriter,
     private val partReader: PartReader,
+    private val semesterReader: SemesterReader,
+    private val interviewRubricReader: InterviewRubricReader,
+    private val interviewRubricWriter: InterviewRubricWriter,
+    private val interviewEvaluationReader: InterviewEvaluationReader,
 ) {
 
     fun readByPartIdAndSemester(partId: Long, semester: Semester): PartInterviewRequirementDto {
@@ -29,21 +42,65 @@ class PartInterviewRequirementService(
     fun saveAll(partId: Long, semester: Semester, request: UpdatePartInterviewRequirementRequest) {
         partReader.readById(partId)
 
+        val resolvedSemester = semesterReader.read(semester)
+        val semesterId = resolvedSemester.id!!
+
+        val existingRubric = interviewRubricReader.findByPartIdAndSemester(partId, semester)
+        existingRubric?.validateEditable()
+
+        if (existingRubric != null && existingRubric.items.isNotEmpty()) {
+            val itemIds = existingRubric.items.mapNotNull { it.id }
+            if (interviewEvaluationReader.existsByInterviewEvaluationItemIdIn(itemIds)) {
+                throw RubricLockedException("해당 파트에 면접 평가(임시저장 포함)가 존재해 수정 불가")
+            }
+        }
+
         val domains = mutableListOf<PartInterviewRequirement>()
 
         request.culture.forEach {
-            domains.add(PartInterviewRequirement(it.id, partId, 0L, RubricGroupType.CULTURE, it.content))
+            domains.add(PartInterviewRequirement(it.id, partId, semesterId, RubricGroupType.CULTURE, it.content))
         }
         request.team.forEach {
-            domains.add(PartInterviewRequirement(it.id, partId, 0L, RubricGroupType.TEAM, it.content))
+            domains.add(PartInterviewRequirement(it.id, partId, semesterId, RubricGroupType.TEAM, it.content))
         }
         request.job.forEach {
-            domains.add(PartInterviewRequirement(it.id, partId, 0L, RubricGroupType.JOB, it.content))
+            domains.add(PartInterviewRequirement(it.id, partId, semesterId, RubricGroupType.JOB, it.content))
         }
         request.other.forEach {
-            domains.add(PartInterviewRequirement(it.id, partId, 0L, RubricGroupType.OTHER, it.content))
+            domains.add(PartInterviewRequirement(it.id, partId, semesterId, RubricGroupType.OTHER, it.content))
         }
 
-        partInterviewRequirementWriter.saveAll(domains, partId, semester)
+        val savedRequirements = partInterviewRequirementWriter.saveAll(domains, partId, semester)
+
+        val newItems = savedRequirements.map { req ->
+            InterviewEvaluationItem(
+                id = null,
+                keyword = req.content,
+                rubricType = req.rubricType,
+                maxScore = 0
+            )
+        }
+
+        val rubricToSave = if (existingRubric != null) {
+            InterviewRubric(
+                id = existingRubric.id,
+                partId = partId,
+                semester = semester,
+                deadline = existingRubric.deadline,
+                isLocked = existingRubric.isLocked,
+                items = newItems
+            )
+        } else {
+            InterviewRubric(
+                id = null,
+                partId = partId,
+                semester = semester,
+                deadline = Instant.now().plus(Duration.ofDays(365)), // 1년 뒤 기본 데드라인
+                isLocked = false,
+                items = newItems
+            )
+        }
+
+        interviewRubricWriter.save(rubricToSave)
     }
 }

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/interview/business/PartInterviewRequirementService.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/interview/business/PartInterviewRequirementService.kt
@@ -1,10 +1,13 @@
 package com.yourssu.scouter.recruiting.interview.business
 
 import com.yourssu.scouter.common.part.implement.PartReader
+import com.yourssu.scouter.common.semester.implement.Semester
 import com.yourssu.scouter.recruiting.interview.business.dto.PartInterviewRequirementDto
 import com.yourssu.scouter.recruiting.interview.implement.PartInterviewRequirement
 import com.yourssu.scouter.recruiting.interview.implement.PartInterviewRequirementReader
 import com.yourssu.scouter.recruiting.interview.implement.PartInterviewRequirementWriter
+import com.yourssu.scouter.recruiting.rubric.implement.RubricGroupType
+import com.yourssu.scouter.recruiting.interview.application.dto.UpdatePartInterviewRequirementRequest
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -15,16 +18,32 @@ class PartInterviewRequirementService(
     private val partReader: PartReader,
 ) {
 
-    fun readByPartId(partId: Long): PartInterviewRequirementDto {
+    fun readByPartIdAndSemester(partId: Long, semester: Semester): PartInterviewRequirementDto {
         partReader.readById(partId)
 
-        return PartInterviewRequirementDto.from(partInterviewRequirementReader.readByPartId(partId))
+        val requirements = partInterviewRequirementReader.readAllByPartIdAndSemester(partId, semester)
+        return PartInterviewRequirementDto.from(requirements)
     }
 
     @Transactional
-    fun upsert(partId: Long, culture: String, team: String, job: String) {
+    fun saveAll(partId: Long, semester: Semester, request: UpdatePartInterviewRequirementRequest) {
         partReader.readById(partId)
 
-        partInterviewRequirementWriter.upsert(PartInterviewRequirement(partId, culture, team, job))
+        val domains = mutableListOf<PartInterviewRequirement>()
+
+        request.culture.forEach {
+            domains.add(PartInterviewRequirement(it.id, partId, 0L, RubricGroupType.CULTURE, it.content))
+        }
+        request.team.forEach {
+            domains.add(PartInterviewRequirement(it.id, partId, 0L, RubricGroupType.TEAM, it.content))
+        }
+        request.job.forEach {
+            domains.add(PartInterviewRequirement(it.id, partId, 0L, RubricGroupType.JOB, it.content))
+        }
+        request.other.forEach {
+            domains.add(PartInterviewRequirement(it.id, partId, 0L, RubricGroupType.OTHER, it.content))
+        }
+
+        partInterviewRequirementWriter.saveAll(domains, partId, semester)
     }
 }

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/interview/business/dto/PartInterviewRequirementDto.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/interview/business/dto/PartInterviewRequirementDto.kt
@@ -1,17 +1,28 @@
 package com.yourssu.scouter.recruiting.interview.business.dto
 
 import com.yourssu.scouter.recruiting.interview.implement.PartInterviewRequirement
+import com.yourssu.scouter.recruiting.rubric.implement.RubricGroupType
+
+data class PartInterviewRequirementItemDto(
+    val id: Long?,
+    val content: String,
+)
 
 data class PartInterviewRequirementDto(
-    val culture: String?,
-    val team: String?,
-    val job: String?,
+    val culture: List<PartInterviewRequirementItemDto>,
+    val team: List<PartInterviewRequirementItemDto>,
+    val job: List<PartInterviewRequirementItemDto>,
+    val other: List<PartInterviewRequirementItemDto>,
 ) {
     companion object {
-        fun from(requirement: PartInterviewRequirement?): PartInterviewRequirementDto = PartInterviewRequirementDto(
-            culture = requirement?.culture,
-            team = requirement?.team,
-            job = requirement?.job,
-        )
+        fun from(requirements: List<PartInterviewRequirement>): PartInterviewRequirementDto {
+            val grouped = requirements.groupBy { it.rubricType }
+            return PartInterviewRequirementDto(
+                culture = grouped[RubricGroupType.CULTURE]?.map { PartInterviewRequirementItemDto(it.id, it.content) } ?: emptyList(),
+                team = grouped[RubricGroupType.TEAM]?.map { PartInterviewRequirementItemDto(it.id, it.content) } ?: emptyList(),
+                job = grouped[RubricGroupType.JOB]?.map { PartInterviewRequirementItemDto(it.id, it.content) } ?: emptyList(),
+                other = grouped[RubricGroupType.OTHER]?.map { PartInterviewRequirementItemDto(it.id, it.content) } ?: emptyList(),
+            )
+        }
     }
 }

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/interview/implement/PartInterviewRequirement.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/interview/implement/PartInterviewRequirement.kt
@@ -1,8 +1,11 @@
 package com.yourssu.scouter.recruiting.interview.implement
 
+import com.yourssu.scouter.recruiting.rubric.implement.RubricGroupType
+
 class PartInterviewRequirement(
+    val id: Long? = null,
     val partId: Long,
-    val culture: String,
-    val team: String,
-    val job: String,
+    val semesterId: Long,
+    val rubricType: RubricGroupType,
+    val content: String,
 )

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/interview/implement/PartInterviewRequirementReader.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/interview/implement/PartInterviewRequirementReader.kt
@@ -1,5 +1,6 @@
 package com.yourssu.scouter.recruiting.interview.implement
 
+import com.yourssu.scouter.common.semester.implement.Semester
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
 
@@ -9,7 +10,7 @@ class PartInterviewRequirementReader(
     private val partInterviewRequirementRepository: PartInterviewRequirementRepository,
 ) {
 
-    fun readByPartId(partId: Long): PartInterviewRequirement? {
-        return partInterviewRequirementRepository.findByPartId(partId)
+    fun readAllByPartIdAndSemester(partId: Long, semester: Semester): List<PartInterviewRequirement> {
+        return partInterviewRequirementRepository.findAllByPartIdAndSemester(partId, semester)
     }
 }

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/interview/implement/PartInterviewRequirementRepository.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/interview/implement/PartInterviewRequirementRepository.kt
@@ -1,8 +1,14 @@
 package com.yourssu.scouter.recruiting.interview.implement
 
+import com.yourssu.scouter.common.semester.implement.Semester
+
 interface PartInterviewRequirementRepository {
 
-    fun findByPartId(partId: Long): PartInterviewRequirement?
+    fun findAllByPartIdAndSemester(partId: Long, semester: Semester): List<PartInterviewRequirement>
 
-    fun upsert(requirement: PartInterviewRequirement): PartInterviewRequirement
+    fun saveAll(
+        requirements: List<PartInterviewRequirement>,
+        partId: Long,
+        semester: Semester
+    ): List<PartInterviewRequirement>
 }

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/interview/implement/PartInterviewRequirementWriter.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/interview/implement/PartInterviewRequirementWriter.kt
@@ -1,5 +1,6 @@
 package com.yourssu.scouter.recruiting.interview.implement
 
+import com.yourssu.scouter.common.semester.implement.Semester
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
 
@@ -9,7 +10,11 @@ class PartInterviewRequirementWriter(
     private val partInterviewRequirementRepository: PartInterviewRequirementRepository,
 ) {
 
-    fun upsert(requirement: PartInterviewRequirement): PartInterviewRequirement {
-        return partInterviewRequirementRepository.upsert(requirement)
+    fun saveAll(
+        requirements: List<PartInterviewRequirement>,
+        partId: Long,
+        semester: Semester
+    ): List<PartInterviewRequirement> {
+        return partInterviewRequirementRepository.saveAll(requirements, partId, semester)
     }
 }

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/interview/storage/JpaPartInterviewRequirementRepository.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/interview/storage/JpaPartInterviewRequirementRepository.kt
@@ -1,5 +1,8 @@
 package com.yourssu.scouter.recruiting.interview.storage
 
+import com.yourssu.scouter.common.semester.storage.SemesterEntity
 import org.springframework.data.jpa.repository.JpaRepository
 
-interface JpaPartInterviewRequirementRepository : JpaRepository<PartInterviewRequirementEntity, Long>
+interface JpaPartInterviewRequirementRepository : JpaRepository<PartInterviewRequirementEntity, Long> {
+    fun findAllByPartIdAndSemester(partId: Long, semester: SemesterEntity): List<PartInterviewRequirementEntity>
+}

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/interview/storage/PartInterviewRequirementEntity.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/interview/storage/PartInterviewRequirementEntity.kt
@@ -1,33 +1,38 @@
 package com.yourssu.scouter.recruiting.interview.storage
 
+import com.yourssu.scouter.common.part.storage.PartEntity
+import com.yourssu.scouter.common.semester.storage.SemesterEntity
 import com.yourssu.scouter.recruiting.interview.implement.PartInterviewRequirement
-import jakarta.persistence.Column
-import jakarta.persistence.Entity
-import jakarta.persistence.Id
-import jakarta.persistence.Table
+import com.yourssu.scouter.recruiting.rubric.implement.RubricGroupType
+import jakarta.persistence.*
 
 @Entity
 @Table(name = "part_interview_requirement")
 class PartInterviewRequirementEntity(
-
     @Id
-    @Column(name = "part_id")
-    val partId: Long,
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long? = null,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "part_id", nullable = false)
+    val part: PartEntity,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "semester_id", nullable = false)
+    val semester: SemesterEntity,
+
+    @Column(name = "rubric_type", nullable = false)
+    @Enumerated(EnumType.STRING)
+    val rubricType: RubricGroupType,
 
     @Column(nullable = false, columnDefinition = "TEXT")
-    val culture: String,
-
-    @Column(nullable = false, columnDefinition = "TEXT")
-    val team: String,
-
-    @Column(nullable = false, columnDefinition = "TEXT")
-    val job: String,
+    val content: String,
 ) {
-
     fun toDomain(): PartInterviewRequirement = PartInterviewRequirement(
-        partId = partId,
-        culture = culture,
-        team = team,
-        job = job,
+        id = id,
+        partId = part.id!!,
+        semesterId = semester.id!!,
+        rubricType = rubricType,
+        content = content,
     )
 }

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/interview/storage/PartInterviewRequirementRepositoryImpl.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/interview/storage/PartInterviewRequirementRepositoryImpl.kt
@@ -1,27 +1,63 @@
 package com.yourssu.scouter.recruiting.interview.storage
 
+import com.yourssu.scouter.common.part.storage.JpaPartRepository
+import com.yourssu.scouter.common.semester.implement.Semester
+import com.yourssu.scouter.common.semester.storage.JpaSemesterRepository
 import com.yourssu.scouter.recruiting.interview.implement.PartInterviewRequirement
 import com.yourssu.scouter.recruiting.interview.implement.PartInterviewRequirementRepository
-import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Repository
 
 @Repository
 class PartInterviewRequirementRepositoryImpl(
     private val jpaPartInterviewRequirementRepository: JpaPartInterviewRequirementRepository,
+    private val jpaPartRepository: JpaPartRepository,
+    private val jpaSemesterRepository: JpaSemesterRepository,
 ) : PartInterviewRequirementRepository {
 
-    override fun findByPartId(partId: Long): PartInterviewRequirement? {
-        return jpaPartInterviewRequirementRepository.findByIdOrNull(partId)?.toDomain()
+    override fun findAllByPartIdAndSemester(partId: Long, semester: Semester): List<PartInterviewRequirement> {
+        val semesterEntity = jpaSemesterRepository.findByYearAndTerm(semester.year, semester.term) ?: return emptyList()
+        return jpaPartInterviewRequirementRepository.findAllByPartIdAndSemester(partId, semesterEntity)
+            .map { it.toDomain() }
     }
 
-    override fun upsert(requirement: PartInterviewRequirement): PartInterviewRequirement {
-        val entity = PartInterviewRequirementEntity(
-            partId = requirement.partId,
-            culture = requirement.culture,
-            team = requirement.team,
-            job = requirement.job,
-        )
+    override fun saveAll(
+        requirements: List<PartInterviewRequirement>,
+        partId: Long,
+        semester: Semester
+    ): List<PartInterviewRequirement> {
+        val semesterEntity = jpaSemesterRepository.findByYearAndTerm(semester.year, semester.term)
+            ?: throw IllegalArgumentException("해당 학기 정보를 찾을 수 없습니다: ${semester.year}-${semester.term.intValue}")
 
-        return jpaPartInterviewRequirementRepository.save(entity).toDomain()
+        val existingEntities = jpaPartInterviewRequirementRepository.findAllByPartIdAndSemester(partId, semesterEntity)
+            .associateBy { it.id }
+
+        val partRef = jpaPartRepository.getReferenceById(partId)
+
+        val updatedIds = requirements.mapNotNull { it.id }.toSet()
+        val toDelete = existingEntities.filterKeys { it !in updatedIds }.values
+        jpaPartInterviewRequirementRepository.deleteAll(toDelete)
+
+        val savedEntities = requirements.map { req ->
+            val entity = if (req.id != null && existingEntities.containsKey(req.id)) {
+                PartInterviewRequirementEntity(
+                    id = req.id,
+                    part = partRef,
+                    semester = semesterEntity,
+                    rubricType = req.rubricType,
+                    content = req.content
+                )
+            } else {
+                PartInterviewRequirementEntity(
+                    id = null,
+                    part = partRef,
+                    semester = semesterEntity,
+                    rubricType = req.rubricType,
+                    content = req.content
+                )
+            }
+            jpaPartInterviewRequirementRepository.save(entity)
+        }
+
+        return savedEntities.map { it.toDomain() }
     }
 }

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/interview/storage/PartInterviewRequirementRepositoryImpl.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/interview/storage/PartInterviewRequirementRepositoryImpl.kt
@@ -38,7 +38,10 @@ class PartInterviewRequirementRepositoryImpl(
         jpaPartInterviewRequirementRepository.deleteAll(toDelete)
 
         val savedEntities = requirements.map { req ->
-            val entity = if (req.id != null && existingEntities.containsKey(req.id)) {
+            val entity = if (req.id != null) {
+                if (!existingEntities.containsKey(req.id)) {
+                    throw IllegalArgumentException("해당 파트 및 학기에 존재하지 않는 요구조건 ID입니다: ${req.id}")
+                }
                 PartInterviewRequirementEntity(
                     id = req.id,
                     part = partRef,

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/rubric/application/InterviewRubricController.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/rubric/application/InterviewRubricController.kt
@@ -43,7 +43,7 @@ class InterviewRubricController(
     )
 
     @Operation(
-        summary = "학기별 면접 평가 루브릭 등록 또는 수정(어드민)",
+        summary = "학기별 면접 평가 루브릭 등록 또는 수정/ 배점설정(어드민)",
         description = "해당 파트·학기에 루브릭이 없으면 생성하고, 있으면 항목 전체를 교체합니다. 잠긴 루브릭은 수정할 수 없으며 모든 항목의 maxScore 합계는 100이어야 합니다.",
         requestBody = io.swagger.v3.oas.annotations.parameters.RequestBody(
             required = true,

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/rubric/application/dto/InterviewRubricResponse.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/rubric/application/dto/InterviewRubricResponse.kt
@@ -50,6 +50,7 @@ data class InterviewRubricResponse(
                         RubricGroupType.CULTURE -> "CULTURE_FIT"
                         RubricGroupType.TEAM -> "TEAM_FIT"
                         RubricGroupType.JOB -> "JOB_FIT"
+                        RubricGroupType.OTHER -> "OTHER"
                     },
                     groupMaxScore = items.sumOf { it.maxScore },
                     items = items.map {

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/rubric/application/dto/InterviewRubricUpdateRequest.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/rubric/application/dto/InterviewRubricUpdateRequest.kt
@@ -53,6 +53,7 @@ data class InterviewRubricUpdateRequest(
                 "CULTURE_FIT" -> RubricGroupType.CULTURE
                 "TEAM_FIT" -> RubricGroupType.TEAM
                 "JOB_FIT" -> RubricGroupType.JOB
+                "OTHER" -> RubricGroupType.OTHER
                 else -> throw IllegalArgumentException("유효하지 않은 평가 그룹입니다: ${groupReq.group}")
             }
             groupReq.items.map { itemReq ->

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/rubric/business/InterviewRubricService.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/rubric/business/InterviewRubricService.kt
@@ -40,12 +40,13 @@ class InterviewRubricService(
             }
         }
 
-        val saved = interviewRubricWriter.save(
-            command.toDomain(
-                existingId = existing?.id,
-                isLocked = existing?.isLocked ?: false,
-            ),
+        val domain = command.toDomain(
+            existingId = existing?.id,
+            isLocked = existing?.isLocked ?: false,
         )
+        domain.validateTotalScore()
+
+        val saved = interviewRubricWriter.save(domain)
 
         return InterviewRubricResult.from(saved)
     }

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/rubric/implement/InterviewRubric.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/rubric/implement/InterviewRubric.kt
@@ -13,7 +13,7 @@ class InterviewRubric(
     val items: List<InterviewEvaluationItem>,
 ) {
 
-    init {
+    fun validateTotalScore() {
         // 배점 합계 100점 비즈니스 검증
         val totalScore = items.sumOf { it.maxScore }
         require(totalScore == 100) {

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/rubric/implement/RubricGroupType.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/rubric/implement/RubricGroupType.kt
@@ -3,5 +3,6 @@ package com.yourssu.scouter.recruiting.rubric.implement
 enum class RubricGroupType {
     JOB,
     CULTURE,
-    TEAM
+    TEAM,
+    OTHER
 }

--- a/src/main/resources/db/migration/V33__refactor_part_interview_requirement.sql
+++ b/src/main/resources/db/migration/V33__refactor_part_interview_requirement.sql
@@ -1,0 +1,13 @@
+DROP TABLE IF EXISTS part_interview_requirement;
+
+CREATE TABLE part_interview_requirement (
+    id          BIGINT AUTO_INCREMENT PRIMARY KEY,
+    part_id     BIGINT NOT NULL,
+    semester_id BIGINT NOT NULL,
+    rubric_type VARCHAR(50) NOT NULL,
+    content     TEXT NOT NULL,
+    CONSTRAINT fk_part_interview_requirement_part
+        FOREIGN KEY (part_id) REFERENCES part (id),
+    CONSTRAINT fk_part_interview_requirement_semester
+        FOREIGN KEY (semester_id) REFERENCES semester (id)
+);

--- a/src/test/kotlin/com/yourssu/scouter/recruiting/interview/storage/PartInterviewRequirementRepositoryImplTest.kt
+++ b/src/test/kotlin/com/yourssu/scouter/recruiting/interview/storage/PartInterviewRequirementRepositoryImplTest.kt
@@ -2,15 +2,19 @@ package com.yourssu.scouter.recruiting.interview.storage
 
 import com.yourssu.scouter.common.division.storage.DivisionEntity
 import com.yourssu.scouter.common.part.storage.PartEntity
+import com.yourssu.scouter.common.semester.implement.Semester
+import com.yourssu.scouter.common.semester.implement.Term
+import com.yourssu.scouter.common.semester.storage.SemesterEntity
 import com.yourssu.scouter.recruiting.interview.implement.PartInterviewRequirement
+import com.yourssu.scouter.recruiting.rubric.implement.RubricGroupType
 import org.assertj.core.api.Assertions.assertThat
-import org.assertj.core.api.Assertions.assertThatCode
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager
 import org.springframework.context.annotation.Import
+import java.time.Year
 
 @DataJpaTest
 @Import(PartInterviewRequirementRepositoryImpl::class)
@@ -31,52 +35,40 @@ class PartInterviewRequirementRepositoryImplTest {
         val part = entityManager.persist(PartEntity(null, division, "PM", 1))
         partId = part.id!!
 
+        entityManager.persist(SemesterEntity(null, Year.of(2026), Term.SPRING))
+
         entityManager.flush()
         entityManager.clear()
     }
 
     @Test
-    fun `설정된 요구조건이 없으면 null을 반환한다`() {
+    fun `설정된 요구조건이 없으면 빈 리스트를 반환한다`() {
         // when
-        val result = partInterviewRequirementRepositoryImpl.findByPartId(partId)
+        val result = partInterviewRequirementRepositoryImpl.findAllByPartIdAndSemester(partId, Semester.of("2026-1"))
 
         // then
-        assertThat(result).isNull()
+        assertThat(result).isEmpty()
     }
 
     @Test
-    fun `요구조건이 없는 파트에 처음 설정하면 저장된다`() {
+    fun `요구조건을 저장하고 조회한다`() {
         // given
-        val requirement = PartInterviewRequirement(partId, "주도성", "커뮤니케이션", "문제 구조화")
+        val semester = Semester.of("2026-1")
+        val requirements = listOf(
+            PartInterviewRequirement(null, partId, 0L, RubricGroupType.CULTURE, "주도성"),
+            PartInterviewRequirement(null, partId, 0L, RubricGroupType.TEAM, "커뮤니케이션"),
+            PartInterviewRequirement(null, partId, 0L, RubricGroupType.JOB, "문제 구조화")
+        )
 
         // when
-        assertThatCode {
-            partInterviewRequirementRepositoryImpl.upsert(requirement)
-        }.doesNotThrowAnyException()
+        val saved = partInterviewRequirementRepositoryImpl.saveAll(requirements, partId, semester)
+        entityManager.flush()
+        entityManager.clear()
 
         // then
-        val found = partInterviewRequirementRepositoryImpl.findByPartId(partId)
-        assertThat(found).isNotNull
-        assertThat(found!!.culture).isEqualTo("주도성")
-        assertThat(found.team).isEqualTo("커뮤니케이션")
-        assertThat(found.job).isEqualTo("문제 구조화")
-    }
-
-    @Test
-    fun `이미 설정된 요구조건을 다시 저장해도 예외 없이 갱신된다`() {
-        // given: 최초 설정
-        partInterviewRequirementRepositoryImpl.upsert(PartInterviewRequirement(partId, "주도성", "커뮤니케이션", "문제 구조화"))
-
-        // when: 같은 파트에 재설정
-        assertThatCode {
-            partInterviewRequirementRepositoryImpl.upsert(PartInterviewRequirement(partId, "집중력", "책임감", "실행안 전환"))
-        }.doesNotThrowAnyException()
-
-        // then
-        val found = partInterviewRequirementRepositoryImpl.findByPartId(partId)
-        assertThat(found).isNotNull
-        assertThat(found!!.culture).isEqualTo("집중력")
-        assertThat(found.team).isEqualTo("책임감")
-        assertThat(found.job).isEqualTo("실행안 전환")
+        val found = partInterviewRequirementRepositoryImpl.findAllByPartIdAndSemester(partId, semester)
+        assertThat(found).hasSize(3)
+        assertThat(found).extracting<String> { it.content }
+            .containsExactlyInAnyOrder("주도성", "커뮤니케이션", "문제 구조화")
     }
 }


### PR DESCRIPTION
  ## 📝 개요                                                                                                                                                          
                                                                                                                                                                      
  파트별 면접 요구조건(Requirements)의 유연한 관리(다중 등록, 기타 문항 추가 등)를 지원하고, 프론트엔드에서의 요구사항 연계를 원활히 처리할 수 있도록 관련 API 스펙 및
  데이터베이스 스키마를 개편하였습니다.                                                                                                                               
                                                                                                                                                   
  ## 🛠️ 주요 변경 사항                                                                                                                                                
                                                                                                                                                                      
  ### 1. 지원자 상세/목록 조회 응답 스펙 확장 (ReadApplicantResponse)                                                                                                 
                                                                                                                                                                      
  • 변경점: GET /applicants/{applicantId} 및 GET /applicants 응답 DTO에 partId: Long 필드를 추가하였습니다.                                                           
  • 목적: 프론트엔드에서 지원자 조회 후, 해당 지원자의 파트에 부합하는 면접 요구사항 목록 조회 API(GET /parts/{partId}/interviews/requirements)를 다이렉트로 호출할 수 있도록 하기 위함입니다.                                                                                                                                             
                                                                                                                                                                      
  ### 2. 면접 요구조건 스키마 개편 (1:1 ➡️ 1:N 구조)                                                                                                                  
                                                                                                                                                                      
  • 변경점: 단일 로우에 문자열 필드로 관리하던 기존 방식에서 개별 요구사항을 다중 행으로 등록/관리할 수 있도록 테이블을 재설계했습니다.                                                                                                                
                                                                                                                                                                      
                                                                                                                                                                      
  ### 3. 면접 요구조건 조회/수정 API 리팩토링 (GET, PUT /parts/{partId}/interviews/requirements)                                                                      
                                                                                                                                                                      
  • 조회 및 수정 시 학기 구분: semester를 필수 쿼리 파라미터로 받도록 변경하여 학기별 요구조건 연동을 명확화했습니다.                                                 
  • 다중 구조의 JSON 입출력:                                                                                                                                          
      • GET 응답 및 PUT 요청 바디를 { "culture": [...], "team": [...], "job": [...], "other": [...] } 구조로 변경했습니다.                                            
      • PUT 요청 시 클라이언트가 전달한 ID 목록을 기반으로 Orphan Removal(누락된 ID 삭제), 신규 삽입(id=null), 기존 정보 수정이 트랜잭션 내에서 한 번에 싱크되도록 리포지토리 로직을 구현했습니다.     
  • 요구조건 입력시 면접 평가 루브릭에도 추가되게 하는 로직을 추가했습니다.                                                                                                                    
                                                                                                                                                                      
                                                                                                                                                                      
  ### 4. RubricGroupType에 OTHER 타입 추가 및 완전성 분기 처리                                                                                                        
                                                                                                                                                                      
  • 기타 요구조건을 지원하기 위해 RubricGroupType enum에 OTHER를 추가하였습니다.                                                                                      
  • 이를 참조하고 있는 기존 면접 평가 루브릭 DTO(ReadInterviewEvaluationResponse, InterviewRubricResponse) 등에서 발생한 non-exhaustive 컴파일 오류 분기를 보완 완료했습니다.                                                                                                                                                       
                                                                                                                                            
  ## 📋 테스트 체크리스트                                                                                                                                             
                                                                                                                                                                      
  [✓] ./gradlew compileKotlin 컴파일 정상 완료                                                                                                                        
  [✓] part_interview_requirement 테이블 1:N 개편용 Flyway 마이그레이션 정상 적용                                                                                      
  [✓] 변경된 GET/PUT DTO 매핑 및 DB 데이터 싱크(Orphan Removal) 검증                                                                                                  


## 📎 Issue 번호
closed #345 
