### PR TITLE
[#347] 면접 요구조건과 질문 매핑 API 추가

### DIFF
--- a/src/main/kotlin/com/yourssu/scouter/recruiting/question/application/QuestionnaireController.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/question/application/QuestionnaireController.kt
@@ -2,6 +2,7 @@ package com.yourssu.scouter.recruiting.question.application
 
 import com.yourssu.scouter.recruiting.question.application.dto.ReadQuestionnaireResponse
 import com.yourssu.scouter.recruiting.question.application.dto.SaveQuestionnaireRequest
+import com.yourssu.scouter.recruiting.question.application.dto.SaveQuestionnaireRequirementMappingRequest
 import com.yourssu.scouter.recruiting.question.business.QuestionnaireService
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
@@ -37,4 +38,16 @@ class QuestionnaireController(
 
         return ResponseEntity.ok(ReadQuestionnaireResponse.from(result))
     }
+
+    @Operation(summary = "지원자별 면접 질문지와 면접 요구조건 매핑 저장")
+    @PutMapping("/applicants/{applicantId}/interviews/questionnaires/requirements")
+    fun saveMappings(
+        @PathVariable applicantId: Long,
+        @RequestBody @Valid request: SaveQuestionnaireRequirementMappingRequest,
+    ): ResponseEntity<ReadQuestionnaireResponse> {
+        val result = questionnaireService.saveMappings(applicantId, request.toCommand())
+
+        return ResponseEntity.ok(ReadQuestionnaireResponse.from(result))
+    }
 }
+

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/question/application/dto/ReadQuestionRequirementResponse.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/question/application/dto/ReadQuestionRequirementResponse.kt
@@ -1,0 +1,15 @@
+package com.yourssu.scouter.recruiting.question.application.dto
+
+import com.yourssu.scouter.recruiting.question.business.dto.QuestionRequirementDto
+
+data class ReadQuestionRequirementResponse(
+    val id: Long,
+    val content: String,
+) {
+    companion object {
+        fun from(dto: QuestionRequirementDto): ReadQuestionRequirementResponse = ReadQuestionRequirementResponse(
+            id = dto.id,
+            content = dto.content,
+        )
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/question/application/dto/ReadQuestionnaireQuestionResponse.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/question/application/dto/ReadQuestionnaireQuestionResponse.kt
@@ -8,6 +8,7 @@ data class ReadQuestionnaireQuestionResponse(
     val group: QuestionGroup,
     val sourceQuestionId: Long?,
     val content: String,
+    val requirements: List<ReadQuestionRequirementResponse>,
 ) {
     companion object {
         fun from(dto: QuestionnaireQuestionDto): ReadQuestionnaireQuestionResponse = ReadQuestionnaireQuestionResponse(
@@ -15,6 +16,9 @@ data class ReadQuestionnaireQuestionResponse(
             group = dto.group,
             sourceQuestionId = dto.sourceQuestionId,
             content = dto.content,
+            requirements = dto.requirements.map { ReadQuestionRequirementResponse.from(it) },
         )
     }
 }
+
+

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/question/application/dto/SaveQuestionnaireRequirementMappingRequest.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/question/application/dto/SaveQuestionnaireRequirementMappingRequest.kt
@@ -1,0 +1,31 @@
+package com.yourssu.scouter.recruiting.question.application.dto
+
+import com.yourssu.scouter.recruiting.question.business.dto.RequirementQuestionMappingItemCommand
+import com.yourssu.scouter.recruiting.question.business.dto.SaveQuestionnaireRequirementMappingCommand
+import jakarta.validation.constraints.NotNull
+
+data class SaveQuestionnaireRequirementMappingRequest(
+    val culture: List<RequirementQuestionMappingItemRequest> = emptyList(),
+    val team: List<RequirementQuestionMappingItemRequest> = emptyList(),
+    val job: List<RequirementQuestionMappingItemRequest> = emptyList(),
+    val other: List<RequirementQuestionMappingItemRequest> = emptyList(),
+) {
+    fun toCommand(): SaveQuestionnaireRequirementMappingCommand = SaveQuestionnaireRequirementMappingCommand(
+        culture = culture.map { it.toCommand() },
+        team = team.map { it.toCommand() },
+        job = job.map { it.toCommand() },
+        other = other.map { it.toCommand() },
+    )
+}
+
+data class RequirementQuestionMappingItemRequest(
+    @field:NotNull
+    val requirementId: Long,
+    val questionIds: List<Long> = emptyList(),
+) {
+    fun toCommand(): RequirementQuestionMappingItemCommand = RequirementQuestionMappingItemCommand(
+        requirementId = requirementId,
+        questionIds = questionIds,
+    )
+}
+

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/question/business/QuestionnaireService.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/question/business/QuestionnaireService.kt
@@ -2,13 +2,18 @@ package com.yourssu.scouter.recruiting.question.business
 
 import com.yourssu.scouter.auth.user.implement.UserReader
 import com.yourssu.scouter.recruiting.applicant.implement.ApplicantReader
+import com.yourssu.scouter.recruiting.interview.implement.PartInterviewRequirementReader
+import com.yourssu.scouter.recruiting.question.business.dto.QuestionRequirementDto
 import com.yourssu.scouter.recruiting.question.business.dto.QuestionnaireDto
 import com.yourssu.scouter.recruiting.question.business.dto.QuestionnaireQuestionDto
 import com.yourssu.scouter.recruiting.question.business.dto.SaveQuestionnaireCommand
+import com.yourssu.scouter.recruiting.question.business.dto.SaveQuestionnaireRequirementMappingCommand
 import com.yourssu.scouter.recruiting.question.implement.FixedQuestion
 import com.yourssu.scouter.recruiting.question.implement.FixedQuestionReader
 import com.yourssu.scouter.recruiting.question.implement.Questionnaire
 import com.yourssu.scouter.recruiting.question.implement.QuestionnaireQuestion
+import com.yourssu.scouter.recruiting.question.implement.QuestionnaireQuestionRequirement
+import com.yourssu.scouter.recruiting.question.implement.QuestionnaireQuestionRequirementRepository
 import com.yourssu.scouter.recruiting.question.implement.QuestionnaireValidator
 import com.yourssu.scouter.recruiting.question.implement.QuestionnaireReader
 import com.yourssu.scouter.recruiting.question.implement.QuestionnaireWriter
@@ -23,27 +28,43 @@ class QuestionnaireService(
     private val questionnaireValidator: QuestionnaireValidator,
     private val applicantReader: ApplicantReader,
     private val userReader: UserReader,
+    private val questionnaireQuestionRequirementRepository: QuestionnaireQuestionRequirementRepository,
+    private val partInterviewRequirementReader: PartInterviewRequirementReader,
 ) {
 
     fun readByApplicantId(applicantId: Long): QuestionnaireDto {
-        applicantReader.readById(applicantId)
+        val applicant = applicantReader.readById(applicantId)
 
         val questionnaire = questionnaireReader.readByApplicantId(applicantId)
         val questions = questionnaireReader.readQuestionsByApplicantId(applicantId)
         val fixedQuestionsById = readFixedQuestionsById(questions)
+
+        val questionIds = questions.mapNotNull { it.id }
+        val mappings = questionnaireQuestionRequirementRepository.findAllByQuestionQuestionIds(questionIds)
+        val mappingsByQuestionId = mappings.groupBy { it.questionnaireQuestionId }
+
+        val requirements = partInterviewRequirementReader.readAllByPartIdAndSemester(applicant.part.id!!, applicant.applicationSemester)
+        val requirementsById = requirements.associateBy { it.id }
 
         return QuestionnaireDto(
             applicantId = applicantId,
             assignedInterviewerUserId = questionnaire?.assignedInterviewerUserId,
             questions = questions
                 .sortedBy { it.sortOrder }
-                .map { it.toDto(fixedQuestionsById) },
+                .map { question ->
+                    val mappedReqs = mappingsByQuestionId[question.id].orEmpty().mapNotNull { m ->
+                        requirementsById[m.partInterviewRequirementId]?.let { req ->
+                            QuestionRequirementDto(req.id!!, req.content)
+                        }
+                    }
+                    question.toDto(fixedQuestionsById, mappedReqs)
+                },
         )
     }
 
     @Transactional
     fun upsert(applicantId: Long, command: SaveQuestionnaireCommand): QuestionnaireDto {
-        applicantReader.readById(applicantId)
+        val applicant = applicantReader.readById(applicantId)
         userReader.readById(command.assignedInterviewerUserId)
 
         val questions = command.questions.mapIndexed { index, question ->
@@ -63,13 +84,54 @@ class QuestionnaireService(
             questions,
         )
 
+        val questionIds = saved.mapNotNull { it.id }
+        val mappings = questionnaireQuestionRequirementRepository.findAllByQuestionQuestionIds(questionIds)
+        val mappingsByQuestionId = mappings.groupBy { it.questionnaireQuestionId }
+
+        val requirements = partInterviewRequirementReader.readAllByPartIdAndSemester(applicant.part.id!!, applicant.applicationSemester)
+        val requirementsById = requirements.associateBy { it.id }
+
         return QuestionnaireDto(
             applicantId = applicantId,
             assignedInterviewerUserId = command.assignedInterviewerUserId,
             questions = saved
                 .sortedBy { it.sortOrder }
-                .map { it.toDto(fixedQuestionsById) },
+                .map { question ->
+                    val mappedReqs = mappingsByQuestionId[question.id].orEmpty().mapNotNull { m ->
+                        requirementsById[m.partInterviewRequirementId]?.let { req ->
+                            QuestionRequirementDto(req.id!!, req.content)
+                        }
+                    }
+                    question.toDto(fixedQuestionsById, mappedReqs)
+                },
         )
+    }
+
+    @Transactional
+    fun saveMappings(applicantId: Long, command: SaveQuestionnaireRequirementMappingCommand): QuestionnaireDto {
+        val applicant = applicantReader.readById(applicantId)
+
+        val questions = questionnaireReader.readQuestionsByApplicantId(applicantId)
+        val questionIds = questions.mapNotNull { it.id }.toSet()
+
+        // Clean up existing mappings for this questionnaire's questions
+        questionnaireQuestionRequirementRepository.deleteAllByQuestionQuestionIds(questionIds.toList())
+
+        // Save new mappings
+        val newMappings = command.toAllItems().flatMap { item ->
+            item.questionIds
+                .filter { questionIds.contains(it) } // Filter valid questionIds belonging to this applicant
+                .map { questionId ->
+                    QuestionnaireQuestionRequirement(
+                        questionnaireQuestionId = questionId,
+                        partInterviewRequirementId = item.requirementId,
+                    )
+                }
+        }
+
+        questionnaireQuestionRequirementRepository.saveAll(newMappings)
+
+        return readByApplicantId(applicantId)
     }
 
     private fun readFixedQuestionsById(questions: List<QuestionnaireQuestion>): Map<Long?, FixedQuestion> {
@@ -80,11 +142,15 @@ class QuestionnaireService(
 
     private fun QuestionnaireQuestion.toDto(
         fixedQuestionsById: Map<Long?, FixedQuestion>,
+        requirements: List<QuestionRequirementDto>,
     ): QuestionnaireQuestionDto = QuestionnaireQuestionDto(
         id = id!!,
         group = group,
         sourceQuestionId = sourceQuestionId,
         content = content ?: fixedQuestionsById[sourceQuestionId]?.content.orEmpty(),
         sortOrder = sortOrder,
+        requirements = requirements,
     )
 }
+
+

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/question/business/dto/QuestionRequirementDto.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/question/business/dto/QuestionRequirementDto.kt
@@ -1,0 +1,6 @@
+package com.yourssu.scouter.recruiting.question.business.dto
+
+data class QuestionRequirementDto(
+    val id: Long,
+    val content: String,
+)

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/question/business/dto/QuestionnaireQuestionDto.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/question/business/dto/QuestionnaireQuestionDto.kt
@@ -8,4 +8,7 @@ data class QuestionnaireQuestionDto(
     val sourceQuestionId: Long?,
     val content: String,
     val sortOrder: Int,
+    val requirements: List<QuestionRequirementDto> = emptyList(),
 )
+
+

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/question/business/dto/SaveQuestionnaireRequirementMappingCommand.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/question/business/dto/SaveQuestionnaireRequirementMappingCommand.kt
@@ -1,0 +1,17 @@
+package com.yourssu.scouter.recruiting.question.business.dto
+
+data class SaveQuestionnaireRequirementMappingCommand(
+    val culture: List<RequirementQuestionMappingItemCommand>,
+    val team: List<RequirementQuestionMappingItemCommand>,
+    val job: List<RequirementQuestionMappingItemCommand>,
+    val other: List<RequirementQuestionMappingItemCommand>,
+) {
+    fun toAllItems(): List<RequirementQuestionMappingItemCommand> {
+        return culture + team + job + other
+    }
+}
+
+data class RequirementQuestionMappingItemCommand(
+    val requirementId: Long,
+    val questionIds: List<Long>,
+)

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/question/implement/QuestionnaireQuestionRequirement.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/question/implement/QuestionnaireQuestionRequirement.kt
@@ -1,0 +1,7 @@
+package com.yourssu.scouter.recruiting.question.implement
+
+class QuestionnaireQuestionRequirement(
+    val id: Long? = null,
+    val questionnaireQuestionId: Long,
+    val partInterviewRequirementId: Long,
+)

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/question/implement/QuestionnaireQuestionRequirementRepository.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/question/implement/QuestionnaireQuestionRequirementRepository.kt
@@ -1,0 +1,7 @@
+package com.yourssu.scouter.recruiting.question.implement
+
+interface QuestionnaireQuestionRequirementRepository {
+    fun findAllByQuestionQuestionIds(questionnaireQuestionIds: List<Long>): List<QuestionnaireQuestionRequirement>
+    fun saveAll(mappings: List<QuestionnaireQuestionRequirement>): List<QuestionnaireQuestionRequirement>
+    fun deleteAllByQuestionQuestionIds(questionnaireQuestionIds: List<Long>)
+}

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/question/storage/JpaQuestionnaireQuestionRequirementRepository.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/question/storage/JpaQuestionnaireQuestionRequirementRepository.kt
@@ -1,0 +1,8 @@
+package com.yourssu.scouter.recruiting.question.storage
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface JpaQuestionnaireQuestionRequirementRepository : JpaRepository<QuestionnaireQuestionRequirementEntity, Long> {
+    fun findAllByQuestionnaireQuestionIdIn(questionnaireQuestionIds: List<Long>): List<QuestionnaireQuestionRequirementEntity>
+    fun deleteAllByQuestionnaireQuestionIdIn(questionnaireQuestionIds: List<Long>)
+}

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/question/storage/QuestionnaireQuestionRequirementEntity.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/question/storage/QuestionnaireQuestionRequirementEntity.kt
@@ -1,0 +1,38 @@
+package com.yourssu.scouter.recruiting.question.storage
+
+import com.yourssu.scouter.recruiting.question.implement.QuestionnaireQuestionRequirement
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+
+@Entity
+@Table(name = "questionnaire_question_requirement")
+class QuestionnaireQuestionRequirementEntity(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long? = null,
+
+    @Column(name = "questionnaire_question_id", nullable = false)
+    val questionnaireQuestionId: Long,
+
+    @Column(name = "part_interview_requirement_id", nullable = false)
+    val partInterviewRequirementId: Long,
+) {
+    fun toDomain(): QuestionnaireQuestionRequirement = QuestionnaireQuestionRequirement(
+        id = id,
+        questionnaireQuestionId = questionnaireQuestionId,
+        partInterviewRequirementId = partInterviewRequirementId,
+    )
+
+    companion object {
+        fun from(domain: QuestionnaireQuestionRequirement): QuestionnaireQuestionRequirementEntity =
+            QuestionnaireQuestionRequirementEntity(
+                id = domain.id,
+                questionnaireQuestionId = domain.questionnaireQuestionId,
+                partInterviewRequirementId = domain.partInterviewRequirementId,
+            )
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/question/storage/QuestionnaireQuestionRequirementRepositoryImpl.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/question/storage/QuestionnaireQuestionRequirementRepositoryImpl.kt
@@ -1,0 +1,27 @@
+package com.yourssu.scouter.recruiting.question.storage
+
+import com.yourssu.scouter.recruiting.question.implement.QuestionnaireQuestionRequirement
+import com.yourssu.scouter.recruiting.question.implement.QuestionnaireQuestionRequirementRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+class QuestionnaireQuestionRequirementRepositoryImpl(
+    private val jpaRepository: JpaQuestionnaireQuestionRequirementRepository,
+) : QuestionnaireQuestionRequirementRepository {
+
+    override fun findAllByQuestionQuestionIds(questionnaireQuestionIds: List<Long>): List<QuestionnaireQuestionRequirement> {
+        if (questionnaireQuestionIds.isEmpty()) return emptyList()
+        return jpaRepository.findAllByQuestionnaireQuestionIdIn(questionnaireQuestionIds)
+            .map { it.toDomain() }
+    }
+
+    override fun saveAll(mappings: List<QuestionnaireQuestionRequirement>): List<QuestionnaireQuestionRequirement> {
+        val entities = mappings.map { QuestionnaireQuestionRequirementEntity.from(it) }
+        return jpaRepository.saveAll(entities).map { it.toDomain() }
+    }
+
+    override fun deleteAllByQuestionQuestionIds(questionnaireQuestionIds: List<Long>) {
+        if (questionnaireQuestionIds.isEmpty()) return
+        jpaRepository.deleteAllByQuestionnaireQuestionIdIn(questionnaireQuestionIds)
+    }
+}

--- a/src/main/resources/db/migration/V34__create_questionnaire_question_requirement_table.sql
+++ b/src/main/resources/db/migration/V34__create_questionnaire_question_requirement_table.sql
@@ -1,0 +1,11 @@
+CREATE TABLE questionnaire_question_requirement (
+    id                             BIGINT AUTO_INCREMENT PRIMARY KEY,
+    questionnaire_question_id     BIGINT NOT NULL,
+    part_interview_requirement_id  BIGINT NOT NULL,
+    CONSTRAINT fk_qqr_questionnaire_question 
+        FOREIGN KEY (questionnaire_question_id) REFERENCES questionnaire_question (id) ON DELETE CASCADE,
+    CONSTRAINT fk_qqr_part_interview_requirement 
+        FOREIGN KEY (part_interview_requirement_id) REFERENCES part_interview_requirement (id) ON DELETE CASCADE,
+    CONSTRAINT uq_qqr_question_requirement 
+        UNIQUE (questionnaire_question_id, part_interview_requirement_id)
+);

--- a/src/test/kotlin/com/yourssu/scouter/recruiting/question/business/QuestionnaireServiceTest.kt
+++ b/src/test/kotlin/com/yourssu/scouter/recruiting/question/business/QuestionnaireServiceTest.kt
@@ -9,6 +9,8 @@ import com.yourssu.scouter.auth.user.implement.UserReader
 import com.yourssu.scouter.recruiting.applicant.implement.ApplicantReader
 import com.yourssu.scouter.recruiting.applicant.implement.fixture.ApplicantFixtureBuilder
 import com.yourssu.scouter.recruiting.interview.implement.PartInterviewRequirementReader
+import com.yourssu.scouter.common.fixture.PartFixtureBuilder
+import com.yourssu.scouter.common.fixture.SemesterFixtureBuilder
 import com.yourssu.scouter.recruiting.question.business.dto.SaveQuestionnaireCommand
 import com.yourssu.scouter.recruiting.question.business.dto.SaveQuestionnaireQuestionCommand
 import com.yourssu.scouter.recruiting.question.implement.FixedQuestion
@@ -101,7 +103,13 @@ class QuestionnaireServiceTest {
             partInterviewRequirementReader,
         )
 
-        whenever(applicantReader.readById(applicantId)).thenReturn(ApplicantFixtureBuilder().id(applicantId).build())
+        whenever(applicantReader.readById(applicantId)).thenReturn(
+            ApplicantFixtureBuilder()
+                .id(applicantId)
+                .part(PartFixtureBuilder().id(1L).build())
+                .applicationSemester(SemesterFixtureBuilder().id(1L).build())
+                .build(),
+        )
         whenever(userReader.readById(interviewerUserId)).thenReturn(user(interviewerUserId))
         whenever(questionnaireQuestionRequirementRepository.findAllByQuestionQuestionIds(any())).thenReturn(emptyList())
         whenever(partInterviewRequirementReader.readAllByPartIdAndSemester(any(), any())).thenReturn(emptyList())

--- a/src/test/kotlin/com/yourssu/scouter/recruiting/question/business/QuestionnaireServiceTest.kt
+++ b/src/test/kotlin/com/yourssu/scouter/recruiting/question/business/QuestionnaireServiceTest.kt
@@ -8,6 +8,7 @@ import com.yourssu.scouter.auth.user.implement.UserInfo
 import com.yourssu.scouter.auth.user.implement.UserReader
 import com.yourssu.scouter.recruiting.applicant.implement.ApplicantReader
 import com.yourssu.scouter.recruiting.applicant.implement.fixture.ApplicantFixtureBuilder
+import com.yourssu.scouter.recruiting.interview.implement.PartInterviewRequirementReader
 import com.yourssu.scouter.recruiting.question.business.dto.SaveQuestionnaireCommand
 import com.yourssu.scouter.recruiting.question.business.dto.SaveQuestionnaireQuestionCommand
 import com.yourssu.scouter.recruiting.question.implement.FixedQuestion
@@ -19,6 +20,7 @@ import com.yourssu.scouter.recruiting.question.implement.QuestionnaireQuestion
 import com.yourssu.scouter.recruiting.question.implement.QuestionnaireValidator
 import com.yourssu.scouter.recruiting.question.implement.QuestionnaireReader
 import com.yourssu.scouter.recruiting.question.implement.QuestionnaireWriter
+import com.yourssu.scouter.recruiting.question.implement.QuestionnaireQuestionRequirementRepository
 import com.yourssu.scouter.recruiting.support.implement.exception.ApplicantNotFoundException
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
@@ -39,6 +41,8 @@ class QuestionnaireServiceTest {
     private lateinit var fixedQuestionReader: FixedQuestionReader
     private lateinit var applicantReader: ApplicantReader
     private lateinit var userReader: UserReader
+    private lateinit var questionnaireQuestionRequirementRepository: QuestionnaireQuestionRequirementRepository
+    private lateinit var partInterviewRequirementReader: PartInterviewRequirementReader
     private lateinit var questionnaireService: QuestionnaireService
 
     private val applicantId = 1L
@@ -83,6 +87,8 @@ class QuestionnaireServiceTest {
         fixedQuestionReader = mock(FixedQuestionReader::class.java)
         applicantReader = mock(ApplicantReader::class.java)
         userReader = mock(UserReader::class.java)
+        questionnaireQuestionRequirementRepository = mock(QuestionnaireQuestionRequirementRepository::class.java)
+        partInterviewRequirementReader = mock(PartInterviewRequirementReader::class.java)
 
         questionnaireService = QuestionnaireService(
             questionnaireReader,
@@ -91,10 +97,14 @@ class QuestionnaireServiceTest {
             questionnaireValidator,
             applicantReader,
             userReader,
+            questionnaireQuestionRequirementRepository,
+            partInterviewRequirementReader,
         )
 
         whenever(applicantReader.readById(applicantId)).thenReturn(ApplicantFixtureBuilder().id(applicantId).build())
         whenever(userReader.readById(interviewerUserId)).thenReturn(user(interviewerUserId))
+        whenever(questionnaireQuestionRequirementRepository.findAllByQuestionQuestionIds(any())).thenReturn(emptyList())
+        whenever(partInterviewRequirementReader.readAllByPartIdAndSemester(any(), any())).thenReturn(emptyList())
     }
 
     @Nested


### PR DESCRIPTION
## 📄 작업 내용 요약
# [#347] 면접 요구조건과 질문 매핑 API 추가

## 작업 내용

- 지원자별 면접 질문과 파트별 면접 요구조건을 매핑하는 API를 추가했습니다.
- 기존 매핑을 전체 교체할 수 있도록 그룹별 요구조건 ID와 질문 ID 목록을 받도록 구현했습니다.
- 면접 질문 조회 및 질문지 수정 응답에 질문별 매핑 요구조건 목록을 포함했습니다.
- 질문-요구조건 매핑을 저장하기 위한 `questionnaire_question_requirement` 테이블과 저장소 계층을 추가했습니다.
- 변경된 면접 평가 문항 API의 요청/응답 및 검증 규칙을 문서화했습니다.

## API

- `PUT /applicants/{applicantId}/interviews/questionnaires/requirements`
- `GET /applicants/{applicantId}/interviews/questionnaires`
- `PUT /parts/{partId}/interviews/rubrics/{semester}` 응답에 평가 문항 ID, 그룹별 합계, 잠금 상태를 명세

## 주요 동작

- 매핑 저장 시 해당 지원자의 질문에 대한 기존 매핑을 삭제하고 요청 내용으로 다시 저장합니다.
- 질문 조회 시 현재 지원자의 파트·지원 학기에 존재하는 요구조건만 응답합니다.
- 면접 평가 문항은 전체 배점 합계 100인지 검증합니다.
- 면접 평가가 임시저장 또는 확정된 경우 평가 문항을 수정할 수 없습니다.




## 📎 Issue 번호
closed #347

