### PR TITLE
[#351] feat: applicant 조회 필터링 변경

### DIFF
--- a/src/main/kotlin/com/yourssu/scouter/recruiting/applicant/application/ApplicantController.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/applicant/application/ApplicantController.kt
@@ -13,6 +13,7 @@ import com.yourssu.scouter.recruiting.applicant.business.dto.ApplicantDto
 import com.yourssu.scouter.recruiting.applicant.business.ApplicantPrivacyService
 import com.yourssu.scouter.recruiting.applicant.business.ApplicantService
 import com.yourssu.scouter.recruiting.support.business.exception.ApplicantAccessDeniedException
+import com.yourssu.scouter.common.support.application.exception.ExceptionResponse
 import com.yourssu.scouter.recruiting.applicant.implement.ApplicantSort
 import com.yourssu.scouter.auth.support.application.authentication.AuthUser
 import com.yourssu.scouter.auth.support.application.authentication.AuthUserInfo
@@ -24,6 +25,7 @@ import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.ExampleObject
 import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.Valid
 import org.springframework.http.ResponseEntity
@@ -65,11 +67,28 @@ class ApplicantController(
         summary = "지원자 목록 조회",
         description = "지원자 목록을 검색, 필터링을 통해 얻습니다. 필터링에 필요한 정보는 각 api에서 얻어야 합니다."
     )
+    @ApiResponses(
+        ApiResponse(responseCode = "200", description = "OK"),
+        ApiResponse(
+            responseCode = "400",
+            description = "잘못된 요청 (states/sort 값이 허용되지 않는 값인 경우)",
+            content = [
+                Content(schema = Schema(implementation = ExceptionResponse::class)),
+            ],
+        ),
+        ApiResponse(
+            responseCode = "404",
+            description = "존재하지 않는 semesterId 또는 partId를 조회한 경우",
+            content = [
+                Content(schema = Schema(implementation = ExceptionResponse::class)),
+            ],
+        ),
+    )
     @GetMapping("/applicants")
     fun readAll(
         @AuthUser authUserInfo: AuthUserInfo,
         @RequestParam(required = false) name: String?,
-        @RequestParam(required = false) state: String?,
+        @RequestParam(required = false) states: List<String>?,
         @RequestParam(required = false) semesterId: Long?,
         @RequestParam(required = false) partId: Long?,
         @RequestParam(required = false, defaultValue = "DEFAULT") sort: String = "DEFAULT",
@@ -78,7 +97,7 @@ class ApplicantController(
             .getOrElse { throw IllegalArgumentException("허용되지 않는 sort 값입니다: $sort") }
         val applicantDtos: List<ApplicantDto> = applicantService.readAllByFilters(
             name = name,
-            state = state,
+            states = states,
             semesterId = semesterId,
             partId = partId,
             sort = applicantSort,

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/applicant/business/ApplicantService.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/applicant/business/ApplicantService.kt
@@ -63,7 +63,7 @@ class ApplicantService(
 
     fun readAllByFilters(
         name: String?,
-        state: String?,
+        states: List<String>?,
         semesterId: Long?,
         partId: Long?,
         sort: ApplicantSort = ApplicantSort.DEFAULT,
@@ -73,10 +73,12 @@ class ApplicantService(
         if (!name.isNullOrEmpty()) {
             applicants = applicants.filter { it.name.contains(name, ignoreCase = true) }
         }
-        if (!state.isNullOrEmpty()) {
-            val applicantState: ApplicantState = runCatching { ApplicantState.valueOf(state) }
-                .getOrElse { throw IllegalArgumentException("허용되지 않는 state 값입니다: $state") }
-            applicants = applicants.filter { it.state == applicantState }
+        if (!states.isNullOrEmpty()) {
+            val applicantStates: List<ApplicantState> = states.map { state ->
+                runCatching { ApplicantState.valueOf(state) }
+                    .getOrElse { throw IllegalArgumentException("허용되지 않는 state 값입니다: $state") }
+            }
+            applicants = applicants.filter { it.state in applicantStates }
         }
         if (semesterId != null) {
             val semester: Semester = semesterReader.readById(semesterId)

--- a/src/test/kotlin/com/yourssu/scouter/recruiting/applicant/application/ApplicantControllerPrivacyTest.kt
+++ b/src/test/kotlin/com/yourssu/scouter/recruiting/applicant/application/ApplicantControllerPrivacyTest.kt
@@ -49,7 +49,7 @@ class ApplicantControllerPrivacyTest {
             val restrictedDto = createApplicantDto(partId = 20L, name = "접근불가")
             val allDtos = listOf(accessibleDto, restrictedDto)
 
-            whenever(applicantService.readAllByFilters(name = null, state = null, semesterId = null, partId = null))
+            whenever(applicantService.readAllByFilters(name = null, states = null, semesterId = null, partId = null))
                 .thenReturn(allDtos)
             whenever(applicantPrivacyService.filterAccessibleApplicants(any<ApplicantAccessScope>(), eq(allDtos)))
                 .thenReturn(listOf(accessibleDto))
@@ -58,7 +58,7 @@ class ApplicantControllerPrivacyTest {
             val responseEntity = controller.readAll(
                 authUserInfo = authUserInfo,
                 name = null,
-                state = null,
+                states = null,
                 semesterId = null,
                 partId = null,
             )
@@ -75,7 +75,7 @@ class ApplicantControllerPrivacyTest {
             val authUserInfo = AuthUserInfo(userId = 1L)
             val dto = createApplicantDto(partId = 10L)
 
-            whenever(applicantService.readAllByFilters(name = null, state = null, semesterId = null, partId = null))
+            whenever(applicantService.readAllByFilters(name = null, states = null, semesterId = null, partId = null))
                 .thenReturn(listOf(dto))
             whenever(applicantPrivacyService.filterAccessibleApplicants(any<ApplicantAccessScope>(), any()))
                 .thenReturn(emptyList())
@@ -84,7 +84,7 @@ class ApplicantControllerPrivacyTest {
             val responseEntity = controller.readAll(
                 authUserInfo = authUserInfo,
                 name = null,
-                state = null,
+                states = null,
                 semesterId = null,
                 partId = null,
             )


### PR DESCRIPTION
## 요약
- 지원자 목록 조회(`GET /applicants`) API의 `state` 필터를 단일 문자열에서 배열(`states`)로 변경
- `states`에 허용되지 않는 값이 포함되거나 `sort` 값이 잘못된 경우 400, 존재하지 않는 `semesterId`/`partId`인 경우 404 에러 응답을 swagger 문서에 명시

## 관련 이슈
closes #351

## 변경 사항
- `ApplicantController.readAll`: `state: String?` → `states: List<String>?`
- `ApplicantService.readAllByFilters`: 여러 state 값을 매핑해 `in` 필터링하도록 수정
- swagger `@ApiResponses`에 400/404 에러 응답 스펙 추가
- 관련 테스트(`ApplicantControllerPrivacyTest`) 파라미터명 갱신

## 테스트
- [x] `./gradlew compileKotlin compileTestKotlin`
- [x] `./gradlew test --tests "*ApplicantControllerPrivacyTest*"`