### PR TITLE
[#358]; feat: 지원자별 과제 평가 API 구현

### DIFF
--- a/src/main/kotlin/com/yourssu/scouter/common/part/implement/Part.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/part/implement/Part.kt
@@ -7,7 +7,7 @@ class Part(
     val division: Division,
     val name: String,
     val sortPriority: Int,
-    val hasAssignment: Boolean = false,
+    val hasAssignment: Boolean,
 ) : Comparable<Part> {
 
     override fun compareTo(other: Part): Int {

--- a/src/main/kotlin/com/yourssu/scouter/common/support/implement/initialization/DivisionsAndPartsInitializer.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/support/implement/initialization/DivisionsAndPartsInitializer.kt
@@ -34,12 +34,12 @@ class DivisionsAndPartsInitializer(
         val division = divisionRepository.save(Division(name = "운영", sortPriority = 1))
 
         val parts = mutableListOf<Part>()
-        parts.add(Part(division = division, name = "Head lead", sortPriority = 1))
-        parts.add(Part(division = division, name = "Finance", sortPriority = 2))
-        parts.add(Part(division = division, name = "HR", sortPriority = 3))
-        parts.add(Part(division = division, name = "Marketing", sortPriority = 4))
-        parts.add(Part(division = division, name = "Legal", sortPriority = 5))
-        parts.add(Part(division = division, name = "PM", sortPriority = 6))
+        parts.add(Part(division = division, hasAssignment = false, name ="Head lead", sortPriority = 1))
+        parts.add(Part(division = division, hasAssignment = false, name ="Finance", sortPriority = 2))
+        parts.add(Part(division = division, hasAssignment = false, name ="HR", sortPriority = 3))
+        parts.add(Part(division = division, hasAssignment = false, name ="Marketing", sortPriority = 4))
+        parts.add(Part(division = division, hasAssignment = false, name ="Legal", sortPriority = 5))
+        parts.add(Part(division = division, hasAssignment = false, name ="PM", sortPriority = 6))
 
         partRepository.saveAll(parts)
     }
@@ -47,10 +47,10 @@ class DivisionsAndPartsInitializer(
     private fun initialize_개발() {
         val division = divisionRepository.save(Division(name = "개발", sortPriority = 2))
         val parts = mutableListOf<Part>()
-        parts.add(Part(division = division, name = "Backend", sortPriority = 1))
-        parts.add(Part(division = division, name = "Android", sortPriority = 2))
-        parts.add(Part(division = division, name = "iOS", sortPriority = 3))
-        parts.add(Part(division = division, name = "Frontend", sortPriority = 4))
+        parts.add(Part(division = division, hasAssignment = false, name ="Backend", sortPriority = 1))
+        parts.add(Part(division = division, hasAssignment = false, name ="Android", sortPriority = 2))
+        parts.add(Part(division = division, hasAssignment = false, name ="iOS", sortPriority = 3))
+        parts.add(Part(division = division, hasAssignment = false, name ="Frontend", sortPriority = 4))
 
         partRepository.saveAll(parts)
     }
@@ -59,7 +59,7 @@ class DivisionsAndPartsInitializer(
         val division = divisionRepository.save(Division(name = "디자인", sortPriority = 3))
 
         val parts = mutableListOf<Part>()
-        parts.add(Part(division = division, name = "Product Design", sortPriority = 1))
+        parts.add(Part(division = division, hasAssignment = false, name ="Product Design", sortPriority = 1))
 
         partRepository.saveAll(parts)
     }

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/applicant/application/ApplicantController.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/applicant/application/ApplicantController.kt
@@ -1,6 +1,7 @@
 package com.yourssu.scouter.recruiting.applicant.application
 
 import com.yourssu.scouter.recruiting.applicant.application.dto.UpdateApplicantRequest
+import com.yourssu.scouter.recruiting.applicant.application.dto.UpdateAssignmentResultRequest
 
 import com.yourssu.scouter.recruiting.applicant.application.dto.ReadApplicantResponse
 
@@ -150,6 +151,16 @@ class ApplicantController(
 
         val answers = applicantService.readAnswersByApplicantId(applicantId)
         return ResponseEntity.ok(answers.map(ReadApplicantAnswerResponse::from))
+    }
+
+    @Operation(summary = "지원자별 과제 평가", description = "지원자별 합격 여부(PASSED / FAILED)를 설정합니다.")
+    @PatchMapping("/applicants/{applicantId}/assignment")
+    fun updateAssignmentResult(
+        @PathVariable applicantId: Long,
+        @RequestBody @Valid request: UpdateAssignmentResultRequest,
+    ): ResponseEntity<Unit> {
+        applicantService.updateAssignmentResult(request.toCommand(applicantId))
+        return ResponseEntity.ok().build()
     }
 
     @Operation(summary = "지원자 삭제", description = "지원자 목록 조회에서 얻은 applicantId를 이용해 지원자를 삭제합니다.")

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/applicant/application/ApplicantController.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/applicant/application/ApplicantController.kt
@@ -154,7 +154,7 @@ class ApplicantController(
     }
 
     @Operation(summary = "지원자별 과제 평가", description = "지원자별 합격 여부(PASSED / FAILED)를 설정합니다.")
-    @PatchMapping("/applicants/{applicantId}/assignment")
+    @PatchMapping("/applicants/{applicantId}/assignments")
     fun updateAssignmentResult(
         @PathVariable applicantId: Long,
         @RequestBody @Valid request: UpdateAssignmentResultRequest,

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/applicant/application/dto/ReadApplicantResponse.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/applicant/application/dto/ReadApplicantResponse.kt
@@ -1,6 +1,7 @@
 package com.yourssu.scouter.recruiting.applicant.application.dto
 
 import com.yourssu.scouter.recruiting.applicant.business.dto.ApplicantDto
+import com.yourssu.scouter.recruiting.applicant.implement.AssignmentResult
 import java.time.Instant
 import java.time.LocalDate
 import java.time.ZoneOffset
@@ -16,6 +17,8 @@ data class ReadApplicantResponse(
     val name: String,
 
     val state: String,
+
+    val assignmentResult: AssignmentResult,
 
     val applicationDate: LocalDate,
 
@@ -47,6 +50,7 @@ data class ReadApplicantResponse(
             part = applicantDto.part.name,
             name = applicantDto.name,
             state = applicantDto.state.name,
+            assignmentResult = applicantDto.assignmentResult,
             applicationDate = applicantDto.applicationDateTime.atZone(ZoneOffset.UTC).toLocalDate(),
             email = applicantDto.email,
             phoneNumber = applicantDto.phoneNumber,

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/applicant/application/dto/UpdateAssignmentResultRequest.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/applicant/application/dto/UpdateAssignmentResultRequest.kt
@@ -1,0 +1,13 @@
+package com.yourssu.scouter.recruiting.applicant.application.dto
+
+import com.yourssu.scouter.recruiting.applicant.business.dto.UpdateAssignmentResultCommand
+import com.yourssu.scouter.recruiting.applicant.implement.AssignmentResult
+
+data class UpdateAssignmentResultRequest(
+    val assignmentResult: AssignmentResult,
+) {
+    fun toCommand(applicantId: Long) = UpdateAssignmentResultCommand(
+        applicantId = applicantId,
+        assignmentResult = assignmentResult,
+    )
+}

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/applicant/business/ApplicantService.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/applicant/business/ApplicantService.kt
@@ -1,6 +1,7 @@
 package com.yourssu.scouter.recruiting.applicant.business
 
 import com.yourssu.scouter.recruiting.applicant.business.dto.UpdateApplicantCommand
+import com.yourssu.scouter.recruiting.applicant.business.dto.UpdateAssignmentResultCommand
 
 import com.yourssu.scouter.recruiting.applicant.business.dto.CreateApplicantCommand
 
@@ -15,6 +16,7 @@ import com.yourssu.scouter.recruiting.applicant.implement.ApplicantReader
 import com.yourssu.scouter.recruiting.applicant.implement.ApplicantSort
 import com.yourssu.scouter.recruiting.applicant.implement.ApplicantState
 import com.yourssu.scouter.recruiting.applicant.implement.ApplicantWriter
+import com.yourssu.scouter.recruiting.applicant.implement.AssignmentEvaluationValidator
 import com.yourssu.scouter.common.department.implement.Department
 import com.yourssu.scouter.common.department.implement.DepartmentReader
 import com.yourssu.scouter.common.part.implement.Part
@@ -34,6 +36,7 @@ class ApplicantService(
     private val partReader: PartReader,
     private val semesterReader: SemesterReader,
     private val documentEvaluationReader: DocumentEvaluationReader,
+    private val assignmentEvaluationValidator: AssignmentEvaluationValidator,
 ) {
 
     fun create(command: CreateApplicantCommand): Long {
@@ -131,6 +134,7 @@ class ApplicantService(
             studentId = command.studentId ?: target.studentId,
             part = command.partId?.let { partReader.readById(it) } ?: target.part,
             state = command.state ?: target.state,
+            assignmentResult = target.assignmentResult,
             applicationDateTime = command.applicationDate?.atStartOfDay()?.toInstant(ZoneOffset.UTC) ?: target.applicationDateTime,
             applicationSemester = command.applicationSemesterId?.let { semesterReader.readById(it) }
                 ?: target.applicationSemester,
@@ -139,6 +143,12 @@ class ApplicantService(
         )
 
         applicantWriter.write(updated)
+    }
+
+    fun updateAssignmentResult(command: UpdateAssignmentResultCommand) {
+        val applicant = applicantReader.readById(command.applicantId)
+        assignmentEvaluationValidator.validate(applicant)
+        applicantWriter.updateAssignmentResult(command.applicantId, command.assignmentResult)
     }
 
     fun deleteById(applicantId: Long) {

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/applicant/business/FormResponseToApplicantProcessor.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/applicant/business/FormResponseToApplicantProcessor.kt
@@ -4,6 +4,7 @@ import com.yourssu.scouter.recruiting.support.business.utils.AgeNormalizer
 import com.yourssu.scouter.recruiting.support.business.utils.AvailableTimeParser
 import com.yourssu.scouter.recruiting.applicant.implement.Applicant
 import com.yourssu.scouter.recruiting.applicant.implement.ApplicantState
+import com.yourssu.scouter.recruiting.applicant.implement.AssignmentResult
 import com.yourssu.scouter.recruiting.applicant.implement.ApplicantSyncMapping
 import com.yourssu.scouter.common.part.implement.Part
 import com.yourssu.scouter.common.semester.implement.Semester
@@ -53,6 +54,7 @@ class FormResponseToApplicantProcessor(
             studentId = userResponse.getAnswer(question.studentIdQuestion) ?: "",
             part = part,
             state = ApplicantState.UNDER_REVIEW,
+            assignmentResult = AssignmentResult.NOT_SUBMITTED,
             applicationDateTime = userResponse.createTime,
             applicationSemester = applicationSemester,
             academicSemester = userResponse.getAnswer(question.academicSemesterQuestion) ?: "",
@@ -89,6 +91,7 @@ class FormResponseToApplicantProcessor(
             studentId = userResponse.getAnswer(applicantSyncMapping.studentIdQuestion) ?: "",
             part = applicantSyncMapping.part,
             state = ApplicantState.UNDER_REVIEW,
+            assignmentResult = AssignmentResult.NOT_SUBMITTED,
             applicationDateTime = userResponse.createTime,
             applicationSemester = applicantSyncMapping.applicationSemester,
             academicSemester = userResponse.getAnswer(applicantSyncMapping.academicSemesterQuestion) ?: "",

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/applicant/business/dto/ApplicantDto.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/applicant/business/dto/ApplicantDto.kt
@@ -2,6 +2,7 @@ package com.yourssu.scouter.recruiting.applicant.business.dto
 
 import com.yourssu.scouter.recruiting.applicant.implement.Applicant
 import com.yourssu.scouter.recruiting.applicant.implement.ApplicantState
+import com.yourssu.scouter.recruiting.applicant.implement.AssignmentResult
 import com.yourssu.scouter.common.part.business.dto.PartDto
 import com.yourssu.scouter.common.semester.business.dto.SemesterDto
 import java.time.Instant
@@ -16,6 +17,7 @@ data class ApplicantDto(
     val studentId: String,
     val part: PartDto,
     val state: ApplicantState,
+    val assignmentResult: AssignmentResult,
     val applicationDateTime: Instant,
     val applicationSemester: SemesterDto,
     val academicSemester: String,
@@ -35,6 +37,7 @@ data class ApplicantDto(
             studentId = applicant.studentId,
             part = PartDto.from(applicant.part),
             state = applicant.state,
+            assignmentResult = applicant.assignmentResult,
             applicationDateTime = applicant.applicationDateTime,
             applicationSemester = SemesterDto.from(applicant.applicationSemester),
             academicSemester = applicant.academicSemester,

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/applicant/business/dto/CreateApplicantCommand.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/applicant/business/dto/CreateApplicantCommand.kt
@@ -2,6 +2,7 @@ package com.yourssu.scouter.recruiting.applicant.business.dto
 
 import com.yourssu.scouter.recruiting.applicant.implement.Applicant
 import com.yourssu.scouter.recruiting.applicant.implement.ApplicantState
+import com.yourssu.scouter.recruiting.applicant.implement.AssignmentResult
 import com.yourssu.scouter.common.department.implement.Department
 import com.yourssu.scouter.common.part.implement.Part
 import com.yourssu.scouter.common.semester.implement.Semester
@@ -37,6 +38,7 @@ data class CreateApplicantCommand(
         studentId = studentId,
         part = part,
         state = state,
+        assignmentResult = AssignmentResult.NOT_SUBMITTED,
         applicationDateTime = applicationDate.atStartOfDay().toInstant(ZoneOffset.UTC),
         applicationSemester = applicationSemester,
         academicSemester = academicSemester,

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/applicant/business/dto/UpdateAssignmentResultCommand.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/applicant/business/dto/UpdateAssignmentResultCommand.kt
@@ -1,0 +1,8 @@
+package com.yourssu.scouter.recruiting.applicant.business.dto
+
+import com.yourssu.scouter.recruiting.applicant.implement.AssignmentResult
+
+data class UpdateAssignmentResultCommand(
+    val applicantId: Long,
+    val assignmentResult: AssignmentResult,
+)

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/applicant/implement/Applicant.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/applicant/implement/Applicant.kt
@@ -14,6 +14,7 @@ class Applicant(
     val studentId: String,
     val part: Part,
     val state: ApplicantState,
+    val assignmentResult: AssignmentResult,
     val applicationDateTime: Instant,
     val applicationSemester: Semester,
     val academicSemester: String,

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/applicant/implement/ApplicantRepository.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/applicant/implement/ApplicantRepository.kt
@@ -25,4 +25,6 @@ interface ApplicantRepository {
     fun findAllByIdIn(applicantIds: List<Long>): List<Applicant>
 
     fun findAllByEmailIn(emails: List<String>): List<Applicant>
+
+    fun updateAssignmentResult(applicantId: Long, assignmentResult: AssignmentResult)
 }

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/applicant/implement/ApplicantWriter.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/applicant/implement/ApplicantWriter.kt
@@ -17,6 +17,10 @@ class ApplicantWriter(
         return applicantRepository.saveAll(applicants)
     }
 
+    fun updateAssignmentResult(applicantId: Long, assignmentResult: AssignmentResult) {
+        applicantRepository.updateAssignmentResult(applicantId, assignmentResult)
+    }
+
     fun delete(applicant: Applicant) {
         applicantRepository.deleteById(applicant.id!!)
     }

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/applicant/implement/AssignmentEvaluationValidator.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/applicant/implement/AssignmentEvaluationValidator.kt
@@ -1,0 +1,14 @@
+package com.yourssu.scouter.recruiting.applicant.implement
+
+import com.yourssu.scouter.recruiting.support.implement.exception.AssignmentEvaluationNotAllowedException
+import org.springframework.stereotype.Component
+
+@Component
+class AssignmentEvaluationValidator {
+
+    fun validate(applicant: Applicant) {
+        if (!applicant.part.hasAssignment) {
+            throw AssignmentEvaluationNotAllowedException("해당 파트는 과제 평가를 사용하지 않습니다: ${applicant.part.name}")
+        }
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/applicant/implement/AssignmentResult.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/applicant/implement/AssignmentResult.kt
@@ -1,0 +1,8 @@
+package com.yourssu.scouter.recruiting.applicant.implement
+
+enum class AssignmentResult {
+
+    NOT_SUBMITTED,
+    PASSED,
+    FAILED,
+}

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/applicant/storage/ApplicantEntity.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/applicant/storage/ApplicantEntity.kt
@@ -2,6 +2,7 @@ package com.yourssu.scouter.recruiting.applicant.storage
 
 import com.yourssu.scouter.recruiting.applicant.implement.Applicant
 import com.yourssu.scouter.recruiting.applicant.implement.ApplicantState
+import com.yourssu.scouter.recruiting.applicant.implement.AssignmentResult
 import com.yourssu.scouter.common.part.storage.PartEntity
 import com.yourssu.scouter.common.semester.storage.SemesterEntity
 import jakarta.persistence.Column
@@ -53,6 +54,10 @@ class ApplicantEntity(
     val state: ApplicantState,
 
     @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    val assignmentResult: AssignmentResult,
+
+    @Column(nullable = false)
     val applicationDateTime: Instant,
 
     @ManyToOne(fetch = FetchType.EAGER)
@@ -74,6 +79,7 @@ class ApplicantEntity(
             studentId = applicant.studentId,
             part = PartEntity.from(applicant.part),
             state = applicant.state,
+            assignmentResult = applicant.assignmentResult,
             applicationDateTime = applicant.applicationDateTime,
             applicationSemester = SemesterEntity.from(applicant.applicationSemester),
             academicSemester = applicant.academicSemester,
@@ -90,6 +96,7 @@ class ApplicantEntity(
         studentId = studentId,
         part = part.toDomain(),
         state = state,
+        assignmentResult = assignmentResult,
         applicationDateTime = applicationDateTime,
         applicationSemester = applicationSemester.toDomain(),
         academicSemester = academicSemester,

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/applicant/storage/ApplicantRepositoryImpl.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/applicant/storage/ApplicantRepositoryImpl.kt
@@ -3,6 +3,7 @@ package com.yourssu.scouter.recruiting.applicant.storage
 import com.yourssu.scouter.recruiting.applicant.implement.Applicant
 import com.yourssu.scouter.recruiting.applicant.implement.ApplicantRepository
 import com.yourssu.scouter.recruiting.applicant.implement.ApplicantState
+import com.yourssu.scouter.recruiting.applicant.implement.AssignmentResult
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Repository
 
@@ -82,6 +83,10 @@ class ApplicantRepositoryImpl(
 
     override fun findAllByEmailIn(emails: List<String>): List<Applicant> {
         return jpaApplicantRepository.findAllByEmailIn(emails).map { it.toDomain(emptyList()) }
+    }
+
+    override fun updateAssignmentResult(applicantId: Long, assignmentResult: AssignmentResult) {
+        jpaApplicantRepository.updateAssignmentResult(applicantId, assignmentResult)
     }
 
     override fun deleteById(applicantId: Long) {

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/applicant/storage/JpaApplicantRepository.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/applicant/storage/JpaApplicantRepository.kt
@@ -1,7 +1,10 @@
 package com.yourssu.scouter.recruiting.applicant.storage
 
 import com.yourssu.scouter.recruiting.applicant.implement.ApplicantState
+import com.yourssu.scouter.recruiting.applicant.implement.AssignmentResult
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
+import org.springframework.data.jpa.repository.Query
 
 interface JpaApplicantRepository : JpaRepository<ApplicantEntity, Long> {
 
@@ -12,4 +15,8 @@ interface JpaApplicantRepository : JpaRepository<ApplicantEntity, Long> {
     fun findAllByPartId(partId: Long): List<ApplicantEntity>
     fun findAllByPartIdAndState(partId: Long, state: ApplicantState): List<ApplicantEntity>
     fun findAllByEmailIn(emails: List<String>): List<ApplicantEntity>
+
+    @Modifying
+    @Query("UPDATE ApplicantEntity a SET a.assignmentResult = :assignmentResult WHERE a.id = :applicantId")
+    fun updateAssignmentResult(applicantId: Long, assignmentResult: AssignmentResult)
 }

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/support/implement/exception/AssignmentEvaluationNotAllowedException.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/support/implement/exception/AssignmentEvaluationNotAllowedException.kt
@@ -1,0 +1,8 @@
+package com.yourssu.scouter.recruiting.support.implement.exception
+
+import com.yourssu.scouter.common.support.implement.exception.CustomException
+import org.springframework.http.HttpStatus
+
+class AssignmentEvaluationNotAllowedException(
+    message: String,
+) : CustomException(message, "Assignment-001", HttpStatus.BAD_REQUEST)

--- a/src/main/resources/db/migration/V39__add_assignment_result_to_applicant.sql
+++ b/src/main/resources/db/migration/V39__add_assignment_result_to_applicant.sql
@@ -1,0 +1,2 @@
+ALTER TABLE applicant
+    ADD COLUMN assignment_result VARCHAR(20) NOT NULL DEFAULT 'NOT_SUBMITTED';

--- a/src/test/kotlin/com/yourssu/scouter/common/fixture/PartFixtureBuilder.kt
+++ b/src/test/kotlin/com/yourssu/scouter/common/fixture/PartFixtureBuilder.kt
@@ -18,6 +18,7 @@ class PartFixtureBuilder {
         id = id,
         division = division,
         name = name,
-        sortPriority = sortPriority
+        sortPriority = sortPriority,
+        hasAssignment = false,
     )
 }

--- a/src/test/kotlin/com/yourssu/scouter/hrms/member/business/MemberPrivacyServiceTest.kt
+++ b/src/test/kotlin/com/yourssu/scouter/hrms/member/business/MemberPrivacyServiceTest.kt
@@ -131,6 +131,7 @@ class MemberPrivacyServiceTest {
                 division = division,
                 name = name,
                 sortPriority = index,
+                hasAssignment = false,
             )
         }.toSortedSet()
         val department = Department(

--- a/src/test/kotlin/com/yourssu/scouter/hrms/member/implement/parser/ApplicantPassSheetProcessorTest.kt
+++ b/src/test/kotlin/com/yourssu/scouter/hrms/member/implement/parser/ApplicantPassSheetProcessorTest.kt
@@ -33,7 +33,7 @@ class ApplicantPassSheetProcessorTest {
     private lateinit var processor: ApplicantPassSheetProcessor
 
     private val division = Division(id = 1L, name = "개발", sortPriority = 1)
-    private val part = Part(id = 1L, division = division, name = "Backend", sortPriority = 1)
+    private val part = Part(id = 1L, division = division, name = "Backend", sortPriority = 1, hasAssignment = false)
     private val department = Department(id = 1L, collegeId = 1L, name = "컴퓨터학부")
     private val joinDate = LocalDate.of(2025, 9, 1)
 

--- a/src/test/kotlin/com/yourssu/scouter/recruiting/applicant/implement/fixture/ApplicantFixtureBuilder.kt
+++ b/src/test/kotlin/com/yourssu/scouter/recruiting/applicant/implement/fixture/ApplicantFixtureBuilder.kt
@@ -2,6 +2,7 @@ package com.yourssu.scouter.recruiting.applicant.implement.fixture
 
 import com.yourssu.scouter.recruiting.applicant.implement.Applicant
 import com.yourssu.scouter.recruiting.applicant.implement.ApplicantState
+import com.yourssu.scouter.recruiting.applicant.implement.AssignmentResult
 import com.yourssu.scouter.common.fixture.PartFixtureBuilder
 import com.yourssu.scouter.common.fixture.SemesterFixtureBuilder
 import com.yourssu.scouter.common.part.implement.Part
@@ -50,6 +51,7 @@ class ApplicantFixtureBuilder {
         studentId = studentId,
         part = part,
         state = state,
+        assignmentResult = AssignmentResult.NOT_SUBMITTED,
         applicationDateTime = applicationDateTime,
         applicationSemester = applicationSemester,
         academicSemester = academicSemester,

--- a/src/test/kotlin/com/yourssu/scouter/recruiting/evaluation/storage/DocumentEvaluationRepositoryImplTest.kt
+++ b/src/test/kotlin/com/yourssu/scouter/recruiting/evaluation/storage/DocumentEvaluationRepositoryImplTest.kt
@@ -1,6 +1,7 @@
 package com.yourssu.scouter.recruiting.evaluation.storage
 
 import com.yourssu.scouter.recruiting.applicant.implement.ApplicantState
+import com.yourssu.scouter.recruiting.applicant.implement.AssignmentResult
 import com.yourssu.scouter.recruiting.evaluation.implement.DocumentEvaluation
 import com.yourssu.scouter.recruiting.evaluation.implement.DocumentEvaluationItem
 import com.yourssu.scouter.recruiting.evaluation.implement.DocumentResult
@@ -63,6 +64,7 @@ class DocumentEvaluationRepositoryImplTest {
                 studentId = "202401002",
                 part = part,
                 state = ApplicantState.UNDER_REVIEW,
+                assignmentResult = AssignmentResult.NOT_SUBMITTED,
                 applicationDateTime = Instant.parse("2025-11-13T00:00:00Z"),
                 applicationSemester = semester,
                 academicSemester = "3-2",

--- a/src/test/kotlin/com/yourssu/scouter/recruiting/interview/storage/InterviewMemoRepositoryImplTest.kt
+++ b/src/test/kotlin/com/yourssu/scouter/recruiting/interview/storage/InterviewMemoRepositoryImplTest.kt
@@ -7,6 +7,7 @@ import com.yourssu.scouter.common.part.storage.PartEntity
 import com.yourssu.scouter.common.semester.implement.Term
 import com.yourssu.scouter.common.semester.storage.SemesterEntity
 import com.yourssu.scouter.recruiting.applicant.implement.ApplicantState
+import com.yourssu.scouter.recruiting.applicant.implement.AssignmentResult
 import com.yourssu.scouter.recruiting.applicant.storage.ApplicantEntity
 import com.yourssu.scouter.recruiting.interview.implement.InterviewMemo
 import com.yourssu.scouter.recruiting.interviewQuestion.implement.AssignedQuestionCategory
@@ -51,6 +52,7 @@ class InterviewMemoRepositoryImplTest {
                 studentId = "202401002",
                 part = part,
                 state = ApplicantState.UNDER_REVIEW,
+                assignmentResult = AssignmentResult.NOT_SUBMITTED,
                 applicationDateTime = Instant.parse("2025-11-13T00:00:00Z"),
                 applicationSemester = semester,
                 academicSemester = "3-2",

--- a/src/test/kotlin/com/yourssu/scouter/recruiting/interviewQuestion/storage/AssignedQuestionRepositoryImplTest.kt
+++ b/src/test/kotlin/com/yourssu/scouter/recruiting/interviewQuestion/storage/AssignedQuestionRepositoryImplTest.kt
@@ -7,6 +7,7 @@ import com.yourssu.scouter.common.part.storage.PartEntity
 import com.yourssu.scouter.common.semester.implement.Term
 import com.yourssu.scouter.common.semester.storage.SemesterEntity
 import com.yourssu.scouter.recruiting.applicant.implement.ApplicantState
+import com.yourssu.scouter.recruiting.applicant.implement.AssignmentResult
 import com.yourssu.scouter.recruiting.applicant.storage.ApplicantEntity
 import com.yourssu.scouter.recruiting.interviewQuestion.implement.AssignedQuestion
 import com.yourssu.scouter.recruiting.interviewQuestion.implement.AssignedQuestionCategory
@@ -50,6 +51,7 @@ class AssignedQuestionRepositoryImplTest {
                 studentId = "202401002",
                 part = part,
                 state = ApplicantState.UNDER_REVIEW,
+                assignmentResult = AssignmentResult.NOT_SUBMITTED,
                 applicationDateTime = Instant.parse("2025-11-13T00:00:00Z"),
                 applicationSemester = semester,
                 academicSemester = "3-2",

--- a/src/test/kotlin/com/yourssu/scouter/recruiting/schedule/implement/ScheduleWriterTest.kt
+++ b/src/test/kotlin/com/yourssu/scouter/recruiting/schedule/implement/ScheduleWriterTest.kt
@@ -22,6 +22,7 @@ import org.mockito.kotlin.whenever
 import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.dao.DuplicateKeyException
 import java.sql.SQLException
+import com.yourssu.scouter.recruiting.applicant.implement.AssignmentResult
 import java.time.Instant
 import java.time.Year
 
@@ -133,6 +134,7 @@ class ScheduleWriterTest {
         studentId = "20210001",
         part = part,
         state = ApplicantState.UNDER_REVIEW,
+        assignmentResult = AssignmentResult.NOT_SUBMITTED,
         applicationDateTime = Instant.parse("2025-09-15T10:00:00Z"),
         applicationSemester = Semester(1L, Year.of(2025), Term.SPRING),
         academicSemester = "2-2",

--- a/src/test/kotlin/com/yourssu/scouter/recruiting/schedule/implement/ScheduleWriterTest.kt
+++ b/src/test/kotlin/com/yourssu/scouter/recruiting/schedule/implement/ScheduleWriterTest.kt
@@ -43,7 +43,7 @@ class ScheduleWriterTest {
     @BeforeEach
     fun setup() {
         val division = Division(id = 1L, name = "개발", sortPriority = 1)
-        val part = Part(1, name = "백엔드", sortPriority = 1, division = division)
+        val part = Part(1, name = "백엔드", sortPriority = 1, division = division, hasAssignment = false)
         testSchedules = listOf(
             Schedule(
                 id = 1L,

--- a/src/test/kotlin/com/yourssu/scouter/recruiting/schedule/storage/JpaScheduleRepositoryTest.kt
+++ b/src/test/kotlin/com/yourssu/scouter/recruiting/schedule/storage/JpaScheduleRepositoryTest.kt
@@ -14,6 +14,7 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager
 import org.springframework.dao.DataIntegrityViolationException
+import com.yourssu.scouter.recruiting.applicant.implement.AssignmentResult
 import java.time.Instant
 import java.time.Year
 
@@ -212,6 +213,7 @@ class JpaScheduleRepositoryTest {
             studentId = "20210001",
             part = part,
             state = ApplicantState.UNDER_REVIEW,
+            assignmentResult = AssignmentResult.NOT_SUBMITTED,
             applicationDateTime = Instant.parse("2025-09-15T10:00:00Z"),
             applicationSemester = semester,
             academicSemester = "2-2"


### PR DESCRIPTION
## 📄 작업 내용 요약
- `applicant` 테이블에 `assignment_result` 컬럼 추가 (기본값 `NOT_SUBMITTED`)
- `AssignmentResult` enum 추가 (`NOT_SUBMITTED`, `PASSED`, `FAILED`)
- `Applicant` 도메인 및 `ApplicantEntity`에 `assignmentResult` 필드 추가
- `AssignmentEvaluationValidator` 구현 — 파트의 `hasAssignment`가 `false`이면 400 예외 반환
- `@Modifying @Query`로 `assignment_result` 컬럼만 UPDATE하도록 구현
- `PATCH /applicants/{applicantId}/assignments` 엔드포인트 추가
- `GET /applicants`, `GET /applicants/{applicantId}` 응답에 `assignmentResult` 필드 추가
- `Part.hasAssignment` 코드 단 기본값 제거 (DB에서 `DEFAULT FALSE` 처리)

## 📎 Issue 번호
closed #358