### PR TITLE
[#364]; refactor: 모집 학기 응답 구조화 및 지원자 재학 학기 필드명 분리

### DIFF
--- a/src/main/kotlin/com/yourssu/scouter/common/semester/application/dto/ReadSemesterResponse.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/semester/application/dto/ReadSemesterResponse.kt
@@ -1,18 +1,19 @@
 package com.yourssu.scouter.common.semester.application.dto
 
 import com.yourssu.scouter.common.semester.business.dto.SemesterDto
-import com.yourssu.scouter.common.support.business.utils.SemesterConverter
 
 data class ReadSemesterResponse(
     val semesterId: Long,
-    val semester: String,
+    val year: Int,
+    val term: Int,
 ) {
 
     companion object {
         fun from(semesterDto: SemesterDto): ReadSemesterResponse {
             return ReadSemesterResponse(
                 semesterId = semesterDto.id,
-                semester = SemesterConverter.convertToStringWithTermLabel(semesterDto)
+                year = semesterDto.year.value,
+                term = semesterDto.term.intValue,
             )
         }
     }

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/applicant/application/dto/ReadApplicantResponse.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/applicant/application/dto/ReadApplicantResponse.kt
@@ -27,7 +27,7 @@ data class ReadApplicantResponse(
 
     val studentId: String,
 
-    val semester: String,
+    val academicSemester: String,
 
     val age: String,
 
@@ -52,7 +52,7 @@ data class ReadApplicantResponse(
             phoneNumber = applicantDto.phoneNumber,
             department = applicantDto.department,
             studentId = applicantDto.studentId,
-            semester = applicantDto.academicSemester,
+            academicSemester = applicantDto.academicSemester,
             age = applicantDto.age,
             availableTimes = applicantDto.availableTimes,
             documentAverageScore = applicantDto.documentAverageScore,


### PR DESCRIPTION
## 📄 작업 내용 요약
- `GET /semesters`, `GET /semesters/now` 응답(`ReadSemesterResponse`)의 `semester: "26-2학기"` 문자열 필드를 `year: Int`, `term: Int`로 구조화
- 지원자 조회 응답(`ReadApplicantResponse`)의 `semester` 필드를 `academicSemester`로 리네이밍(값은 동일, 재학 학기를 의미하는데 모집 학기와 이름이 겹쳐 혼동되던 것을 명확화)
- 면접 루브릭 응답(`InterviewRubricResponse`), 면접 루브릭/요구조건 API의 요청 파라미터(`semester`), HRMS 회원 응답(`ReadCompletedMemberResponse` 등)에도 동일하게 학기가 문자열로 노출/전달되는 지점이 있으나, 이번 PR 범위에서는 의도적으로 다루지 않음 — 담당자가 필요 시 별도로 검토 요망

## 📎 Issue 번호
closed #364