### PR TITLE
[#366] refactor: 면접 평가 루브릭 배점 수정 API로 변경

### DIFF
--- a/src/main/kotlin/com/yourssu/scouter/recruiting/rubric/application/InterviewRubricController.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/rubric/application/InterviewRubricController.kt
@@ -63,8 +63,8 @@ class InterviewRubricController(
     )
 
     @Operation(
-        summary = "학기별 면접 평가 루브릭 등록 또는 수정/ 배점설정(어드민)",
-        description = "해당 파트·학기에 루브릭이 없으면 생성하고, 있으면 항목 전체를 교체합니다. 잠긴 루브릭은 수정할 수 없으며 모든 항목의 maxScore 합계는 100이어야 합니다.",
+        summary = "면접 평가 항목(루브릭)의 배점을 설정합니다.",
+        description = "해당 루브릭에 해당하는 평가가 있다면 배점 수정이 불가능 합니다. 모든 항목의 maxScore 합계는 100이어야 합니다.",
         requestBody = io.swagger.v3.oas.annotations.parameters.RequestBody(
             required = true,
             description = "학기는 URL 경로에서 지정합니다.",
@@ -76,19 +76,19 @@ class InterviewRubricController(
     {
       "group": "CULTURE_FIT",
       "items": [
-        { "title": "주도성, 실행력", "maxScore": 10 }
+        { "itemId": 10, "maxScore": 10 }
       ]
     },
     {
       "group": "TEAM_FIT",
       "items": [
-        { "title": "팀 목표 이해", "maxScore": 10 }
+        { "itemId": 20, "maxScore": 10 }
       ]
     },
     {
       "group": "JOB_FIT",
       "items": [
-        { "title": "파트 핵심 역량", "maxScore": 80 }
+        { "itemId": 30, "maxScore": 80 }
       ]
     }
   ]

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/rubric/application/dto/InterviewRubricUpdateRequest.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/rubric/application/dto/InterviewRubricUpdateRequest.kt
@@ -35,12 +35,9 @@ data class InterviewRubricUpdateRequest(
 
     @Schema(description = "면접 루브릭 평가 항목 요청")
     data class ItemRequest(
-        @field:Schema(description = "기존 항목 수정 시 해당 항목 ID. 새 항목이면 생략", example = "10", nullable = true)
-        val itemId: Long? = null,
-
-        @field:NotBlank
-        @field:Schema(description = "평가 항목명", example = "주도성, 실행력")
-        val title: String,
+        @field:NotNull
+        @field:Schema(description = "항목 ID", example = "10")
+        val itemId: Long,
 
         @field:Min(0)
         @field:Schema(description = "항목의 최대 배점. 0 이상", example = "10")
@@ -49,18 +46,9 @@ data class InterviewRubricUpdateRequest(
 
     fun toCommand(partId: Long, semester: String): UpdateInterviewRubricCommand {
         val commandItems = groups.flatMap { groupReq ->
-            val rubricType = when(groupReq.group) {
-                "CULTURE_FIT" -> RubricGroupType.CULTURE
-                "TEAM_FIT" -> RubricGroupType.TEAM
-                "JOB_FIT" -> RubricGroupType.JOB
-                "OTHER" -> RubricGroupType.OTHER
-                else -> throw IllegalArgumentException("유효하지 않은 평가 그룹입니다: ${groupReq.group}")
-            }
             groupReq.items.map { itemReq ->
                 UpdateInterviewRubricCommand.ItemCommand(
                     id = itemReq.itemId,
-                    keyword = itemReq.title,
-                    rubricType = rubricType,
                     maxScore = itemReq.maxScore
                 )
             }

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/rubric/application/dto/InterviewRubricUpdateRequest.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/rubric/application/dto/InterviewRubricUpdateRequest.kt
@@ -9,6 +9,7 @@ import jakarta.validation.constraints.Min
 import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.NotEmpty
 import jakarta.validation.constraints.NotNull
+import jakarta.validation.constraints.Pattern
 
 @Schema(description = "면접 루브릭 등록 또는 수정 요청")
 data class InterviewRubricUpdateRequest(
@@ -24,6 +25,7 @@ data class InterviewRubricUpdateRequest(
     @Schema(description = "면접 루브릭 평가 항목 그룹 요청")
     data class GroupRequest(
         @field:NotBlank
+        @field:Pattern(regexp = "^(JOB|CULTURE|TEAM)_FIT$", message = "group must be JOB_FIT, CULTURE_FIT, or TEAM_FIT")
         @field:Schema(description = "평가 그룹", example = "CULTURE_FIT", allowableValues = ["JOB_FIT", "CULTURE_FIT", "TEAM_FIT"])
         val group: String,
 
@@ -49,7 +51,8 @@ data class InterviewRubricUpdateRequest(
             groupReq.items.map { itemReq ->
                 UpdateInterviewRubricCommand.ItemCommand(
                     id = itemReq.itemId,
-                    maxScore = itemReq.maxScore
+                    maxScore = itemReq.maxScore,
+                    group = groupReq.group.toRubricGroupType(),
                 )
             }
         }
@@ -59,5 +62,12 @@ data class InterviewRubricUpdateRequest(
             deadline = deadline,
             items = commandItems
         )
+    }
+
+    private fun String.toRubricGroupType(): RubricGroupType = when (this) {
+        "JOB_FIT" -> RubricGroupType.JOB
+        "CULTURE_FIT" -> RubricGroupType.CULTURE
+        "TEAM_FIT" -> RubricGroupType.TEAM
+        else -> throw IllegalArgumentException("지원하지 않는 평가 그룹입니다: $this")
     }
 }

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/rubric/business/InterviewRubricService.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/rubric/business/InterviewRubricService.kt
@@ -74,8 +74,17 @@ class InterviewRubricService(
 
         val existingItemIds = existing.items.mapNotNull { it.id }.toSet()
         val requestItemIds = command.items.map { it.id }.toSet()
-        if (existingItemIds != requestItemIds) {
+        if (existingItemIds != requestItemIds || command.items.size != requestItemIds.size) {
             throw IllegalArgumentException("요청된 평가 항목 ID 목록이 기존 루브릭의 평가 항목 ID 목록과 일치하지 않습니다. (항목을 추가하거나 삭제할 수 없습니다.)")
+        }
+
+        val existingItemsById = existing.items.associateBy { it.id!! }
+        command.items.forEach { requestedItem ->
+            val existingItem = existingItemsById[requestedItem.id]
+                ?: throw IllegalArgumentException("존재하지 않는 면접 평가 항목입니다. itemId=${requestedItem.id}")
+            require(existingItem.rubricType == requestedItem.group) {
+                "요청 그룹과 면접 평가 항목의 실제 그룹이 일치하지 않습니다. itemId=${requestedItem.id}"
+            }
         }
 
         val maxScoreMap = command.items.associate { it.id to it.maxScore }

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/rubric/business/InterviewRubricService.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/rubric/business/InterviewRubricService.kt
@@ -11,6 +11,7 @@ import com.yourssu.scouter.recruiting.rubric.implement.InterviewRubricReader
 import com.yourssu.scouter.recruiting.rubric.implement.InterviewRubricWriter
 import com.yourssu.scouter.recruiting.support.business.InterviewRequirementLookup
 import com.yourssu.scouter.recruiting.support.implement.exception.RubricLockedException
+import com.yourssu.scouter.recruiting.support.implement.exception.InterviewRubricNotFoundException
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.Duration
@@ -61,22 +62,41 @@ class InterviewRubricService(
         partReader.readById(command.partId)
 
         val existing = interviewRubricReader.findByPartIdAndSemester(command.partId, Semester.of(command.semester))
-        existing?.validateEditable()
+            ?: throw InterviewRubricNotFoundException("해당 파트와 학기에 생성된 면접 루브릭이 없습니다. 면접 요구조건을 먼저 설정해 주세요. partId=${command.partId}, semester=${command.semester}")
+        existing.validateEditable()
 
-        if (existing != null && existing.items.isNotEmpty()) {
-            val itemIds = existing.items.mapNotNull { it.id }
+        val itemIds = existing.items.mapNotNull { it.id }
+        if (itemIds.isNotEmpty()) {
             if (interviewEvaluationReader.existsByInterviewEvaluationItemIdIn(itemIds)) {
                 throw RubricLockedException("해당 파트에 면접 평가(임시저장 포함)가 존재해 수정 불가")
             }
         }
 
-        val domain = command.toDomain(
-            existingId = existing?.id,
-            isLocked = existing?.isLocked ?: false,
-        )
-        domain.validateTotalScore()
+        val existingItemIds = existing.items.mapNotNull { it.id }.toSet()
+        val requestItemIds = command.items.map { it.id }.toSet()
+        if (existingItemIds != requestItemIds) {
+            throw IllegalArgumentException("요청된 평가 항목 ID 목록이 기존 루브릭의 평가 항목 ID 목록과 일치하지 않습니다. (항목을 추가하거나 삭제할 수 없습니다.)")
+        }
 
-        val saved = interviewRubricWriter.save(domain)
+        val maxScoreMap = command.items.associate { it.id to it.maxScore }
+        val updatedItems = existing.items.map { item ->
+            InterviewEvaluationItem(
+                id = item.id,
+                interviewRequirementId = item.interviewRequirementId,
+                keyword = item.keyword,
+                rubricType = item.rubricType,
+                maxScore = maxScoreMap[item.id!!] ?: item.maxScore
+            )
+        }
+
+        val updated = existing.update(
+            semester = existing.semester,
+            deadline = command.deadline,
+            items = updatedItems
+        )
+        updated.validateTotalScore()
+
+        val saved = interviewRubricWriter.save(updated)
 
         return InterviewRubricResult.from(saved)
     }

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/rubric/business/dto/InterviewRubricCommand.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/rubric/business/dto/InterviewRubricCommand.kt
@@ -13,27 +13,7 @@ data class UpdateInterviewRubricCommand(
     val items: List<ItemCommand>
 ) {
     data class ItemCommand(
-        val id: Long? = null,
-        val keyword: String,
-        val rubricType: RubricGroupType,
+        val id: Long,
         val maxScore: Int
     )
-
-    fun toDomain(existingId: Long?, isLocked: Boolean = false): InterviewRubric {
-        return InterviewRubric(
-            id = existingId,
-            partId = partId,
-            semester = Semester.of(semester),
-            deadline = deadline,
-            isLocked = isLocked,
-            items = items.map {
-                InterviewEvaluationItem(
-                    id = it.id,
-                    keyword = it.keyword,
-                    rubricType = it.rubricType,
-                    maxScore = it.maxScore
-                )
-            }
-        )
-    }
 }

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/rubric/business/dto/InterviewRubricCommand.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/rubric/business/dto/InterviewRubricCommand.kt
@@ -14,6 +14,7 @@ data class UpdateInterviewRubricCommand(
 ) {
     data class ItemCommand(
         val id: Long,
-        val maxScore: Int
+        val maxScore: Int,
+        val group: RubricGroupType,
     )
 }


### PR DESCRIPTION
### 변경 사항

* 기존 루브릭의 **평가 항목 ID를 기준으로 배점(`maxScore`)만 수정**하도록 변경
* 루브릭 **항목 추가·삭제 및 항목명/그룹 변경을 방지**
* 존재하지 않는 루브릭에 대한 **수정 요청을 명시적으로 거부**
* 이미 면접 평가가 존재하는 루브릭은 **배점 수정 불가**하도록 처리

### 참고

* 모든 평가 항목의 `maxScore` 합계는 **기존과 동일하게 100점**을 유지해야 합니다.
