### PR TITLE
feat: 면접 질문 카탈로그 및 파트별 질문 관리 API 추가

### DIFF
--- a/src/main/kotlin/com/yourssu/scouter/recruiting/interview/implement/InterviewRequirementReader.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/interview/implement/InterviewRequirementReader.kt
@@ -21,4 +21,7 @@ class InterviewRequirementReader(
     fun readAllApplicableByPartIdAndSemester(partId: Long, semester: Semester): List<InterviewRequirement> {
         return partInterviewRequirementRepository.findAllApplicableByPartIdAndSemester(partId, semester)
     }
+
+    fun readAllByIdIn(ids: Collection<Long>): List<InterviewRequirement> =
+        partInterviewRequirementRepository.findAllByIdIn(ids)
 }

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/interview/implement/InterviewRequirementRepository.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/interview/implement/InterviewRequirementRepository.kt
@@ -10,6 +10,8 @@ interface InterviewRequirementRepository {
 
     fun findAllApplicableByPartIdAndSemester(partId: Long, semester: Semester): List<InterviewRequirement>
 
+    fun findAllByIdIn(ids: Collection<Long>): List<InterviewRequirement>
+
     fun saveAll(
         requirements: List<InterviewRequirement>,
         partId: Long,

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/interview/storage/InterviewRequirementRepositoryImpl.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/interview/storage/InterviewRequirementRepositoryImpl.kt
@@ -34,6 +34,9 @@ class InterviewRequirementRepositoryImpl(
             .map { it.toDomain() }
     }
 
+    override fun findAllByIdIn(ids: Collection<Long>): List<InterviewRequirement> =
+        jpaInterviewRequirementRepository.findAllByIdIn(ids).map { it.toDomain() }
+
     override fun saveAll(
         requirements: List<InterviewRequirement>,
         partId: Long,

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/interview/storage/JpaInterviewRequirementRepository.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/interview/storage/JpaInterviewRequirementRepository.kt
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
 
 interface JpaInterviewRequirementRepository : JpaRepository<InterviewRequirementEntity, Long> {
+    fun findAllByIdIn(ids: Collection<Long>): List<InterviewRequirementEntity>
     fun findAllByPartIdAndSemester(partId: Long, semester: SemesterEntity): List<InterviewRequirementEntity>
 
     fun findAllByPartIsNullAndSemester(semester: SemesterEntity): List<InterviewRequirementEntity>

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/interviewQuestion/application/QuestionController.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/interviewQuestion/application/QuestionController.kt
@@ -1,44 +1,30 @@
 package com.yourssu.scouter.recruiting.interviewQuestion.application
 
+import com.yourssu.scouter.recruiting.interviewQuestion.application.dto.CreateQuestionsRequest
 import com.yourssu.scouter.recruiting.interviewQuestion.application.dto.ReadQuestionResponse
+import com.yourssu.scouter.recruiting.interviewQuestion.application.dto.UpdatePartQuestionsRequest
 import com.yourssu.scouter.recruiting.interviewQuestion.business.QuestionService
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
-import org.springframework.http.ResponseEntity
-import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.PathVariable
-import org.springframework.web.bind.annotation.RestController
-import org.springframework.web.bind.annotation.PostMapping
-import org.springframework.web.bind.annotation.RequestBody
 import jakarta.validation.Valid
-import com.yourssu.scouter.recruiting.interviewQuestion.application.dto.CreateQuestionsRequest
-import com.yourssu.scouter.recruiting.interviewQuestion.application.dto.UpdatePartQuestionsRequest
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.*
 
 @Tag(name = "면접 질문")
 @RestController
-class QuestionController(
-    private val questionService: QuestionService,
-) {
-
-    @org.springframework.web.bind.annotation.PutMapping("/parts/{partId}/interviews/questions")
-    fun upsertParts(
-        @PathVariable partId: Long,
-        @RequestBody @Valid request: UpdatePartQuestionsRequest,
-    ): ResponseEntity<List<ReadQuestionResponse>> =
+class QuestionController(private val questionService: QuestionService) {
+    @Operation(summary = "파트별 면접 공통 질문 전체 수정", description = "id가 있으면 수정하고 없으면 생성하며, 누락된 기존 질문은 삭제합니다.")
+    @PutMapping("/parts/{partId}/interviews/questions")
+    fun upsertParts(@PathVariable partId: Long, @RequestBody @Valid request: UpdatePartQuestionsRequest): ResponseEntity<List<ReadQuestionResponse>> =
         ResponseEntity.ok(questionService.upsertParts(partId, request).map(ReadQuestionResponse::from))
 
+    @Operation(summary = "전역·문화 면접 질문 생성", description = "GLOBAL 및 CULTURE 질문을 생성합니다.")
     @PostMapping("/interviews/questions")
-    fun create(@RequestBody @Valid request: CreateQuestionsRequest): ResponseEntity<List<ReadQuestionResponse>> {
-        return ResponseEntity.ok(questionService.create(request).map(ReadQuestionResponse::from))
-    }
+    fun create(@RequestBody @Valid request: CreateQuestionsRequest): ResponseEntity<List<ReadQuestionResponse>> =
+        ResponseEntity.ok(questionService.create(request).map(ReadQuestionResponse::from))
 
-    @Operation(summary = "파트별 면접 질문 카탈로그 조회")
+    @Operation(summary = "파트별 면접 질문 및 요구조건 조회", description = "GLOBAL, CULTURE, PART 질문과 매핑된 요구조건을 조회합니다.")
     @GetMapping("/parts/{partId}/interviews/questions")
-    fun readAll(
-        @PathVariable partId: Long,
-    ): ResponseEntity<List<ReadQuestionResponse>> {
-        val questions = questionService.readAll(partId)
-
-        return ResponseEntity.ok(questions.map(ReadQuestionResponse::from))
-    }
+    fun readAll(@PathVariable partId: Long): ResponseEntity<List<ReadQuestionResponse>> =
+        ResponseEntity.ok(questionService.readAll(partId).map(ReadQuestionResponse::from))
 }

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/interviewQuestion/application/QuestionController.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/interviewQuestion/application/QuestionController.kt
@@ -8,12 +8,29 @@ import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import jakarta.validation.Valid
+import com.yourssu.scouter.recruiting.interviewQuestion.application.dto.CreateQuestionsRequest
+import com.yourssu.scouter.recruiting.interviewQuestion.application.dto.UpdatePartQuestionsRequest
 
 @Tag(name = "면접 질문")
 @RestController
 class QuestionController(
     private val questionService: QuestionService,
 ) {
+
+    @org.springframework.web.bind.annotation.PutMapping("/parts/{partId}/interviews/questions")
+    fun upsertParts(
+        @PathVariable partId: Long,
+        @RequestBody @Valid request: UpdatePartQuestionsRequest,
+    ): ResponseEntity<List<ReadQuestionResponse>> =
+        ResponseEntity.ok(questionService.upsertParts(partId, request).map(ReadQuestionResponse::from))
+
+    @PostMapping("/interviews/questions")
+    fun create(@RequestBody @Valid request: CreateQuestionsRequest): ResponseEntity<List<ReadQuestionResponse>> {
+        return ResponseEntity.ok(questionService.create(request).map(ReadQuestionResponse::from))
+    }
 
     @Operation(summary = "파트별 면접 질문 카탈로그 조회")
     @GetMapping("/parts/{partId}/interviews/questions")

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/interviewQuestion/application/QuestionController.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/interviewQuestion/application/QuestionController.kt
@@ -19,9 +19,9 @@ class QuestionController(private val questionService: QuestionService) {
         ResponseEntity.ok(questionService.upsertParts(partId, request).map(ReadQuestionResponse::from))
 
     @Operation(summary = "전역·문화 면접 질문 생성", description = "GLOBAL 및 CULTURE 질문을 생성합니다.")
-    @PostMapping("/interviews/questions")
-    fun create(@RequestBody @Valid request: CreateQuestionsRequest): ResponseEntity<List<ReadQuestionResponse>> =
-        ResponseEntity.ok(questionService.create(request).map(ReadQuestionResponse::from))
+    @PutMapping("/interviews/questions")
+    fun upsertGlobalAndCulture(@RequestBody @Valid request: CreateQuestionsRequest): ResponseEntity<List<ReadQuestionResponse>> =
+        ResponseEntity.ok(questionService.upsertGlobalAndCulture(request).map(ReadQuestionResponse::from))
 
     @Operation(summary = "파트별 면접 질문 및 요구조건 조회", description = "GLOBAL, CULTURE, PART 질문과 매핑된 요구조건을 조회합니다.")
     @GetMapping("/parts/{partId}/interviews/questions")

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/interviewQuestion/application/QuestionController.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/interviewQuestion/application/QuestionController.kt
@@ -15,10 +15,11 @@ import org.springframework.web.bind.annotation.*
 class QuestionController(private val questionService: QuestionService) {
     @Operation(summary = "파트별 면접 공통 질문 전체 수정", description = "id가 있으면 수정하고 없으면 생성하며, 누락된 기존 질문은 삭제합니다.")
     @PutMapping("/parts/{partId}/interviews/questions")
-    fun upsertParts(@PathVariable partId: Long, @RequestBody @Valid request: UpdatePartQuestionsRequest): ResponseEntity<List<ReadQuestionResponse>> =
+    fun upsertParts(@PathVariable partId: Long, @RequestBody @Valid request: UpdatePartQuestionsRequest)
+    : ResponseEntity<List<ReadQuestionResponse>> =
         ResponseEntity.ok(questionService.upsertParts(partId, request).map(ReadQuestionResponse::from))
 
-    @Operation(summary = "전역·문화 면접 질문 생성", description = "GLOBAL 및 CULTURE 질문을 생성합니다.")
+    @Operation(summary = "전역·문화 면접 질문 수정/생성", description = "GLOBAL 및 CULTURE 질문을 생성합니다.")
     @PutMapping("/interviews/questions")
     fun upsertGlobalAndCulture(@RequestBody @Valid request: CreateQuestionsRequest): ResponseEntity<List<ReadQuestionResponse>> =
         ResponseEntity.ok(questionService.upsertGlobalAndCulture(request).map(ReadQuestionResponse::from))

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/interviewQuestion/application/dto/CreateQuestionsRequest.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/interviewQuestion/application/dto/CreateQuestionsRequest.kt
@@ -10,6 +10,7 @@ data class CreateQuestionsRequest(
     @field:Valid val culture: List<Item> = emptyList(),
 ) {
     data class Item(
+        val id: Long? = null,
         @field:NotBlank val content: String,
         @field:NotNull val sortOrder: Int,
         val requirementIds: List<Long> = emptyList(),

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/interviewQuestion/application/dto/CreateQuestionsRequest.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/interviewQuestion/application/dto/CreateQuestionsRequest.kt
@@ -1,0 +1,28 @@
+package com.yourssu.scouter.recruiting.interviewQuestion.application.dto
+
+import com.yourssu.scouter.recruiting.interviewQuestion.implement.QuestionCategory
+import jakarta.validation.Valid
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotNull
+
+data class CreateQuestionsRequest(
+    @field:Valid val global: List<Item> = emptyList(),
+    @field:Valid val culture: List<Item> = emptyList(),
+) {
+    data class Item(
+        @field:NotBlank val content: String,
+        @field:NotNull val sortOrder: Int,
+        val requirementIds: List<Long> = emptyList(),
+    )
+}
+
+data class PartQuestionRequest(
+    val id: Long? = null,
+    @field:NotBlank val content: String,
+    @field:NotNull val sortOrder: Int,
+    @field:NotNull val requirementIds: List<Long>,
+)
+
+data class UpdatePartQuestionsRequest(
+    @field:Valid val questions: List<PartQuestionRequest>,
+)

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/interviewQuestion/application/dto/ReadQuestionResponse.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/interviewQuestion/application/dto/ReadQuestionResponse.kt
@@ -2,6 +2,7 @@ package com.yourssu.scouter.recruiting.interviewQuestion.application.dto
 
 import com.yourssu.scouter.recruiting.interviewQuestion.business.dto.QuestionDto
 import com.yourssu.scouter.recruiting.interviewQuestion.implement.QuestionCategory
+import com.yourssu.scouter.recruiting.interviewQuestion.business.dto.QuestionRequirementDto
 
 data class ReadQuestionResponse(
     val id: Long,
@@ -9,6 +10,7 @@ data class ReadQuestionResponse(
     val category: QuestionCategory,
     val content: String,
     val sortOrder: Int,
+    val requirements: List<QuestionRequirementDto>,
 ) {
     companion object {
         fun from(dto: QuestionDto): ReadQuestionResponse = ReadQuestionResponse(
@@ -17,6 +19,7 @@ data class ReadQuestionResponse(
             category = dto.category,
             content = dto.content,
             sortOrder = dto.sortOrder,
+            requirements = dto.requirements,
         )
     }
 }

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/interviewQuestion/business/QuestionService.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/interviewQuestion/business/QuestionService.kt
@@ -23,46 +23,83 @@ class QuestionService(
 ) {
 
     fun upsertGlobalAndCulture(request: CreateQuestionsRequest): List<QuestionDto> {
-        require(request.global.mapNotNull { it.id }.size == request.global.mapNotNull { it.id }.toSet().size) { "GLOBAL 질문 ID가 중복되었습니다." }
-        require(request.culture.mapNotNull { it.id }.size == request.culture.mapNotNull { it.id }.toSet().size) { "CULTURE 질문 ID가 중복되었습니다." }
+        require(
+            request.global.mapNotNull { it.id }.size == request.global.mapNotNull { it.id }.toSet().size,
+        ) { "GLOBAL 질문 ID가 중복되었습니다." }
+        require(
+            request.culture.mapNotNull { it.id }.size == request.culture.mapNotNull { it.id }.toSet().size,
+        ) { "CULTURE 질문 ID가 중복되었습니다." }
+
         validateCultureRequirements(request.culture.flatMap { it.requirementIds })
-        val existing = questionReader.readAll().filter { it.partId == null && it.category in setOf(QuestionCategory.GLOBAL, QuestionCategory.CULTURE) }
+
+        val existing = questionReader.readAll()
+            .filter { it.partId == null && it.category in setOf(QuestionCategory.GLOBAL, QuestionCategory.CULTURE) }
         val byId = existing.associateBy { it.id }
-        val items = request.global.map { it to QuestionCategory.GLOBAL } + request.culture.map { it to QuestionCategory.CULTURE }
-        items.forEach { (item, category) -> if (item.id != null) require(byId[item.id]?.category == category) { "카테고리가 일치하지 않거나 존재하지 않는 질문입니다: ${item.id}" } }
+
+        val items = request.global.map { it to QuestionCategory.GLOBAL } +
+            request.culture.map { it to QuestionCategory.CULTURE }
+
+        items.forEach { (item, category) ->
+            if (item.id != null) {
+                require(byId[item.id]?.category == category) {
+                    "카테고리가 일치하지 않거나 존재하지 않는 질문입니다: ${item.id}"
+                }
+            }
+        }
+
         val retained = items.mapNotNull { it.first.id }.toSet()
         questionWriter.deleteAllByIdIn(existing.mapNotNull { it.id }.filterNot { it in retained })
+
         return items.map { (item, category) ->
             val question = Question(item.id, null, category, item.content, item.sortOrder, item.requirementIds)
-            if (item.id == null) QuestionDto.from(questionWriter.save(question))
-            else { questionWriter.update(question); QuestionDto.from(question) }
+            if (item.id == null) {
+                QuestionDto.from(questionWriter.save(question))
+            } else {
+                questionWriter.update(question)
+                QuestionDto.from(question)
+            }
         }
     }
 
     private fun validateCultureRequirements(ids: List<Long>) {
         val requirements = requirementReader.readAllByIdIn(ids)
-        require(requirements.size == ids.toSet().size && requirements.all { it.rubricType == RubricGroupType.CULTURE }) { "CULTURE 질문에는 CULTURE 요구조건 ID만 사용할 수 있습니다." }
+        require(
+            requirements.size == ids.toSet().size &&
+                requirements.all { it.rubricType == RubricGroupType.CULTURE },
+        ) { "CULTURE 질문에는 CULTURE 요구조건 ID만 사용할 수 있습니다." }
     }
 
     fun upsertParts(partId: Long, request: UpdatePartQuestionsRequest): List<QuestionDto> {
         partReader.readById(partId)
-        require(request.questions.mapNotNull { it.id }.size == request.questions.mapNotNull { it.id }.toSet().size) { "질문 ID가 중복되었습니다." }
-        val existing = questionReader.readAll().filter { it.partId == partId && it.category == QuestionCategory.PART }
+        require(
+            request.questions.mapNotNull { it.id }.size == request.questions.mapNotNull { it.id }.toSet().size,
+        ) { "질문 ID가 중복되었습니다." }
+
+        val existing = questionReader.readAll()
+            .filter { it.partId == partId && it.category == QuestionCategory.PART }
         val existingById = existing.associateBy { it.id }
+
         request.questions.forEach { item ->
             validatePartRequirements(item.requirementIds)
             if (item.id != null) {
                 require(existingById[item.id] != null) { "해당 파트에 존재하지 않는 질문입니다: ${item.id}" }
             }
         }
+
         val retainedIds = request.questions.mapNotNull { it.id }.toSet()
         questionWriter.deleteAllByIdIn(existing.mapNotNull { it.id }.filterNot { it in retainedIds })
+
         val allRequirementIds = request.questions.flatMap { it.requirementIds }.distinct()
         val requirementsById = requirementReader.readAllByIdIn(allRequirementIds).associateBy { it.id }
+
         return request.questions.map { item ->
             val question = Question(item.id, partId, QuestionCategory.PART, item.content, item.sortOrder, item.requirementIds)
-            val savedQuestion = if (item.id == null) questionWriter.save(question)
-                                else { questionWriter.update(question); question }
+            val savedQuestion = if (item.id == null) {
+                questionWriter.save(question)
+            } else {
+                questionWriter.update(question)
+                question
+            }
             val requirementDtos = savedQuestion.requirementIds.mapNotNull { id ->
                 requirementsById[id]?.let { QuestionRequirementDto(id, it.content) }
             }
@@ -73,9 +110,10 @@ class QuestionService(
     private fun validatePartRequirements(ids: List<Long>) {
         require(ids.isNotEmpty()) { "파트 질문은 요구조건을 최소 1개 이상 매핑해야 합니다." }
         val requirements = requirementReader.readAllByIdIn(ids)
-        require(requirements.size == ids.toSet().size && requirements.all { it.rubricType in setOf(RubricGroupType.TEAM, RubricGroupType.JOB, RubricGroupType.OTHER) }) {
-            "파트 질문에는 TEAM, JOB, OTHER 요구조건 ID만 사용할 수 있습니다."
-        }
+        require(
+            requirements.size == ids.toSet().size &&
+                requirements.all { it.rubricType in setOf(RubricGroupType.TEAM, RubricGroupType.JOB, RubricGroupType.OTHER) },
+        ) { "파트 질문에는 TEAM, JOB, OTHER 요구조건 ID만 사용할 수 있습니다." }
     }
 
     fun readAll(partId: Long): List<QuestionDto> {
@@ -85,9 +123,12 @@ class QuestionService(
         val requirements = requirementReader.readAllByIdIn(questions.flatMap { it.requirementIds }.distinct())
             .associateBy { it.id }
         return questions.map { question ->
-            QuestionDto.from(question, question.requirementIds.mapNotNull { id ->
-                requirements[id]?.let { QuestionRequirementDto(id, it.content) }
-            })
+            QuestionDto.from(
+                question,
+                question.requirementIds.mapNotNull { id ->
+                    requirements[id]?.let { QuestionRequirementDto(id, it.content) }
+                },
+            )
         }
     }
 }

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/interviewQuestion/business/QuestionService.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/interviewQuestion/business/QuestionService.kt
@@ -22,17 +22,26 @@ class QuestionService(
     private val requirementReader: InterviewRequirementReader,
 ) {
 
-    fun create(request: CreateQuestionsRequest): List<QuestionDto> {
-        val allCultureRequirementIds = request.culture.flatMap { it.requirementIds }
-        val requirements = requirementReader.readAllByIdIn(allCultureRequirementIds)
-        if (requirements.size != allCultureRequirementIds.toSet().size ||
-            requirements.any { it.rubricType.name != "CULTURE" }) {
-            throw IllegalArgumentException("CULTURE 질문에는 CULTURE 요구조건 ID만 사용할 수 있습니다.")
-        }
+    fun upsertGlobalAndCulture(request: CreateQuestionsRequest): List<QuestionDto> {
+        require(request.global.mapNotNull { it.id }.size == request.global.mapNotNull { it.id }.toSet().size) { "GLOBAL 질문 ID가 중복되었습니다." }
+        require(request.culture.mapNotNull { it.id }.size == request.culture.mapNotNull { it.id }.toSet().size) { "CULTURE 질문 ID가 중복되었습니다." }
+        validateCultureRequirements(request.culture.flatMap { it.requirementIds })
+        val existing = questionReader.readAll().filter { it.partId == null && it.category in setOf(QuestionCategory.GLOBAL, QuestionCategory.CULTURE) }
+        val byId = existing.associateBy { it.id }
         val items = request.global.map { it to QuestionCategory.GLOBAL } + request.culture.map { it to QuestionCategory.CULTURE }
+        items.forEach { (item, category) -> if (item.id != null) require(byId[item.id]?.category == category) { "카테고리가 일치하지 않거나 존재하지 않는 질문입니다: ${item.id}" } }
+        val retained = items.mapNotNull { it.first.id }.toSet()
+        questionWriter.deleteAllByIdIn(existing.mapNotNull { it.id }.filterNot { it in retained })
         return items.map { (item, category) ->
-            QuestionDto.from(questionWriter.save(Question(category = category, content = item.content, sortOrder = item.sortOrder, requirementIds = item.requirementIds)))
+            val question = Question(item.id, null, category, item.content, item.sortOrder, item.requirementIds)
+            if (item.id == null) QuestionDto.from(questionWriter.save(question))
+            else { questionWriter.update(question); QuestionDto.from(question) }
         }
+    }
+
+    private fun validateCultureRequirements(ids: List<Long>) {
+        val requirements = requirementReader.readAllByIdIn(ids)
+        require(requirements.size == ids.toSet().size && requirements.all { it.rubricType == RubricGroupType.CULTURE }) { "CULTURE 질문에는 CULTURE 요구조건 ID만 사용할 수 있습니다." }
     }
 
     fun upsertParts(partId: Long, request: UpdatePartQuestionsRequest): List<QuestionDto> {

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/interviewQuestion/business/QuestionService.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/interviewQuestion/business/QuestionService.kt
@@ -57,10 +57,16 @@ class QuestionService(
         }
         val retainedIds = request.questions.mapNotNull { it.id }.toSet()
         questionWriter.deleteAllByIdIn(existing.mapNotNull { it.id }.filterNot { it in retainedIds })
+        val allRequirementIds = request.questions.flatMap { it.requirementIds }.distinct()
+        val requirementsById = requirementReader.readAllByIdIn(allRequirementIds).associateBy { it.id }
         return request.questions.map { item ->
             val question = Question(item.id, partId, QuestionCategory.PART, item.content, item.sortOrder, item.requirementIds)
-            if (item.id == null) QuestionDto.from(questionWriter.save(question))
-            else { questionWriter.update(question); QuestionDto.from(question) }
+            val savedQuestion = if (item.id == null) questionWriter.save(question)
+                                else { questionWriter.update(question); question }
+            val requirementDtos = savedQuestion.requirementIds.mapNotNull { id ->
+                requirementsById[id]?.let { QuestionRequirementDto(id, it.content) }
+            }
+            QuestionDto.from(savedQuestion, requirementDtos)
         }
     }
 

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/interviewQuestion/business/QuestionService.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/interviewQuestion/business/QuestionService.kt
@@ -2,20 +2,77 @@ package com.yourssu.scouter.recruiting.interviewQuestion.business
 
 import com.yourssu.scouter.common.part.implement.PartReader
 import com.yourssu.scouter.recruiting.interviewQuestion.business.dto.QuestionDto
+import com.yourssu.scouter.recruiting.interviewQuestion.business.dto.QuestionRequirementDto
 import com.yourssu.scouter.recruiting.interviewQuestion.implement.QuestionReader
+import com.yourssu.scouter.recruiting.interviewQuestion.implement.QuestionWriter
+import com.yourssu.scouter.recruiting.interviewQuestion.implement.Question
+import com.yourssu.scouter.recruiting.interviewQuestion.implement.QuestionCategory
+import com.yourssu.scouter.recruiting.interview.implement.InterviewRequirementReader
+import com.yourssu.scouter.recruiting.interviewQuestion.application.dto.CreateQuestionsRequest
+import com.yourssu.scouter.recruiting.interviewQuestion.application.dto.PartQuestionRequest
+import com.yourssu.scouter.recruiting.interviewQuestion.application.dto.UpdatePartQuestionsRequest
+import com.yourssu.scouter.recruiting.rubric.implement.RubricGroupType
 import org.springframework.stereotype.Service
 
 @Service
 class QuestionService(
     private val questionReader: QuestionReader,
     private val partReader: PartReader,
+    private val questionWriter: QuestionWriter,
+    private val requirementReader: InterviewRequirementReader,
 ) {
+
+    fun create(request: CreateQuestionsRequest): List<QuestionDto> {
+        val allCultureRequirementIds = request.culture.flatMap { it.requirementIds }
+        val requirements = requirementReader.readAllByIdIn(allCultureRequirementIds)
+        if (requirements.size != allCultureRequirementIds.toSet().size ||
+            requirements.any { it.rubricType.name != "CULTURE" }) {
+            throw IllegalArgumentException("CULTURE 질문에는 CULTURE 요구조건 ID만 사용할 수 있습니다.")
+        }
+        val items = request.global.map { it to QuestionCategory.GLOBAL } + request.culture.map { it to QuestionCategory.CULTURE }
+        return items.map { (item, category) ->
+            QuestionDto.from(questionWriter.save(Question(category = category, content = item.content, sortOrder = item.sortOrder, requirementIds = item.requirementIds)))
+        }
+    }
+
+    fun upsertParts(partId: Long, request: UpdatePartQuestionsRequest): List<QuestionDto> {
+        partReader.readById(partId)
+        require(request.questions.mapNotNull { it.id }.size == request.questions.mapNotNull { it.id }.toSet().size) { "질문 ID가 중복되었습니다." }
+        val existing = questionReader.readAll().filter { it.partId == partId && it.category == QuestionCategory.PART }
+        val existingById = existing.associateBy { it.id }
+        request.questions.forEach { item ->
+            validatePartRequirements(item.requirementIds)
+            if (item.id != null) {
+                require(existingById[item.id] != null) { "해당 파트에 존재하지 않는 질문입니다: ${item.id}" }
+            }
+        }
+        val retainedIds = request.questions.mapNotNull { it.id }.toSet()
+        questionWriter.deleteAllByIdIn(existing.mapNotNull { it.id }.filterNot { it in retainedIds })
+        return request.questions.map { item ->
+            val question = Question(item.id, partId, QuestionCategory.PART, item.content, item.sortOrder, item.requirementIds)
+            if (item.id == null) QuestionDto.from(questionWriter.save(question))
+            else { questionWriter.update(question); QuestionDto.from(question) }
+        }
+    }
+
+    private fun validatePartRequirements(ids: List<Long>) {
+        require(ids.isNotEmpty()) { "파트 질문은 요구조건을 최소 1개 이상 매핑해야 합니다." }
+        val requirements = requirementReader.readAllByIdIn(ids)
+        require(requirements.size == ids.toSet().size && requirements.all { it.rubricType in setOf(RubricGroupType.TEAM, RubricGroupType.JOB, RubricGroupType.OTHER) }) {
+            "파트 질문에는 TEAM, JOB, OTHER 요구조건 ID만 사용할 수 있습니다."
+        }
+    }
 
     fun readAll(partId: Long): List<QuestionDto> {
         partReader.readById(partId)
-
-        return questionReader.readAll()
+        val questions = questionReader.readAll()
             .filter { it.partId == null || it.partId == partId }
-            .map(QuestionDto::from)
+        val requirements = requirementReader.readAllByIdIn(questions.flatMap { it.requirementIds }.distinct())
+            .associateBy { it.id }
+        return questions.map { question ->
+            QuestionDto.from(question, question.requirementIds.mapNotNull { id ->
+                requirements[id]?.let { QuestionRequirementDto(id, it.content) }
+            })
+        }
     }
 }

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/interviewQuestion/business/dto/QuestionDto.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/interviewQuestion/business/dto/QuestionDto.kt
@@ -9,14 +9,16 @@ data class QuestionDto(
     val category: QuestionCategory,
     val content: String,
     val sortOrder: Int,
+    val requirements: List<QuestionRequirementDto> = emptyList(),
 ) {
     companion object {
-        fun from(question: Question): QuestionDto = QuestionDto(
+        fun from(question: Question, requirements: List<QuestionRequirementDto> = emptyList()): QuestionDto = QuestionDto(
             id = question.id!!,
             partId = question.partId,
             category = question.category,
             content = question.content,
             sortOrder = question.sortOrder,
+            requirements = requirements,
         )
     }
 }

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/interviewQuestion/implement/QuestionRepository.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/interviewQuestion/implement/QuestionRepository.kt
@@ -7,4 +7,8 @@ interface QuestionRepository {
     fun findAllByIdIn(ids: Collection<Long>): List<Question>
 
     fun update(question: Question)
+
+    fun save(question: Question): Question
+
+    fun deleteAllByIdIn(ids: Collection<Long>)
 }

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/interviewQuestion/implement/QuestionWriter.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/interviewQuestion/implement/QuestionWriter.kt
@@ -9,7 +9,11 @@ class QuestionWriter(
     private val questionRepository: QuestionRepository,
 ) {
 
+    fun save(question: Question): Question = questionRepository.save(question)
+
     fun update(question: Question) {
         questionRepository.update(question)
     }
+
+    fun deleteAllByIdIn(ids: Collection<Long>) = questionRepository.deleteAllByIdIn(ids)
 }

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/interviewQuestion/storage/QuestionRepositoryImpl.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/interviewQuestion/storage/QuestionRepositoryImpl.kt
@@ -43,6 +43,27 @@ class QuestionRepositoryImpl(
         )
     }
 
+    override fun save(question: Question): Question {
+        val saved = jpaQuestionRepository.save(
+            QuestionEntity(
+                category = question.category,
+                content = question.content,
+                sortOrder = question.sortOrder,
+            ),
+        )
+        jpaQuestionRequirementRepository.saveAll(
+            question.requirementIds.map { QuestionRequirementEntity(saved.id!!, it) },
+        )
+        return saved.toDomain(question.requirementIds)
+    }
+
+    override fun deleteAllByIdIn(ids: Collection<Long>) {
+        if (ids.isNotEmpty()) {
+            jpaQuestionRequirementRepository.deleteAllByQuestionIdIn(ids.toList())
+            jpaQuestionRepository.deleteAllById(ids)
+        }
+    }
+
     private fun readRequirementIdsByQuestionId(questionIds: List<Long>): Map<Long, List<Long>> {
         if (questionIds.isEmpty()) {
             return emptyMap()

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/interviewQuestion/storage/QuestionRepositoryImpl.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/interviewQuestion/storage/QuestionRepositoryImpl.kt
@@ -46,6 +46,7 @@ class QuestionRepositoryImpl(
     override fun save(question: Question): Question {
         val saved = jpaQuestionRepository.save(
             QuestionEntity(
+                partId = question.partId,
                 category = question.category,
                 content = question.content,
                 sortOrder = question.sortOrder,


### PR DESCRIPTION
## Summary

면접 질문 카탈로그 및 파트별 공통 질문을 관리하기 위한 API를 추가했습니다.

## Changes

- GLOBAL · CULTURE 질문 생성 API 추가
- PART 질문 전체 동기화 API 추가
  - `id`가 존재하면 기존 질문 수정
  - `id`가 없으면 신규 질문 생성
  - 요청에서 누락된 기존 질문 삭제
- 질문 조회 응답에 매핑된 `requirement`의 `id` 및 `content` 추가
- CULTURE / PART 질문의 요구조건 그룹 및 필수 매핑 검증 추가
- `QuestionController` Swagger API 명세 추가

## API

| Method | Endpoint | Description |
| --- | --- | --- |
| POST | `/interviews/questions` | GLOBAL · CULTURE 질문 생성 |
| PUT | `/parts/{partId}/interviews/questions` | PART 질문 전체 동기화 |
| GET | `/parts/{partId}/interviews/questions` | 파트별 공통 질문 조회 |

## Validation

### CULTURE

- CULTURE 요구조건만 매핑 가능

### PART

- TEAM, JOB, OTHER 요구조건 중 1개 이상 필요

## Verification

- `./gradlew.bat compileKotlin` 통과

## Notes

- 로컬 환경 설정 파일(`application-dev.yml`)은 커밋에 포함하지 않았습니다.