### PR TITLE
[#372]; OpenAPI 스키마 수정

### DIFF
--- a/src/main/kotlin/com/yourssu/scouter/recruiting/interviewQuestion/application/dto/ReadAssignedQuestionResponse.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/interviewQuestion/application/dto/ReadAssignedQuestionResponse.kt
@@ -2,14 +2,28 @@ package com.yourssu.scouter.recruiting.interviewQuestion.application.dto
 
 import com.yourssu.scouter.recruiting.interviewQuestion.business.dto.AssignedQuestionDto
 import com.yourssu.scouter.recruiting.interviewQuestion.implement.AssignedQuestionCategory
+import io.swagger.v3.oas.annotations.media.Schema
 
 data class ReadAssignedQuestionResponse(
+    @field:Schema(description = "배정 질문 ID (초기 기본 질문인 경우 null)", nullable = true)
     val id: Long?,
+
+    @field:Schema(description = "배정된 면접관 유저 ID", nullable = true)
     val assignedInterviewerUserId: Long?,
+
+    @field:Schema(description = "카탈로그 원본 질문 ID (개인 질문인 경우 null)", nullable = true)
     val sourceQuestionId: Long?,
+
+    @field:Schema(description = "질문 내용")
     val content: String,
+
+    @field:Schema(description = "질문 카테고리")
     val category: AssignedQuestionCategory,
+
+    @field:Schema(description = "질문 선택 여부", nullable = true)
     val isSelected: Boolean?,
+
+    @field:Schema(description = "질문 요구조건 리스트")
     val requirements: List<ReadQuestionRequirementResponse>,
 ) {
     companion object {

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/interviewQuestion/application/dto/SaveAssignedQuestionRequest.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/interviewQuestion/application/dto/SaveAssignedQuestionRequest.kt
@@ -2,22 +2,29 @@ package com.yourssu.scouter.recruiting.interviewQuestion.application.dto
 
 import com.yourssu.scouter.recruiting.interviewQuestion.business.dto.SaveAssignedQuestionCommand
 import com.yourssu.scouter.recruiting.interviewQuestion.implement.AssignedQuestionCategory
+import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.constraints.NotNull
 
 data class SaveAssignedQuestionRequest(
 
     @field:NotNull
+    @field:Schema(description = "배정할 면접관 유저 ID")
     val assignedInterviewerUserId: Long?,
 
+    @field:Schema(description = "카탈로그 원본 질문 ID (개인 질문인 경우 null)", nullable = true)
     val sourceQuestionId: Long?,
 
+    @field:Schema(description = "질문 내용 (개인 질문이거나 PART 질문의 내용을 수정할 경우)", nullable = true)
     val content: String?,
 
     @field:NotNull
+    @field:Schema(description = "질문 카테고리")
     val category: AssignedQuestionCategory?,
 
+    @field:Schema(description = "질문 선택 여부", nullable = true)
     val isSelected: Boolean? = null,
 
+    @field:Schema(description = "질문 요구조건 ID 목록 (PERSONAL 혹은 PART 질문 수정 시 필요)")
     val requirementIds: List<Long> = emptyList(),
 ) {
     fun toCommand(): SaveAssignedQuestionCommand = SaveAssignedQuestionCommand(

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/interviewQuestion/application/dto/SaveAssignedQuestionRequest.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/interviewQuestion/application/dto/SaveAssignedQuestionRequest.kt
@@ -7,6 +7,7 @@ import jakarta.validation.constraints.NotNull
 
 data class SaveAssignedQuestionRequest(
 
+    @field:NotNull
     @field:Schema(description = "배정할 면접관 유저 ID")
     val assignedInterviewerUserId: Long?,
 

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/interviewQuestion/application/dto/SaveAssignedQuestionRequest.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/interviewQuestion/application/dto/SaveAssignedQuestionRequest.kt
@@ -7,7 +7,6 @@ import jakarta.validation.constraints.NotNull
 
 data class SaveAssignedQuestionRequest(
 
-    @field:NotNull
     @field:Schema(description = "배정할 면접관 유저 ID")
     val assignedInterviewerUserId: Long?,
 


### PR DESCRIPTION

 ### 📝 작업 개요                                                                                                                                                    
                                                                                                                                                                      
  지원자별 면접 질문 조회 및 수정 API의 일부 필드들이 명세 상에서 nullable함이 드러나지 않는 문제를 해결하기 위해, DTO 필드에 Swagger/OpenAPI @Schema 어노테이션을 적용했습니다.                                                                                                                                                       
                                                                                                                                                                      
  ### 🛠️ 작업 내용                                                                                                                                                    
                                                                                                                                                                      
  • ReadAssignedQuestionResponse 필드 스키마 명세 보완                                                                                                                
      • id, assignedInterviewerUserId, sourceQuestionId, isSelected 필드에 @field:Schema(..., nullable = true) 속성과 상세 설명을 추가했습니다.                       
  • SaveAssignedQuestionRequest 필드 스키마 명세 보완                                                                                                                 
      • sourceQuestionId, content, isSelected 필드에 @field:Schema(..., nullable = true) 속성과 상세 설명을 추가했습니다.                                             
                                                                                                                                                                      
                                                                                                                                                                      
  ### 💡 기대 효과                                                                                                                                                    
                                                                                                                                                                      
  • v3/api-docs 스키마 및 Swagger UI 상에 해당 필드들이 nullable: true로 올바르게 표시됩니다.                                                                         
  • OpenAPI 스키마를 통해 Typescript 등의 클라이언트 코드를 자동 생성할 때, 해당 필드들이 Type | null 형태로 올바른 nullable 타입으로 추론됩니다.   

## 📎 Issue 번호
#372 
