### PR TITLE
[#374]; 면접 평가·면접 루브릭 OpenAPI 스키마 보완

### DIFF
--- a/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/application/InterviewEvaluationController.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/application/InterviewEvaluationController.kt
@@ -15,6 +15,7 @@ import com.yourssu.scouter.recruiting.evaluation.business.InterviewEvaluationSer
 import com.yourssu.scouter.recruiting.support.business.exception.ApplicantAccessDeniedException
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.media.ArraySchema
 import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.ExampleObject
 import io.swagger.v3.oas.annotations.media.Schema
@@ -90,7 +91,7 @@ class InterviewEvaluationController(
 
     @Operation(summary = "다른 평가자 면접 평가 조회", description = "다른 면접관들의 평가 내역을 조회합니다. 본인이 평가를 완료(최종 제출)한 경우에만 타인 평가가 조회 가능합니다.")
     @ApiResponses(value = [
-        ApiResponse(responseCode = "200", description = "조회 성공", content = [Content(schema = Schema(implementation = ReadOtherInterviewEvaluationResponse::class))]),
+        ApiResponse(responseCode = "200", description = "조회 성공", content = [Content(array = ArraySchema(schema = Schema(implementation = ReadOtherInterviewEvaluationResponse::class)))]),
         ApiResponse(responseCode = "403", description = "해당 지원자의 정보를 조회할 권한이 없거나, 본인이 아직 최종 제출하지 않아 블라인드 처리됨"),
         ApiResponse(responseCode = "404", description = "지원자를 찾을 수 없음"),
     ])
@@ -107,7 +108,7 @@ class InterviewEvaluationController(
 
     @Operation(summary = "면접 평가자 상태 목록 조회", description = "해당 지원자에게 할당된 면접관들의 평가 작성 진행 상태를 조회합니다.")
     @ApiResponses(value = [
-        ApiResponse(responseCode = "200", description = "조회 성공", content = [Content(schema = Schema(implementation = ReadEvaluatorStatusResponse::class))]),
+        ApiResponse(responseCode = "200", description = "조회 성공", content = [Content(array = ArraySchema(schema = Schema(implementation = ReadEvaluatorStatusResponse::class)))]),
         ApiResponse(responseCode = "403", description = "해당 지원자의 정보를 조회할 권한이 없음"),
         ApiResponse(responseCode = "404", description = "지원자를 찾을 수 없음"),
     ])

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/application/dto/ReadEvaluatorStatusResponse.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/application/dto/ReadEvaluatorStatusResponse.kt
@@ -2,10 +2,15 @@ package com.yourssu.scouter.recruiting.evaluation.application.dto
 
 import com.yourssu.scouter.recruiting.evaluation.business.dto.EvaluatorStatusDto
 import com.yourssu.scouter.recruiting.evaluation.implement.EvaluationStatus
+import io.swagger.v3.oas.annotations.media.Schema
 
+@Schema(description = "지원자에 대한 면접 평가자별 작성 진행 상태")
 data class ReadEvaluatorStatusResponse(
+    @field:Schema(description = "평가자 사용자 ID", example = "23", nullable = false)
     val userId: Long,
+    @field:Schema(description = "평가자 이름", example = "홍길동", nullable = false)
     val name: String,
+    @field:Schema(description = "평가 작성 상태", example = "SUBMITTED", allowableValues = ["NOT_STARTED", "IN_PROGRESS", "SUBMITTED"], nullable = false)
     val status: EvaluationStatus,
 ) {
     companion object {

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/application/dto/ReadInterviewEvaluationResponse.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/application/dto/ReadInterviewEvaluationResponse.kt
@@ -4,25 +4,40 @@ import com.yourssu.scouter.recruiting.evaluation.business.dto.InterviewEvaluatio
 import com.yourssu.scouter.recruiting.evaluation.business.dto.InterviewEvaluationItemDto
 import com.yourssu.scouter.recruiting.evaluation.implement.InterviewResult
 import com.yourssu.scouter.recruiting.rubric.implement.RubricGroupType
+import io.swagger.v3.oas.annotations.media.Schema
 import java.time.LocalDateTime
 
+@Schema(description = "면접 평가 루브릭 그룹별 점수 정보")
 data class ReadInterviewEvaluationGroupResponse(
+    @field:Schema(description = "평가 그룹", example = "CULTURE_FIT", allowableValues = ["CULTURE_FIT", "TEAM_FIT", "JOB_FIT"], nullable = false)
     val group: String,
+    @field:Schema(description = "그룹에 속한 평가 항목과 점수 목록", nullable = false)
     val items: List<ReadInterviewEvaluationItemResponse>
 )
 
+@Schema(description = "면접 평가 항목별 조회 정보")
 data class ReadInterviewEvaluationItemResponse(
+    @field:Schema(description = "면접 루브릭 평가 항목 ID", example = "101", nullable = false)
     val itemId: Long,
+    @field:Schema(description = "평가 항목명", example = "주도적인 실행력", nullable = false)
     val itemTitle: String,
+    @field:Schema(description = "평가 항목의 최대 배점", example = "10", nullable = false)
     val maxScore: Int,
+    @field:Schema(description = "평가자가 부여한 점수", example = "8", nullable = false)
     val score: Int,
 )
 
+@Schema(description = "로그인한 면접관 본인의 면접 평가 조회 응답")
 data class ReadInterviewEvaluationResponse(
+    @field:Schema(description = "모든 평가 항목 점수의 합계", example = "85", nullable = false)
     val totalScore: Int,
+    @field:Schema(description = "루브릭 그룹별 평가 항목과 점수", nullable = false)
     val groups: List<ReadInterviewEvaluationGroupResponse>,
+    @field:Schema(description = "면접 전반에 대한 종합 의견", example = "질문에 대한 답변이 구조적이고 문화 적합성이 높습니다.", nullable = false)
     val overallComment: String,
+    @field:Schema(description = "면접 평가 결과", example = "FINAL_PASS", allowableValues = ["PENDING", "FINAL_PASS", "INTERVIEW_FAIL"], nullable = false)
     val result: InterviewResult,
+    @field:Schema(description = "최종 제출 시각. 임시저장 상태이면 null입니다.", example = "2026-08-01T09:30:00", type = "string", format = "date-time", nullable = true)
     val submittedAt: LocalDateTime?,
 ) {
     companion object {

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/application/dto/ReadOtherInterviewEvaluationResponse.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/application/dto/ReadOtherInterviewEvaluationResponse.kt
@@ -3,9 +3,13 @@ package com.yourssu.scouter.recruiting.evaluation.application.dto
 import com.yourssu.scouter.recruiting.evaluation.business.dto.OtherInterviewEvaluationDto
 import com.yourssu.scouter.recruiting.evaluation.business.dto.OtherInterviewEvaluationItemDto
 import com.yourssu.scouter.recruiting.evaluation.implement.InterviewResult
+import io.swagger.v3.oas.annotations.media.Schema
 
+@Schema(description = "다른 면접관의 항목별 점수 정보")
 data class ReadOtherInterviewEvaluationItemResponse(
+    @field:Schema(description = "면접 루브릭 평가 항목 ID", example = "101", nullable = false)
     val itemId: Long,
+    @field:Schema(description = "다른 면접관이 부여한 점수. 평가 미제출 시 마스킹될 수 있습니다.", example = "8", nullable = false)
     val score: Int,
 ) {
     companion object {
@@ -14,12 +18,19 @@ data class ReadOtherInterviewEvaluationItemResponse(
     }
 }
 
+@Schema(description = "다른 면접관의 면접 평가 조회 응답")
 data class ReadOtherInterviewEvaluationResponse(
+    @field:Schema(description = "평가자 사용자 ID", example = "23", nullable = false)
     val evaluatorId: Long,
+    @field:Schema(description = "평가자 이름", example = "홍길동", nullable = false)
     val evaluatorName: String,
+    @field:Schema(description = "평가 항목 점수의 합계", example = "85", nullable = false)
     val totalScore: Int,
+    @field:Schema(description = "면접 평가 결과", example = "FINAL_PASS", allowableValues = ["PENDING", "FINAL_PASS", "INTERVIEW_FAIL"], nullable = false)
     val result: InterviewResult,
+    @field:Schema(description = "면접 전반에 대한 종합 의견", example = "기술 이해도가 높고 협업 역량이 좋습니다.", nullable = false)
     val overallComment: String,
+    @field:Schema(description = "평가 항목별 점수 목록", nullable = false)
     val items: List<ReadOtherInterviewEvaluationItemResponse>,
 ) {
     companion object {

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/application/dto/SaveInterviewEvaluationRequest.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/application/dto/SaveInterviewEvaluationRequest.kt
@@ -3,14 +3,18 @@ package com.yourssu.scouter.recruiting.evaluation.application.dto
 import com.yourssu.scouter.recruiting.evaluation.business.dto.SaveInterviewEvaluationCommand
 import com.yourssu.scouter.recruiting.evaluation.business.dto.SaveInterviewEvaluationItemCommand
 import com.yourssu.scouter.recruiting.evaluation.implement.InterviewResult
+import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.constraints.NotEmpty
 import jakarta.validation.constraints.NotNull
 
+@Schema(description = "면접 평가 항목별 점수 저장 요청")
 data class SaveInterviewEvaluationItemRequest(
     @field:NotNull
+    @field:Schema(description = "면접 루브릭 평가 항목 ID", example = "101", nullable = false)
     val itemId: Long?,
 
     @field:NotNull
+    @field:Schema(description = "해당 평가 항목에 부여한 점수. 항목별 최대 배점을 초과할 수 없습니다.", example = "8", minimum = "1", nullable = false)
     val score: Int?,
 ) {
     fun toCommand(): SaveInterviewEvaluationItemCommand = SaveInterviewEvaluationItemCommand(
@@ -19,16 +23,21 @@ data class SaveInterviewEvaluationItemRequest(
     )
 }
 
+@Schema(description = "면접 평가 임시저장 또는 최종 제출 요청")
 data class SaveInterviewEvaluationRequest(
     @field:NotEmpty(message = "평가 항목 점수 리스트는 비어있을 수 없습니다.")
+    @field:Schema(description = "루브릭 항목별 점수 목록. 비어 있을 수 없습니다.", nullable = false)
     val items: List<SaveInterviewEvaluationItemRequest> = emptyList(),
 
+    @field:Schema(description = "면접 전반에 대한 종합 의견", example = "질문에 대한 답변이 구조적이고 문화 적합성이 높습니다.", nullable = false)
     val overallComment: String = "",
 
     @field:NotNull
+    @field:Schema(description = "면접 평가 결과", example = "FINAL_PASS", allowableValues = ["PENDING", "FINAL_PASS", "INTERVIEW_FAIL"], nullable = false)
     val result: InterviewResult?,
 
     @field:NotNull
+    @field:Schema(description = "최종 제출 여부. false는 임시저장, true는 최종 제출입니다.", example = "true", nullable = false)
     val submit: Boolean?,
 ) {
     fun toCommand(applicantId: Long, evaluatorUserId: Long): SaveInterviewEvaluationCommand = SaveInterviewEvaluationCommand(

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/rubric/application/dto/InterviewRubricDeadlineResponse.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/rubric/application/dto/InterviewRubricDeadlineResponse.kt
@@ -3,7 +3,8 @@ package com.yourssu.scouter.recruiting.rubric.application.dto
 import io.swagger.v3.oas.annotations.media.Schema
 import java.time.Instant
 
+@Schema(description = "면접 평가 루브릭 수정 마감일 조회 응답")
 data class InterviewRubricDeadlineResponse(
-    @field:Schema(description = "루브릭 수정 마감 시각(UTC ISO-8601)", example = "2026-08-01T09:00:00Z", type = "string", format = "date-time")
+    @field:Schema(description = "루브릭 수정 마감 시각(UTC ISO-8601)", example = "2026-08-01T09:00:00Z", type = "string", format = "date-time", nullable = false)
     val deadline: Instant,
 )

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/rubric/application/dto/InterviewRubricDeadlineUpdateRequest.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/rubric/application/dto/InterviewRubricDeadlineUpdateRequest.kt
@@ -4,8 +4,9 @@ import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.constraints.NotNull
 import java.time.Instant
 
+@Schema(description = "면접 평가 루브릭 수정 마감일 변경 요청")
 data class InterviewRubricDeadlineUpdateRequest(
     @field:NotNull
-    @field:Schema(description = "루브릭 수정 마감 시각(UTC ISO-8601)", example = "2026-08-01T09:00:00Z", type = "string", format = "date-time")
+    @field:Schema(description = "루브릭 수정 마감 시각(UTC ISO-8601)", example = "2026-08-01T09:00:00Z", type = "string", format = "date-time", nullable = false)
     val deadline: Instant?,
 )

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/rubric/application/dto/InterviewRubricResponse.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/rubric/application/dto/InterviewRubricResponse.kt
@@ -7,36 +7,36 @@ import io.swagger.v3.oas.annotations.media.Schema
 
 @Schema(description = "면접 루브릭 조회 또는 저장 응답")
 data class InterviewRubricResponse(
-    @field:Schema(description = "루브릭 ID", example = "1")
+    @field:Schema(description = "루브릭 ID", example = "1", nullable = false)
     val id: Long,
-    @field:Schema(description = "파트 ID", example = "3")
+    @field:Schema(description = "파트 ID", example = "3", nullable = false)
     val partId: Long,
-    @field:Schema(description = "학기 식별자", example = "2026-1")
+    @field:Schema(description = "학기 식별자", example = "2026-1", nullable = false)
     val semester: String,
-    @field:Schema(description = "루브릭 수정 마감 시각(UTC ISO-8601)", example = "2026-08-01T09:00:00Z", type = "string", format = "date-time")
+    @field:Schema(description = "루브릭 수정 마감 시각(UTC ISO-8601)", example = "2026-08-01T09:00:00Z", type = "string", format = "date-time", nullable = false)
     val deadline: Instant,
-    @field:Schema(description = "잠금 여부. true이면 수정 불가", example = "false")
+    @field:Schema(description = "잠금 여부. true이면 수정 불가", example = "false", nullable = false)
     val isLocked: Boolean,
-    @field:Schema(description = "평가 항목 그룹 목록")
+    @field:Schema(description = "평가 항목 그룹 목록", nullable = false)
     val groups: List<GroupResponse>
 ) {
     @Schema(description = "면접 루브릭 평가 항목 그룹 응답")
     data class GroupResponse(
-        @field:Schema(description = "평가 그룹", example = "CULTURE_FIT", allowableValues = ["JOB_FIT", "CULTURE_FIT", "TEAM_FIT"])
+        @field:Schema(description = "평가 그룹", example = "CULTURE_FIT", allowableValues = ["JOB_FIT", "CULTURE_FIT", "TEAM_FIT"], nullable = false)
         val group: String,
-        @field:Schema(description = "그룹 합계 배점", example = "30")
+        @field:Schema(description = "그룹 합계 배점", example = "30", nullable = false)
         val groupMaxScore: Int,
-        @field:Schema(description = "평가 항목 목록")
+        @field:Schema(description = "평가 항목 목록", nullable = false)
         val items: List<ItemResponse>
     )
 
     @Schema(description = "면접 루브릭 평가 항목 응답")
     data class ItemResponse(
-        @field:Schema(description = "평가 항목 ID", example = "1")
+        @field:Schema(description = "평가 항목 ID", example = "1", nullable = false)
         val itemId: Long,
-        @field:Schema(description = "평가 항목명", example = "주도성, 실행력")
+        @field:Schema(description = "평가 항목명", example = "주도성, 실행력", nullable = false)
         val title: String,
-        @field:Schema(description = "항목 최대 배점", example = "10")
+        @field:Schema(description = "항목 최대 배점", example = "10", nullable = false)
         val maxScore: Int
     )
 


### PR DESCRIPTION
  ### 변경 사항

  - 면접 평가 요청 DTO에 필드별 OpenAPI 스키마 추가
      - 평가 항목 ID
      - 점수
      - 종합 의견
      - 평가 결과
      - 최종 제출 여부

  - 면접 평가 응답 DTO에 필드 설명·예시·nullable 여부 추가
      - 본인 평가 응답
      - 다른 평가자의 평가 응답
      - 평가자 상태 응답

  - 면접 루브릭 응답·요청 DTO에 필드별 타입과 nullable 여부 명시
      - 루브릭 정보
      - 평가 그룹
      - 평가 항목
      - 마감일
      - 루브릭 수정 요청

  - 면접 평가 컨트롤러의 @ApiResponse 응답 타입 보완
      - 본인 평가: ReadInterviewEvaluationResponse
      - 타인 평가: List<ReadOtherInterviewEvaluationResponse>
      - 평가자 상태: List<ReadEvaluatorStatusResponse>

  - 배열 응답은 ArraySchema를 사용해 OpenAPI 생성 클라이언트에서 배열 타입으로 생성되도록 수정
  - ResponseEntity<Unit> 저장 API는 응답 body 스키마를 잘못 생성하지 않도록 별도 응답 타입을 지정하지 않음

  ### 기대 효과

  - Swagger 문서에서 실제 컨트롤러 반환 타입과 응답 스키마가 일치
  - OpenAPI 기반 클라이언트 생성 시 단일 객체와 배열 응답 타입이 정확히 생성
  - 면접 평가·루브릭 DTO의 필수/nullable 필드 구분 명확화
  - 평가 결과, 상태, 루브릭 그룹 등의 enum 허용값 확인 가능


## 📎 Issue 번호
closed #374 
