### PR TITLE
[#384]; refactor: auth 내 login을 authentication으로 병합

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,8 @@
 ```
 com.yourssu.scouter
 ├── auth/                  // 인증/인가 — 로그인, 토큰, 계정, 권한
-│   ├── authentication/        // OAuth2 로그인 처리, 토큰 발급/갱신
+│   ├── authentication/        // OAuth2 로그인 처리, 토큰 발급/갱신 (회원 조회를 묶은 로그인 유스케이스 포함)
 │   ├── authorization/         // 사용자 권한(Role) 관리
-│   ├── login/                 // OAuth2 로그인 + 회원 조회를 묶은 로그인 유스케이스
 │   └── user/                  // 로그인 계정(User) 도메인
 │
 ├── member/                // Yourssu 동아리 회원 관리
@@ -22,7 +21,10 @@ com.yourssu.scouter
 │   ├── part/                  // Yourssu 파트 
 │   └── semester/              // 학기
 │
-├── mail/                  // 메일 발송 (작업 진행 중)
+├── mail/                  // 메일 발송
+│   ├── core/                  // 즉시발송 + 예약발송
+│   ├── template/               // 메일 템플릿 관리
+│   └── file/                    // 첨부파일 업로드/관리
 │
 ├── recruiting/            // 채용/지원자 관리 (작업 진행 중)
 │

--- a/src/main/kotlin/com/yourssu/scouter/auth/authentication/application/AuthenticationController.kt
+++ b/src/main/kotlin/com/yourssu/scouter/auth/authentication/application/AuthenticationController.kt
@@ -16,8 +16,8 @@ import com.yourssu.scouter.auth.authentication.application.dto.TokenRefreshReque
 
 import com.yourssu.scouter.auth.authentication.business.AuthenticationService
 import com.yourssu.scouter.auth.authentication.business.dto.TokenDto
-import com.yourssu.scouter.auth.login.business.LoginService
-import com.yourssu.scouter.auth.login.business.dto.LoginWithMemberResult
+import com.yourssu.scouter.auth.authentication.business.LoginService
+import com.yourssu.scouter.auth.authentication.business.dto.LoginWithMemberResult
 import com.yourssu.scouter.auth.authentication.implement.OAuth2Type
 import com.yourssu.scouter.auth.authentication.implement.TokenType
 import io.swagger.v3.oas.annotations.Operation

--- a/src/main/kotlin/com/yourssu/scouter/auth/authentication/application/dto/LoginResponse.kt
+++ b/src/main/kotlin/com/yourssu/scouter/auth/authentication/application/dto/LoginResponse.kt
@@ -1,6 +1,6 @@
 package com.yourssu.scouter.auth.authentication.application.dto
 
-import com.yourssu.scouter.auth.login.business.dto.LoginWithMemberResult
+import com.yourssu.scouter.auth.authentication.business.dto.LoginWithMemberResult
 import io.swagger.v3.oas.annotations.media.Schema
 
 @Schema(description = "로그인 응답")

--- a/src/main/kotlin/com/yourssu/scouter/auth/authentication/business/LoginService.kt
+++ b/src/main/kotlin/com/yourssu/scouter/auth/authentication/business/LoginService.kt
@@ -1,9 +1,8 @@
-package com.yourssu.scouter.auth.login.business
+package com.yourssu.scouter.auth.authentication.business
 
-import com.yourssu.scouter.auth.login.business.dto.LoginWithMemberResult
+import com.yourssu.scouter.auth.authentication.business.dto.LoginWithMemberResult
 
 import com.yourssu.scouter.auth.authentication.business.dto.LoginResult
-import com.yourssu.scouter.auth.authentication.business.OAuth2Service
 import com.yourssu.scouter.auth.authentication.implement.OAuth2Type
 import com.yourssu.scouter.member.core.business.dto.MemberDto
 import com.yourssu.scouter.member.core.implement.Member

--- a/src/main/kotlin/com/yourssu/scouter/auth/authentication/business/dto/LoginWithMemberResult.kt
+++ b/src/main/kotlin/com/yourssu/scouter/auth/authentication/business/dto/LoginWithMemberResult.kt
@@ -1,4 +1,4 @@
-package com.yourssu.scouter.auth.login.business.dto
+package com.yourssu.scouter.auth.authentication.business.dto
 
 import com.yourssu.scouter.member.core.business.dto.MemberDto
 

--- a/src/main/kotlin/com/yourssu/scouter/auth/user/storage/UserEntity.kt
+++ b/src/main/kotlin/com/yourssu/scouter/auth/user/storage/UserEntity.kt
@@ -14,7 +14,6 @@ import jakarta.persistence.Id
 import jakarta.persistence.Table
 import java.time.Instant
 
-
 @Entity
 @Table(name = "users")
 class UserEntity(

--- a/src/test/kotlin/com/yourssu/scouter/auth/authentication/business/LoginServiceTest.kt
+++ b/src/test/kotlin/com/yourssu/scouter/auth/authentication/business/LoginServiceTest.kt
@@ -1,7 +1,6 @@
-package com.yourssu.scouter.auth.login.business
+package com.yourssu.scouter.auth.authentication.business
 
 import com.yourssu.scouter.auth.authentication.business.dto.LoginResult
-import com.yourssu.scouter.auth.authentication.business.OAuth2Service
 import com.yourssu.scouter.auth.authentication.implement.OAuth2Type
 import com.yourssu.scouter.member.core.fixture.MemberFixtureBuilder
 import com.yourssu.scouter.member.core.implement.MemberReader


### PR DESCRIPTION
## 📄 작업 내용 요약
- `auth/login`(LoginService, LoginWithMemberResult)을 `auth/authentication`으로 흡수 
  - OAuth2Service.login()을 감싸서 회원 여부만 체크하는 로직으로 authentication에 개념적으로 속한다고 판단
- README 아키텍처에서 `auth/login` 제거, `mail` 하위도메인(core/template/file) 반영

## 📎 Issue 번호
closed #384