### PR TITLE
[#388]; fix: 질문자 id 컬럼을 이름으로 변경 - id - 이름 mapping 로직 추가 - response와 dto의 id를 이름으로 변경

### DIFF
--- a/src/main/kotlin/com/yourssu/scouter/recruiting/interviewQuestion/application/dto/ReadAssignedQuestionResponse.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/interviewQuestion/application/dto/ReadAssignedQuestionResponse.kt
@@ -8,8 +8,8 @@ data class ReadAssignedQuestionResponse(
     @field:Schema(description = "배정 질문 ID (초기 기본 질문인 경우 null)", nullable = true)
     val id: Long?,
 
-    @field:Schema(description = "배정된 면접관 유저 ID", nullable = true)
-    val assignedInterviewerUserId: Long?,
+    @field:Schema(description = "배정된 면접관 영어 닉네임", nullable = true)
+    val assignedInterviewerName: String?,
 
     @field:Schema(description = "카탈로그 원본 질문 ID (개인 질문인 경우 null)", nullable = true)
     val sourceQuestionId: Long?,
@@ -29,7 +29,7 @@ data class ReadAssignedQuestionResponse(
     companion object {
         fun from(dto: AssignedQuestionDto): ReadAssignedQuestionResponse = ReadAssignedQuestionResponse(
             id = dto.id,
-            assignedInterviewerUserId = dto.assignedInterviewerUserId,
+            assignedInterviewerName = dto.assignedInterviewerName,
             sourceQuestionId = dto.sourceQuestionId,
             content = dto.content,
             category = dto.category,

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/interviewQuestion/business/AssignedQuestionService.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/interviewQuestion/business/AssignedQuestionService.kt
@@ -17,6 +17,7 @@ import com.yourssu.scouter.recruiting.interviewQuestion.implement.Question
 import com.yourssu.scouter.recruiting.interviewQuestion.implement.QuestionCategory
 import com.yourssu.scouter.recruiting.interviewQuestion.implement.QuestionReader
 import com.yourssu.scouter.recruiting.interviewQuestion.implement.QuestionWriter
+import com.yourssu.scouter.recruiting.support.business.EvaluatorDirectory
 import com.yourssu.scouter.recruiting.support.business.InterviewRequirementLookup
 import com.yourssu.scouter.recruiting.support.business.InterviewRequirementProfile
 import com.yourssu.scouter.recruiting.support.implement.exception.QuestionInvalidException
@@ -32,6 +33,7 @@ class AssignedQuestionService(
     private val assignedQuestionValidator: AssignedQuestionValidator,
     private val applicantReader: ApplicantReader,
     private val userReader: UserReader,
+    private val evaluatorDirectory: EvaluatorDirectory,
     private val interviewRequirementLookup: InterviewRequirementLookup,
 ) {
 
@@ -147,11 +149,30 @@ class AssignedQuestionService(
         sourceQuestionsById: Map<Long?, Question>,
         requirementsById: Map<Long?, InterviewRequirementProfile>,
     ): List<AssignedQuestionDto> {
+        val assignedInterviewerNamesById = readAssignedInterviewerNamesById(questions)
+
         return questions
             .sortedBy { it.sortOrder }
             .map { question ->
-                question.toDto(sourceQuestionsById, requirementsById)
+                question.toDto(sourceQuestionsById, requirementsById, assignedInterviewerNamesById)
             }
+    }
+
+    private fun readAssignedInterviewerNamesById(questions: List<AssignedQuestion>): Map<Long, String> {
+        val usersById = userReader
+            .readAllByIds(questions.map { it.assignedInterviewerUserId }.distinct())
+            .associateBy { it.id!! }
+
+        return questions
+            .map { it.assignedInterviewerUserId }
+            .distinct()
+            .mapNotNull { userId ->
+                val user = usersById[userId] ?: return@mapNotNull null
+                val name = evaluatorDirectory.findEvaluatorInfo(user.userInfo.email)?.nicknameEnglish
+                    ?: user.userInfo.name
+                userId to name
+            }
+            .toMap()
     }
 
     private fun readDefaultQuestions(
@@ -174,7 +195,7 @@ class AssignedQuestionService(
             .mapIndexed { index, question ->
                 AssignedQuestionDto(
                     id = null,
-                    assignedInterviewerUserId = null,
+                    assignedInterviewerName = null,
                     sourceQuestionId = question.id,
                     content = question.content,
                     category = question.category.toAssignedQuestionCategory(),
@@ -196,6 +217,7 @@ class AssignedQuestionService(
     private fun AssignedQuestion.toDto(
         sourceQuestionsById: Map<Long?, Question>,
         requirementsById: Map<Long?, InterviewRequirementProfile>,
+        assignedInterviewerNamesById: Map<Long, String>,
     ): AssignedQuestionDto {
         // 카탈로그 카테고리(GLOBAL/CULTURE/PART)는 요구조건을 원본 질문(Question)에서 가져오고, PERSONAL만 인스턴스 자체 값을 사용한다.
         val effectiveRequirementIds = if (category == AssignedQuestionCategory.PERSONAL) {
@@ -206,7 +228,7 @@ class AssignedQuestionService(
 
         return AssignedQuestionDto(
             id = id!!,
-            assignedInterviewerUserId = assignedInterviewerUserId,
+            assignedInterviewerName = assignedInterviewerNamesById[assignedInterviewerUserId],
             sourceQuestionId = sourceQuestionId,
             content = content ?: sourceQuestionsById[sourceQuestionId]?.content.orEmpty(),
             category = category,

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/interviewQuestion/business/dto/AssignedQuestionDto.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/interviewQuestion/business/dto/AssignedQuestionDto.kt
@@ -4,7 +4,7 @@ import com.yourssu.scouter.recruiting.interviewQuestion.implement.AssignedQuesti
 
 data class AssignedQuestionDto(
     val id: Long?,
-    val assignedInterviewerUserId: Long?,
+    val assignedInterviewerName: String?,
     val sourceQuestionId: Long?,
     val content: String,
     val category: AssignedQuestionCategory,

--- a/src/test/kotlin/com/yourssu/scouter/recruiting/interviewQuestion/business/AssignedQuestionServiceTest.kt
+++ b/src/test/kotlin/com/yourssu/scouter/recruiting/interviewQuestion/business/AssignedQuestionServiceTest.kt
@@ -1,7 +1,10 @@
 package com.yourssu.scouter.recruiting.interviewQuestion.business
 
 import com.yourssu.scouter.auth.user.implement.User
+import com.yourssu.scouter.auth.user.implement.UserInfo
 import com.yourssu.scouter.auth.user.implement.UserReader
+import com.yourssu.scouter.auth.user.implement.TokenInfo
+import com.yourssu.scouter.auth.authentication.implement.OAuth2Type
 import com.yourssu.scouter.masterdata.part.implement.fixture.PartFixtureBuilder
 import com.yourssu.scouter.masterdata.semester.implement.fixture.SemesterFixtureBuilder
 import com.yourssu.scouter.recruiting.applicant.implement.ApplicantReader
@@ -17,6 +20,8 @@ import com.yourssu.scouter.recruiting.interviewQuestion.implement.Question
 import com.yourssu.scouter.recruiting.interviewQuestion.implement.QuestionCategory
 import com.yourssu.scouter.recruiting.interviewQuestion.implement.QuestionReader
 import com.yourssu.scouter.recruiting.interviewQuestion.implement.QuestionWriter
+import com.yourssu.scouter.recruiting.support.business.EvaluatorDirectory
+import com.yourssu.scouter.recruiting.support.business.EvaluatorInfo
 import com.yourssu.scouter.recruiting.support.business.InterviewRequirementLookup
 import com.yourssu.scouter.recruiting.support.implement.exception.QuestionInvalidException
 import org.assertj.core.api.Assertions.assertThat
@@ -38,6 +43,7 @@ class AssignedQuestionServiceTest {
     private lateinit var questionWriter: QuestionWriter
     private lateinit var applicantReader: ApplicantReader
     private lateinit var userReader: UserReader
+    private lateinit var evaluatorDirectory: EvaluatorDirectory
     private lateinit var interviewRequirementLookup: InterviewRequirementLookup
     private lateinit var assignedQuestionService: AssignedQuestionService
 
@@ -52,6 +58,7 @@ class AssignedQuestionServiceTest {
         questionWriter = mock(QuestionWriter::class.java)
         applicantReader = mock(ApplicantReader::class.java)
         userReader = mock(UserReader::class.java)
+        evaluatorDirectory = mock(EvaluatorDirectory::class.java)
         interviewRequirementLookup = mock(InterviewRequirementLookup::class.java)
 
         assignedQuestionService = AssignedQuestionService(
@@ -62,6 +69,7 @@ class AssignedQuestionServiceTest {
             AssignedQuestionValidator(),
             applicantReader,
             userReader,
+            evaluatorDirectory,
             interviewRequirementLookup,
         )
 
@@ -73,6 +81,7 @@ class AssignedQuestionServiceTest {
                 .build(),
         )
         whenever(interviewRequirementLookup.findAllByPartIdAndSemester(any(), any())).thenReturn(emptyList())
+        whenever(userReader.readAllByIds(any())).thenReturn(emptyList())
     }
 
     @Test
@@ -101,8 +110,40 @@ class AssignedQuestionServiceTest {
             .allSatisfy { assertThat(it.isSelected).isNull() }
         assertThat(result.questions).allSatisfy {
             assertThat(it.id).isNull()
-            assertThat(it.assignedInterviewerUserId).isNull()
+            assertThat(it.assignedInterviewerName).isNull()
         }
+    }
+
+    @Test
+    fun `저장된 질문은 배정된 면접관 영어 닉네임을 반환한다`() {
+        val interviewerUserId = 100L
+        val interviewerEmail = "interviewer@yourssu.com"
+        val sourceQuestions = listOf(
+            Question(1L, null, QuestionCategory.GLOBAL, "자기소개", 1),
+        )
+        val savedQuestions = listOf(
+            AssignedQuestion(
+                id = 11L,
+                assignedInterviewerUserId = interviewerUserId,
+                applicantId = applicantId,
+                sourceQuestionId = 1L,
+                content = null,
+                category = AssignedQuestionCategory.GLOBAL,
+                sortOrder = 0,
+            ),
+        )
+        whenever(assignedQuestionReader.readAllByApplicantId(applicantId)).thenReturn(savedQuestions)
+        whenever(questionReader.readAllByIdIn(listOf(1L))).thenReturn(sourceQuestions)
+        whenever(userReader.readAllByIds(listOf(interviewerUserId))).thenReturn(
+            listOf(user(interviewerUserId, "면접관", interviewerEmail)),
+        )
+        whenever(evaluatorDirectory.findEvaluatorInfo(interviewerEmail)).thenReturn(
+            EvaluatorInfo(memberId = 1L, nicknameEnglish = "piki", partName = "Backend"),
+        )
+
+        val result = assignedQuestionService.readByApplicantId(applicantId)
+
+        assertThat(result.questions.single().assignedInterviewerName).isEqualTo("piki")
     }
 
     @Test
@@ -312,6 +353,25 @@ class AssignedQuestionServiceTest {
             category = AssignedQuestionCategory.CULTURE,
             sortOrder = sortOrder,
             isSelected = isSelected,
+        )
+    }
+
+    private fun user(id: Long, name: String, email: String): User {
+        return User(
+            id = id,
+            userInfo = UserInfo(
+                name = name,
+                email = email,
+                profileImageUrl = "",
+                oauthId = "oauth-$id",
+                oauth2Type = OAuth2Type.GOOGLE,
+            ),
+            tokenInfo = TokenInfo(
+                tokenPrefix = "Bearer",
+                accessToken = "access-token",
+                refreshToken = "refresh-token",
+                accessTokenExpiresIn = 3600L,
+            ),
         )
     }
 }


### PR DESCRIPTION
## 📄 작업 내용 요약
질문자 id 컬럼을 이름으로 변경하는 작업입니다.

## 📎 Issue 번호
<!-- closed #번호 -->
closed #388