### PR TITLE
[#392]; fix: 면접 질문 카테고리 분리

### DIFF
--- a/src/main/kotlin/com/yourssu/scouter/recruiting/interviewQuestion/application/QuestionController.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/interviewQuestion/application/QuestionController.kt
@@ -16,15 +16,15 @@ class QuestionController(private val questionService: QuestionService) {
     @Operation(summary = "파트별 면접 공통 질문 전체 수정", description = "id가 있으면 수정하고 없으면 생성하며, 누락된 기존 질문은 삭제합니다.")
     @PutMapping("/parts/{partId}/interviews/questions")
     fun upsertParts(@PathVariable partId: Long, @RequestBody @Valid request: UpdatePartQuestionsRequest)
-    : ResponseEntity<List<ReadQuestionResponse>> =
+            : ResponseEntity<List<ReadQuestionResponse>> =
         ResponseEntity.ok(questionService.upsertParts(partId, request).map(ReadQuestionResponse::from))
 
-    @Operation(summary = "전역·문화 면접 질문 수정/생성", description = "GLOBAL 및 CULTURE 질문을 생성합니다.")
+    @Operation(summary = "전역·문화 면접 질문 수정/생성", description = "INTRO, OUTRO 및 CULTURE 질문을 생성합니다.")
     @PutMapping("/interviews/questions")
     fun upsertGlobalAndCulture(@RequestBody @Valid request: CreateQuestionsRequest): ResponseEntity<List<ReadQuestionResponse>> =
-        ResponseEntity.ok(questionService.upsertGlobalAndCulture(request).map(ReadQuestionResponse::from))
+        ResponseEntity.ok(questionService.upsert(request).map(ReadQuestionResponse::from))
 
-    @Operation(summary = "파트별 면접 질문 및 요구조건 조회", description = "GLOBAL, CULTURE, PART 질문과 매핑된 요구조건을 조회합니다.")
+    @Operation(summary = "파트별 면접 질문 및 요구조건 조회", description = "INTRO, OUTRO, CULTURE, PART 질문과 매핑된 요구조건을 조회합니다.")
     @GetMapping("/parts/{partId}/interviews/questions")
     fun readAll(@PathVariable partId: Long): ResponseEntity<List<ReadQuestionResponse>> =
         ResponseEntity.ok(questionService.readAll(partId).map(ReadQuestionResponse::from))

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/interviewQuestion/application/dto/CreateQuestionsRequest.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/interviewQuestion/application/dto/CreateQuestionsRequest.kt
@@ -1,12 +1,12 @@
 package com.yourssu.scouter.recruiting.interviewQuestion.application.dto
 
-import com.yourssu.scouter.recruiting.interviewQuestion.implement.QuestionCategory
 import jakarta.validation.Valid
 import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.NotNull
 
 data class CreateQuestionsRequest(
-    @field:Valid val global: List<Item> = emptyList(),
+    @field:Valid val intro: List<Item> = emptyList(),
+    @field:Valid val outro: List<Item> = emptyList(),
     @field:Valid val culture: List<Item> = emptyList(),
 ) {
     data class Item(

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/interviewQuestion/business/AssignedQuestionService.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/interviewQuestion/business/AssignedQuestionService.kt
@@ -98,14 +98,14 @@ class AssignedQuestionService(
         questions: List<SaveAssignedQuestionCommand>,
         sourceQuestionsById: Map<Long?, Question>,
     ) {
-        // 카탈로그 카테고리(GLOBAL/CULTURE/PART)의 content와 요구조건은 인스턴스가 아닌 원본 질문(Question)에 매핑된다.
-        // GLOBAL/CULTURE는 이 요청으로 값을 변경할 수 없고, PART만 여기서 갱신 가능하다.
+        // 카탈로그 카테고리(INTRO/OUTRO/CULTURE/PART)의 content와 요구조건은 인스턴스가 아닌 원본 질문(Question)에 매핑된다.
+        // INTRO/OUTRO/CULTURE는 이 요청으로 값을 변경할 수 없고, PART만 여기서 갱신 가능하다.
         questions
             .filter { it.sourceQuestionId != null }
             .forEach { question ->
                 val sourceQuestion = sourceQuestionsById.getValue(question.sourceQuestionId)
                 when (sourceQuestion.category) {
-                    QuestionCategory.GLOBAL, QuestionCategory.CULTURE -> {
+                    QuestionCategory.INTRO, QuestionCategory.OUTRO, QuestionCategory.CULTURE -> {
                         if (question.requirementIds.isNotEmpty()) {
                             throw QuestionInvalidException(
                                 "${sourceQuestion.category} 질문은 요구조건을 변경할 수 없습니다.",
@@ -117,6 +117,7 @@ class AssignedQuestionService(
                             )
                         }
                     }
+
                     QuestionCategory.PART -> {
                         val updatedQuestion = Question(
                             id = sourceQuestion.id,
@@ -182,16 +183,7 @@ class AssignedQuestionService(
         val catalogQuestions = questionReader.readAll()
             .filter { it.partId == null || it.partId == applicantPartId }
 
-        val fixedQuestions = catalogQuestions
-            .filter { it.category == QuestionCategory.GLOBAL }
-
-        val partQuestions = catalogQuestions
-            .filter { it.category == QuestionCategory.PART }
-
-        val cultureQuestions = catalogQuestions
-            .filter { it.category == QuestionCategory.CULTURE }
-
-        return (fixedQuestions + partQuestions + cultureQuestions)
+        return catalogQuestions
             .mapIndexed { index, question ->
                 AssignedQuestionDto(
                     id = null,
@@ -220,7 +212,7 @@ class AssignedQuestionService(
         requirementsById: Map<Long?, InterviewRequirementProfile>,
         assignedInterviewerNamesById: Map<Long, String>,
     ): AssignedQuestionDto {
-        // 카탈로그 카테고리(GLOBAL/CULTURE/PART)는 요구조건을 원본 질문(Question)에서 가져오고, PERSONAL만 인스턴스 자체 값을 사용한다.
+        // 카탈로그 카테고리(INTRO/OUTRO/CULTURE/PART)는 요구조건을 원본 질문(Question)에서 가져오고, PERSONAL만 인스턴스 자체 값을 사용한다.
         val effectiveRequirementIds = if (category == AssignedQuestionCategory.PERSONAL) {
             requirementIds
         } else {

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/interviewQuestion/business/QuestionService.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/interviewQuestion/business/QuestionService.kt
@@ -24,10 +24,13 @@ class QuestionService(
 ) {
 
     @Transactional
-    fun upsertGlobalAndCulture(request: CreateQuestionsRequest): List<QuestionDto> {
+    fun upsert(request: CreateQuestionsRequest): List<QuestionDto> {
         require(
-            request.global.mapNotNull { it.id }.size == request.global.mapNotNull { it.id }.toSet().size,
-        ) { "GLOBAL 질문 ID가 중복되었습니다." }
+            request.intro.mapNotNull { it.id }.size == request.intro.mapNotNull { it.id }.toSet().size,
+        ) { "INTRO 질문 ID가 중복되었습니다." }
+        require(
+            request.outro.mapNotNull { it.id }.size == request.outro.mapNotNull { it.id }.toSet().size,
+        ) { "OUTRO 질문 ID가 중복되었습니다." }
         require(
             request.culture.mapNotNull { it.id }.size == request.culture.mapNotNull { it.id }.toSet().size,
         ) { "CULTURE 질문 ID가 중복되었습니다." }
@@ -35,11 +38,18 @@ class QuestionService(
         validateCultureRequirements(request.culture.flatMap { it.requirementIds })
 
         val existing = questionReader.readAll()
-            .filter { it.partId == null && it.category in setOf(QuestionCategory.GLOBAL, QuestionCategory.CULTURE) }
+            .filter {
+                it.partId == null && it.category in setOf(
+                    QuestionCategory.INTRO,
+                    QuestionCategory.OUTRO,
+                    QuestionCategory.CULTURE
+                )
+            }
         val byId = existing.associateBy { it.id }
 
-        val items = request.global.map { it to QuestionCategory.GLOBAL } +
-            request.culture.map { it to QuestionCategory.CULTURE }
+        val items = request.intro.map { it to QuestionCategory.INTRO } +
+                request.outro.map { it to QuestionCategory.OUTRO } +
+                request.culture.map { it to QuestionCategory.CULTURE }
 
         items.forEach { (item, category) ->
             if (item.id != null) {
@@ -67,9 +77,10 @@ class QuestionService(
         val requirements = requirementReader.readAllByIdIn(ids)
         require(
             requirements.size == ids.toSet().size &&
-                requirements.all { it.rubricType == RubricGroupType.CULTURE },
+                    requirements.all { it.rubricType == RubricGroupType.CULTURE },
         ) { "CULTURE 질문에는 CULTURE 요구조건 ID만 사용할 수 있습니다." }
     }
+
     @Transactional
     fun upsertParts(partId: Long, request: UpdatePartQuestionsRequest): List<QuestionDto> {
         partReader.readById(partId)
@@ -95,7 +106,8 @@ class QuestionService(
         val requirementsById = requirementReader.readAllByIdIn(allRequirementIds).associateBy { it.id }
 
         return request.questions.map { item ->
-            val question = Question(item.id, partId, QuestionCategory.PART, item.content, item.sortOrder, item.requirementIds)
+            val question =
+                Question(item.id, partId, QuestionCategory.PART, item.content, item.sortOrder, item.requirementIds)
             val savedQuestion = if (item.id == null) {
                 questionWriter.save(question)
             } else {
@@ -114,7 +126,13 @@ class QuestionService(
         val requirements = requirementReader.readAllByIdIn(ids)
         require(
             requirements.size == ids.toSet().size &&
-                requirements.all { it.rubricType in setOf(RubricGroupType.TEAM, RubricGroupType.JOB, RubricGroupType.OTHER) },
+                    requirements.all {
+                        it.rubricType in setOf(
+                            RubricGroupType.TEAM,
+                            RubricGroupType.JOB,
+                            RubricGroupType.OTHER
+                        )
+                    },
         ) { "파트 질문에는 TEAM, JOB, OTHER 요구조건 ID만 사용할 수 있습니다." }
     }
 

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/interviewQuestion/implement/AssignedQuestionCategory.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/interviewQuestion/implement/AssignedQuestionCategory.kt
@@ -4,7 +4,8 @@ enum class AssignedQuestionCategory(val isCatalog: Boolean) {
     /**
      * Question 카탈로그는 PERSONAL이 생길 수 없으므로 ENUM 분리
      */
-    GLOBAL(true),
+    INTRO(true),
+    OUTRO(true),
     CULTURE(true),
     PART(true),
     PERSONAL(false),

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/interviewQuestion/implement/Question.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/interviewQuestion/implement/Question.kt
@@ -18,7 +18,8 @@ class Question(
                     throw QuestionInvalidException("$category 질문은 최소 1개 이상의 요구조건이 필요합니다.")
                 }
             }
-            QuestionCategory.GLOBAL -> Unit
+            // INTRO / OUTRO 질문은 요구조건이 없음. 개인 인적 정보나 지원 동기 등을 묻는 기본 질문.
+            QuestionCategory.INTRO, QuestionCategory.OUTRO -> Unit
         }
     }
 }

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/interviewQuestion/implement/QuestionCategory.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/interviewQuestion/implement/QuestionCategory.kt
@@ -1,7 +1,8 @@
 package com.yourssu.scouter.recruiting.interviewQuestion.implement
 
 enum class QuestionCategory {
-    GLOBAL,
+    INTRO,
+    OUTRO,
     CULTURE,
     PART,
 }

--- a/src/main/resources/db/migration/V35__move_questionnaire_requirement_mapping_to_question.sql
+++ b/src/main/resources/db/migration/V35__move_questionnaire_requirement_mapping_to_question.sql
@@ -24,7 +24,8 @@ ALTER TABLE question
 UPDATE question
 SET category = CASE category
     WHEN 'CULTURE_FIT' THEN 'CULTURE'
-    ELSE 'GLOBAL'
+    WHEN 'CLOSING' THEN 'OUTRO'
+    ELSE 'INTRO'
 END;
 
 INSERT INTO question (part_id, category, content, sort_order) VALUES
@@ -46,8 +47,8 @@ SET aq.assigned_interviewer_user_id = q.assigned_interviewer_user_id;
 UPDATE assigned_question
 SET category = CASE category
     WHEN 'CULTURE_FIT' THEN 'CULTURE'
-    WHEN 'REQUIRED' THEN 'GLOBAL'
-    WHEN 'CLOSING' THEN 'GLOBAL'
+    WHEN 'REQUIRED' THEN 'INTRO'
+    WHEN 'CLOSING' THEN 'OUTRO'
     WHEN 'TEAM_FIT' THEN 'PERSONAL'
     WHEN 'JOB_FIT' THEN 'PERSONAL'
     ELSE category

--- a/src/main/resources/db/migration/V42__split_global_question_category.sql
+++ b/src/main/resources/db/migration/V42__split_global_question_category.sql
@@ -1,0 +1,14 @@
+UPDATE question
+SET category = CASE
+    WHEN category = 'GLOBAL' AND content = '마지막으로 하고 싶은 말이 있나요?' THEN 'OUTRO'
+    WHEN category = 'GLOBAL' THEN 'INTRO'
+    ELSE category
+END;
+
+UPDATE assigned_question aq
+LEFT JOIN question q ON aq.source_question_id = q.id
+SET aq.category = CASE
+    WHEN aq.category = 'GLOBAL' AND q.category IN ('INTRO', 'OUTRO') THEN q.category
+    WHEN aq.category = 'GLOBAL' THEN 'INTRO'
+    ELSE aq.category
+END;

--- a/src/test/kotlin/com/yourssu/scouter/recruiting/interviewQuestion/business/AssignedQuestionServiceTest.kt
+++ b/src/test/kotlin/com/yourssu/scouter/recruiting/interviewQuestion/business/AssignedQuestionServiceTest.kt
@@ -1,25 +1,17 @@
 package com.yourssu.scouter.recruiting.interviewQuestion.business
 
+import com.yourssu.scouter.auth.authentication.implement.OAuth2Type
+import com.yourssu.scouter.auth.user.implement.TokenInfo
 import com.yourssu.scouter.auth.user.implement.User
 import com.yourssu.scouter.auth.user.implement.UserInfo
 import com.yourssu.scouter.auth.user.implement.UserReader
-import com.yourssu.scouter.auth.user.implement.TokenInfo
-import com.yourssu.scouter.auth.authentication.implement.OAuth2Type
 import com.yourssu.scouter.masterdata.part.implement.fixture.PartFixtureBuilder
 import com.yourssu.scouter.masterdata.semester.implement.fixture.SemesterFixtureBuilder
 import com.yourssu.scouter.recruiting.applicant.implement.ApplicantReader
 import com.yourssu.scouter.recruiting.applicant.implement.fixture.ApplicantFixtureBuilder
 import com.yourssu.scouter.recruiting.interviewQuestion.business.dto.SaveAssignedQuestionCommand
 import com.yourssu.scouter.recruiting.interviewQuestion.business.dto.SaveAssignedQuestionsCommand
-import com.yourssu.scouter.recruiting.interviewQuestion.implement.AssignedQuestion
-import com.yourssu.scouter.recruiting.interviewQuestion.implement.AssignedQuestionCategory
-import com.yourssu.scouter.recruiting.interviewQuestion.implement.AssignedQuestionReader
-import com.yourssu.scouter.recruiting.interviewQuestion.implement.AssignedQuestionValidator
-import com.yourssu.scouter.recruiting.interviewQuestion.implement.AssignedQuestionWriter
-import com.yourssu.scouter.recruiting.interviewQuestion.implement.Question
-import com.yourssu.scouter.recruiting.interviewQuestion.implement.QuestionCategory
-import com.yourssu.scouter.recruiting.interviewQuestion.implement.QuestionReader
-import com.yourssu.scouter.recruiting.interviewQuestion.implement.QuestionWriter
+import com.yourssu.scouter.recruiting.interviewQuestion.implement.*
 import com.yourssu.scouter.recruiting.support.business.EvaluatorDirectory
 import com.yourssu.scouter.recruiting.support.business.EvaluatorInfo
 import com.yourssu.scouter.recruiting.support.business.InterviewRequirementLookup
@@ -28,7 +20,9 @@ import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
 import org.mockito.Mockito.mock
+import org.junit.jupiter.params.provider.EnumSource
 import org.mockito.Mockito.verify
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
@@ -89,19 +83,21 @@ class AssignedQuestionServiceTest {
         whenever(assignedQuestionReader.readAllByApplicantId(applicantId)).thenReturn(emptyList())
         whenever(questionReader.readAll()).thenReturn(
             listOf(
-                Question(1L, null, QuestionCategory.GLOBAL, "자기소개", 1),
-                Question(2L, null, QuestionCategory.CULTURE, "컬쳐1", 1, requirementIds = listOf(1L)),
-                Question(3L, null, QuestionCategory.CULTURE, "컬쳐2", 2, requirementIds = listOf(1L)),
-                Question(4L, null, QuestionCategory.CULTURE, "컬쳐3", 3, requirementIds = listOf(1L)),
-                Question(5L, null, QuestionCategory.CULTURE, "컬쳐4", 4, requirementIds = listOf(1L)),
+                Question(1L, null, QuestionCategory.INTRO, "자기소개", 1),
+                Question(2L, null, QuestionCategory.OUTRO, "계획", 1),
+                Question(3L, null, QuestionCategory.CULTURE, "컬쳐1", 1, requirementIds = listOf(1L)),
+                Question(4L, null, QuestionCategory.CULTURE, "컬쳐2", 2, requirementIds = listOf(1L)),
+                Question(5L, null, QuestionCategory.CULTURE, "컬쳐3", 3, requirementIds = listOf(1L)),
+                Question(6L, null, QuestionCategory.CULTURE, "컬쳐4", 4, requirementIds = listOf(1L)),
                 Question(7L, partId, QuestionCategory.PART, "파트 질문", 1, requirementIds = listOf(901L)),
             ),
         )
 
         val result = assignedQuestionService.readByApplicantId(applicantId)
 
-        assertThat(result.questions).hasSize(6)
-        assertThat(result.questions.count { it.category == AssignedQuestionCategory.GLOBAL }).isEqualTo(1)
+        assertThat(result.questions).hasSize(7)
+        assertThat(result.questions.count { it.category == AssignedQuestionCategory.INTRO }).isEqualTo(1)
+        assertThat(result.questions.count { it.category == AssignedQuestionCategory.OUTRO }).isEqualTo(1)
         assertThat(result.questions.count { it.category == AssignedQuestionCategory.PART }).isEqualTo(1)
         assertThat(result.questions.count { it.category == AssignedQuestionCategory.CULTURE }).isEqualTo(4)
         assertThat(result.questions.filter { it.category == AssignedQuestionCategory.CULTURE })
@@ -120,7 +116,7 @@ class AssignedQuestionServiceTest {
         val interviewerUserId = 100L
         val interviewerEmail = "interviewer@yourssu.com"
         val sourceQuestions = listOf(
-            Question(1L, null, QuestionCategory.GLOBAL, "자기소개", 1),
+            Question(1L, null, QuestionCategory.INTRO, "자기소개", 1),
         )
         val savedQuestions = listOf(
             AssignedQuestion(
@@ -129,7 +125,7 @@ class AssignedQuestionServiceTest {
                 applicantId = applicantId,
                 sourceQuestionId = 1L,
                 content = null,
-                category = AssignedQuestionCategory.GLOBAL,
+                category = AssignedQuestionCategory.INTRO,
                 sortOrder = 0,
             ),
         )
@@ -298,38 +294,60 @@ class AssignedQuestionServiceTest {
             .isInstanceOf(QuestionInvalidException::class.java)
     }
 
-    @Test
-    fun `GLOBAL 질문에 요구조건을 지정하면 예외를 발생시킨다`() {
+    @ParameterizedTest
+    @EnumSource(value = AssignedQuestionCategory::class, names = ["INTRO", "OUTRO"])
+    fun `INTRO, OUTRO 질문에 요구조건을 지정하면 예외를 발생시킨다`(
+        targetCategory: AssignedQuestionCategory
+    ) {
         val interviewerUserId = 100L
+        val targetSourceQuestionId = 1L
+
         val sourceQuestions = listOf(
-            Question(1L, null, QuestionCategory.CULTURE, "컬쳐1", 1, requirementIds = listOf(1L)),
-            Question(2L, null, QuestionCategory.CULTURE, "컬쳐2", 2, requirementIds = listOf(1L)),
-            Question(3L, null, QuestionCategory.GLOBAL, "전역 질문", 1),
+            Question(targetSourceQuestionId, null, QuestionCategory.valueOf(targetCategory.name), "필수 질문", 1),
+            Question(
+                targetSourceQuestionId + 1,
+                null,
+                QuestionCategory.CULTURE,
+                "컬쳐 질문 1",
+                2,
+                requirementIds = listOf(1)
+            ),
+            Question(
+                targetSourceQuestionId + 2,
+                null,
+                QuestionCategory.CULTURE,
+                "컬쳐 질문 2",
+                3,
+                requirementIds = listOf(1)
+            ),
         )
+
         whenever(userReader.readById(interviewerUserId)).thenReturn(mock(User::class.java))
-        whenever(questionReader.readAllByIdIn(listOf(1L, 2L, 3L))).thenReturn(sourceQuestions)
+        whenever(questionReader.readAllByIdIn(any())).thenReturn(sourceQuestions)
 
         val command = SaveAssignedQuestionsCommand(
             questions = listOf(
                 SaveAssignedQuestionCommand(
                     assignedInterviewerUserId = interviewerUserId,
-                    sourceQuestionId = 1L,
+                    sourceQuestionId = targetSourceQuestionId,
                     content = null,
-                    category = AssignedQuestionCategory.CULTURE,
-                    isSelected = true,
+                    category = targetCategory,
+                    requirementIds = listOf(1L),
                 ),
                 SaveAssignedQuestionCommand(
                     assignedInterviewerUserId = interviewerUserId,
-                    sourceQuestionId = 2L,
+                    sourceQuestionId = targetSourceQuestionId + 1,
                     content = null,
-                    category = AssignedQuestionCategory.CULTURE,
                     isSelected = true,
+                    category = AssignedQuestionCategory.CULTURE,
+                    requirementIds = listOf(1L),
                 ),
                 SaveAssignedQuestionCommand(
                     assignedInterviewerUserId = interviewerUserId,
-                    sourceQuestionId = 3L,
+                    sourceQuestionId = targetSourceQuestionId + 2,
                     content = null,
-                    category = AssignedQuestionCategory.GLOBAL,
+                    isSelected = true,
+                    category = AssignedQuestionCategory.CULTURE,
                     requirementIds = listOf(1L),
                 ),
             ),

--- a/src/test/kotlin/com/yourssu/scouter/recruiting/interviewQuestion/business/QuestionServiceTest.kt
+++ b/src/test/kotlin/com/yourssu/scouter/recruiting/interviewQuestion/business/QuestionServiceTest.kt
@@ -1,0 +1,82 @@
+package com.yourssu.scouter.recruiting.interviewQuestion.business
+
+import com.yourssu.scouter.masterdata.part.implement.PartReader
+import com.yourssu.scouter.recruiting.interview.implement.InterviewRequirement
+import com.yourssu.scouter.recruiting.interview.implement.InterviewRequirementReader
+import com.yourssu.scouter.recruiting.interviewQuestion.application.dto.CreateQuestionsRequest
+import com.yourssu.scouter.recruiting.interviewQuestion.implement.Question
+import com.yourssu.scouter.recruiting.interviewQuestion.implement.QuestionCategory
+import com.yourssu.scouter.recruiting.interviewQuestion.implement.QuestionReader
+import com.yourssu.scouter.recruiting.interviewQuestion.implement.QuestionWriter
+import com.yourssu.scouter.recruiting.rubric.implement.RubricGroupType
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.whenever
+
+@Suppress("NonAsciiCharacters")
+class QuestionServiceTest {
+
+    private lateinit var questionReader: QuestionReader
+    private lateinit var questionWriter: QuestionWriter
+    private lateinit var requirementReader: InterviewRequirementReader
+    private lateinit var questionService: QuestionService
+
+    @BeforeEach
+    fun setUp() {
+        questionReader = mock(QuestionReader::class.java)
+        questionWriter = mock(QuestionWriter::class.java)
+        requirementReader = mock(InterviewRequirementReader::class.java)
+
+        questionService = QuestionService(
+            questionReader = questionReader,
+            partReader = mock(PartReader::class.java),
+            questionWriter = questionWriter,
+            requirementReader = requirementReader,
+        )
+    }
+
+    @Test
+    fun `INTRO, OUTRO, CULTURE 질문을 각각의 카테고리로 생성한다`() {
+        whenever(questionReader.readAll()).thenReturn(emptyList())
+        whenever(requirementReader.readAllByIdIn(listOf(1L))).thenReturn(
+            listOf(
+                InterviewRequirement(
+                    id = 1L,
+                    partId = null,
+                    semesterId = 1L,
+                    rubricType = RubricGroupType.CULTURE,
+                    content = "컬쳐 요구조건",
+                ),
+            ),
+        )
+        whenever(questionWriter.save(any())).thenReturn(
+            Question(1L, null, QuestionCategory.INTRO, "자기소개", 1),
+            Question(2L, null, QuestionCategory.OUTRO, "마지막 한마디", 1),
+            Question(3L, null, QuestionCategory.CULTURE, "컬쳐 질문", 1, listOf(1L)),
+        )
+
+        questionService.upsert(
+            CreateQuestionsRequest(
+                intro = listOf(CreateQuestionsRequest.Item(content = "자기소개", sortOrder = 1)),
+                outro = listOf(CreateQuestionsRequest.Item(content = "마지막 한마디", sortOrder = 1)),
+                culture = listOf(
+                    CreateQuestionsRequest.Item(
+                        content = "컬쳐 질문",
+                        sortOrder = 1,
+                        requirementIds = listOf(1L),
+                    ),
+                ),
+            ),
+        )
+
+        val captor = argumentCaptor<Question>()
+        org.mockito.kotlin.verify(questionWriter, org.mockito.kotlin.times(3)).save(captor.capture())
+
+        assertThat(captor.allValues.map { it.category })
+            .containsExactly(QuestionCategory.INTRO, QuestionCategory.OUTRO, QuestionCategory.CULTURE)
+    }
+}

--- a/src/test/kotlin/com/yourssu/scouter/recruiting/interviewQuestion/implement/AssignedQuestionTest.kt
+++ b/src/test/kotlin/com/yourssu/scouter/recruiting/interviewQuestion/implement/AssignedQuestionTest.kt
@@ -3,6 +3,8 @@ package com.yourssu.scouter.recruiting.interviewQuestion.implement
 import com.yourssu.scouter.recruiting.support.implement.exception.AssignedQuestionInvalidException
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
 
 @Suppress("NonAsciiCharacters")
 class AssignedQuestionTest {
@@ -21,15 +23,16 @@ class AssignedQuestionTest {
         }.isInstanceOf(AssignedQuestionInvalidException::class.java)
     }
 
-    @Test
-    fun `전역 질문은 content를 직접 가질 수 없다`() {
+    @ParameterizedTest
+    @EnumSource(value = AssignedQuestionCategory::class, names = ["INTRO", "OUTRO"])
+    fun `전역 질문은 content를 직접 가질 수 없다`(questionCategory: AssignedQuestionCategory) {
         assertThatThrownBy {
             AssignedQuestion(
                 assignedInterviewerUserId = 1L,
                 applicantId = 1L,
                 sourceQuestionId = 1L,
                 content = "직접 수정한 질문",
-                category = AssignedQuestionCategory.GLOBAL,
+                category = questionCategory,
                 sortOrder = 0,
             )
         }.isInstanceOf(AssignedQuestionInvalidException::class.java)

--- a/src/test/kotlin/com/yourssu/scouter/recruiting/interviewQuestion/implement/AssignedQuestionValidatorTest.kt
+++ b/src/test/kotlin/com/yourssu/scouter/recruiting/interviewQuestion/implement/AssignedQuestionValidatorTest.kt
@@ -47,7 +47,7 @@ class AssignedQuestionValidatorTest {
             catalogQuestion(2L, AssignedQuestionCategory.CULTURE, isSelected = true),
         )
         val sourceQuestionsById = mapOf<Long?, Question>(
-            1L to Question(1L, null, QuestionCategory.GLOBAL, "질문1", 1),
+            1L to Question(1L, null, QuestionCategory.INTRO, "질문1", 1),
             2L to Question(2L, null, QuestionCategory.CULTURE, "질문2", 2, requirementIds = listOf(1L)),
         )
 

--- a/src/test/kotlin/com/yourssu/scouter/recruiting/interviewQuestion/implement/QuestionTest.kt
+++ b/src/test/kotlin/com/yourssu/scouter/recruiting/interviewQuestion/implement/QuestionTest.kt
@@ -4,6 +4,8 @@ import com.yourssu.scouter.recruiting.support.implement.exception.QuestionInvali
 import org.assertj.core.api.Assertions.assertThatCode
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
 
 @Suppress("NonAsciiCharacters")
 class QuestionTest {
@@ -35,12 +37,13 @@ class QuestionTest {
         }.isInstanceOf(QuestionInvalidException::class.java)
     }
 
-    @Test
-    fun `GLOBAL 질문은 요구조건이 없어도 된다`() {
+    @ParameterizedTest
+    @EnumSource(value = QuestionCategory::class, names = ["INTRO", "OUTRO"])
+    fun `필수 질문은 요구조건이 없어도 된다`(questionCategory: QuestionCategory) {
         assertThatCode {
             Question(
                 id = 1L,
-                category = QuestionCategory.GLOBAL,
+                category = questionCategory,
                 content = "전역 질문",
                 sortOrder = 0,
                 requirementIds = emptyList(),


### PR DESCRIPTION
## 📄 작업 내용 요약
면접 질문 카테고리 중 GLOBAL 카테고리를
INTRO, OUTRO로 분리한다.

## 📎 Issue 번호
<!-- closed #번호 -->
closed #392 