### PR TITLE
[#406]; Question 에 semester 필터 추가

### DIFF
--- a/src/main/kotlin/com/yourssu/scouter/admin/AdminQuestionController.kt
+++ b/src/main/kotlin/com/yourssu/scouter/admin/AdminQuestionController.kt
@@ -1,6 +1,7 @@
 package com.yourssu.scouter.admin
 
 import com.yourssu.scouter.masterdata.semester.implement.Semester
+import com.yourssu.scouter.masterdata.semester.implement.SemesterReader
 import com.yourssu.scouter.masterdata.support.converter.SemesterConverter
 import com.yourssu.scouter.recruiting.interview.business.InterviewRequirementService
 import com.yourssu.scouter.recruiting.interviewQuestion.application.dto.CreateQuestionsRequest
@@ -24,6 +25,7 @@ import java.time.LocalDate
 class AdminQuestionController(
     private val questionService: QuestionService,
     private val questionReader: QuestionReader,
+    private val semesterReader: SemesterReader,
     private val interviewRequirementService: InterviewRequirementService,
     private val requirementReader: InterviewRequirementReader,
 ) {
@@ -46,12 +48,20 @@ class AdminQuestionController(
         val cultureRequirements = requirementDto?.culture ?: emptyList()
         model.addAttribute("cultureRequirements", cultureRequirements)
 
-        // 2. Fetch all global questions
+        // 2. Fetch global questions
+        // INTRO / OUTRO: 학기에 무관
         val allQuestions = questionReader.readAll().filter { it.partId == null }
-        
         val introQuestions = allQuestions.filter { it.category == QuestionCategory.INTRO }
         val outroQuestions = allQuestions.filter { it.category == QuestionCategory.OUTRO }
-        val cultureQuestions = allQuestions.filter { it.category == QuestionCategory.CULTURE }
+
+        // CULTURE: 해당 학기에 귀속된 질문만 조회
+        val resolvedSemesterObj = runCatching { semesterReader.readByString(resolvedSemester) }.getOrNull()
+        val cultureQuestions = if (resolvedSemesterObj?.id != null) {
+            questionReader.readAllBySemesterId(resolvedSemesterObj.id!!)
+                .filter { it.partId == null && it.category == QuestionCategory.CULTURE }
+        } else {
+            allQuestions.filter { it.category == QuestionCategory.CULTURE }
+        }
 
         model.addAttribute("introQuestions", introQuestions)
         model.addAttribute("outroQuestions", outroQuestions)
@@ -63,13 +73,15 @@ class AdminQuestionController(
     @PostMapping
     @ResponseBody
     fun saveGlobalQuestions(
+        @RequestParam semester: String,
         @RequestBody request: CreateQuestionsRequest,
     ): ResponseEntity<Map<String, Any?>> {
         return runCatching {
-            questionService.upsert(request)
+            questionService.upsert(semester, request)
         }.fold(
             onSuccess = { ResponseEntity.ok(mapOf("success" to true)) },
             onFailure = { ResponseEntity.badRequest().body(mapOf("error" to it.message)) }
         )
     }
 }
+

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/interviewQuestion/application/QuestionController.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/interviewQuestion/application/QuestionController.kt
@@ -12,20 +12,41 @@ import org.springframework.web.bind.annotation.*
 
 @Tag(name = "면접 질문")
 @RestController
-class QuestionController(private val questionService: QuestionService) {
-    @Operation(summary = "파트별 면접 공통 질문 전체 수정", description = "id가 있으면 수정하고 없으면 생성하며, 누락된 기존 질문은 삭제합니다.")
-    @PutMapping("/parts/{partId}/interviews/questions")
-    fun upsertParts(@PathVariable partId: Long, @RequestBody @Valid request: UpdatePartQuestionsRequest)
-            : ResponseEntity<List<ReadQuestionResponse>> =
-        ResponseEntity.ok(questionService.upsertParts(partId, request).map(ReadQuestionResponse::from))
+class QuestionController(
+    private val questionService: QuestionService,
+) {
 
-    @Operation(summary = "전역·문화 면접 질문 수정/생성", description = "INTRO, OUTRO 및 CULTURE 질문을 생성합니다.")
-    @PutMapping("/interviews/questions")
-    fun upsertGlobalAndCulture(@RequestBody @Valid request: CreateQuestionsRequest): ResponseEntity<List<ReadQuestionResponse>> =
-        ResponseEntity.ok(questionService.upsert(request).map(ReadQuestionResponse::from))
+    @Operation(
+        summary = "파트별 면접 공통 질문 전체 수정",
+        description = "id가 있으면 수정하고 없으면 생성하며, 누락된 기존 질문은 삭제합니다. 학기는 '2026-1' 형식으로 전달합니다.",
+    )
+    @PutMapping("/semesters/{semester}/parts/{partId}/interviews/questions")
+    fun upsertParts(
+        @PathVariable semester: String,
+        @PathVariable partId: Long,
+        @RequestBody @Valid request: UpdatePartQuestionsRequest,
+    ): ResponseEntity<List<ReadQuestionResponse>> =
+        ResponseEntity.ok(questionService.upsertParts(partId, semester, request).map(ReadQuestionResponse::from))
 
-    @Operation(summary = "파트별 면접 질문 및 요구조건 조회", description = "INTRO, OUTRO, CULTURE, PART 질문과 매핑된 요구조건을 조회합니다.")
-    @GetMapping("/parts/{partId}/interviews/questions")
-    fun readAll(@PathVariable partId: Long): ResponseEntity<List<ReadQuestionResponse>> =
-        ResponseEntity.ok(questionService.readAll(partId).map(ReadQuestionResponse::from))
+    @Operation(
+        summary = "전역·문화 면접 질문 수정/생성",
+        description = "INTRO, OUTRO 및 CULTURE 질문을 생성합니다. CULTURE 질문은 지정된 학기에 귀속되고, INTRO/OUTRO는 학기에 무관하게 공유됩니다. 학기는 '2026-1' 형식으로 전달합니다.",
+    )
+    @PutMapping("/semesters/{semester}/interviews/questions")
+    fun upsertGlobalAndCulture(
+        @PathVariable semester: String,
+        @RequestBody @Valid request: CreateQuestionsRequest,
+    ): ResponseEntity<List<ReadQuestionResponse>> =
+        ResponseEntity.ok(questionService.upsert(semester, request).map(ReadQuestionResponse::from))
+
+    @Operation(
+        summary = "파트별 면접 질문 및 요구조건 조회",
+        description = "INTRO, OUTRO, CULTURE, PART 질문과 매핑된 요구조건을 조회합니다. CULTURE/PART 는 지정된 학기 기준으로 필터링됩니다. 학기는 '2026-1' 형식으로 전달합니다.",
+    )
+    @GetMapping("/semesters/{semester}/parts/{partId}/interviews/questions")
+    fun readAll(
+        @PathVariable semester: String,
+        @PathVariable partId: Long,
+    ): ResponseEntity<List<ReadQuestionResponse>> =
+        ResponseEntity.ok(questionService.readAll(partId, semester).map(ReadQuestionResponse::from))
 }

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/interviewQuestion/business/AssignedQuestionService.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/interviewQuestion/business/AssignedQuestionService.kt
@@ -40,12 +40,13 @@ class AssignedQuestionService(
     fun readByApplicantId(applicantId: Long): AssignedQuestionsDto {
         val applicant = applicantReader.readById(applicantId)
         val applicantPartId = applicant.part.id!!
+        val applicantSemesterId = applicant.applicationSemester.id!!
         val requirementsById = readRequirementsById(applicant)
 
         val questions = assignedQuestionReader.readAllByApplicantId(applicantId)
         if (questions.isEmpty()) {
             return AssignedQuestionsDto(
-                questions = readDefaultQuestions(applicantPartId, requirementsById),
+                questions = readDefaultQuestions(applicantPartId, applicantSemesterId, requirementsById),
             )
         }
 
@@ -122,6 +123,7 @@ class AssignedQuestionService(
                         val updatedQuestion = Question(
                             id = sourceQuestion.id,
                             partId = sourceQuestion.partId,
+                            semesterId = sourceQuestion.semesterId,
                             category = sourceQuestion.category,
                             content = question.content ?: sourceQuestion.content,
                             sortOrder = sourceQuestion.sortOrder,
@@ -178,10 +180,19 @@ class AssignedQuestionService(
 
     private fun readDefaultQuestions(
         applicantPartId: Long,
+        applicantSemesterId: Long,
         requirementsById: Map<Long?, InterviewRequirementProfile>,
     ): List<AssignedQuestionDto> {
-        val catalogQuestions = questionReader.readAll()
-            .filter { it.partId == null || it.partId == applicantPartId }
+        // INTRO / OUTRO : 학기에 무관하게 전체 공유
+        val introOutroQuestions = questionReader.readAll()
+            .filter { it.partId == null && it.category in setOf(QuestionCategory.INTRO, QuestionCategory.OUTRO) }
+
+        // CULTURE / PART : 지원자의 학기에 귀속된 질문만 조회
+        val cultureQuestions = questionReader.readAllBySemesterId(applicantSemesterId)
+            .filter { it.partId == null && it.category == QuestionCategory.CULTURE }
+        val partQuestions = questionReader.readAllByPartIdAndSemesterId(applicantPartId, applicantSemesterId)
+
+        val catalogQuestions = introOutroQuestions + cultureQuestions + partQuestions
 
         return catalogQuestions
             .mapIndexed { index, question ->

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/interviewQuestion/business/QuestionService.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/interviewQuestion/business/QuestionService.kt
@@ -1,6 +1,7 @@
 package com.yourssu.scouter.recruiting.interviewQuestion.business
 
 import com.yourssu.scouter.masterdata.part.implement.PartReader
+import com.yourssu.scouter.masterdata.semester.implement.SemesterReader
 import com.yourssu.scouter.recruiting.interviewQuestion.business.dto.QuestionDto
 import com.yourssu.scouter.recruiting.interviewQuestion.business.dto.QuestionRequirementDto
 import com.yourssu.scouter.recruiting.interviewQuestion.implement.QuestionReader
@@ -19,12 +20,20 @@ import org.springframework.stereotype.Service
 class QuestionService(
     private val questionReader: QuestionReader,
     private val partReader: PartReader,
+    private val semesterReader: SemesterReader,
     private val questionWriter: QuestionWriter,
     private val requirementReader: InterviewRequirementReader,
 ) {
 
+    /**
+     * INTRO / OUTRO / CULTURE 질문을 생성·수정합니다.
+     * CULTURE 질문은 [semester] 학기에 귀속됩니다. (예: "2026-1")
+     * INTRO / OUTRO 는 학기에 무관하게 공유되므로 semesterId=null 로 저장됩니다.
+     */
     @Transactional
-    fun upsert(request: CreateQuestionsRequest): List<QuestionDto> {
+    fun upsert(semester: String, request: CreateQuestionsRequest): List<QuestionDto> {
+        val semesterId = semesterReader.readByString(semester).id!!
+
         require(
             request.intro.mapNotNull { it.id }.size == request.intro.mapNotNull { it.id }.toSet().size,
         ) { "INTRO 질문 ID가 중복되었습니다." }
@@ -37,19 +46,25 @@ class QuestionService(
 
         validateCultureRequirements(request.culture.flatMap { it.requirementIds })
 
-        val existing = questionReader.readAll()
+        // INTRO / OUTRO : semester 무관 (semesterId = null)
+        // CULTURE       : 해당 semester 에 귀속된 질문만 대상으로 upsert
+        val existingIntroOutro = questionReader.readAll()
             .filter {
                 it.partId == null && it.category in setOf(
                     QuestionCategory.INTRO,
                     QuestionCategory.OUTRO,
-                    QuestionCategory.CULTURE
                 )
             }
+        val existingCulture = questionReader.readAllBySemesterId(semesterId)
+            .filter { it.partId == null && it.category == QuestionCategory.CULTURE }
+
+        val existing = existingIntroOutro + existingCulture
         val byId = existing.associateBy { it.id }
 
-        val items = request.intro.map { it to QuestionCategory.INTRO } +
-                request.outro.map { it to QuestionCategory.OUTRO } +
-                request.culture.map { it to QuestionCategory.CULTURE }
+        val introItems = request.intro.map { it to QuestionCategory.INTRO }
+        val outroItems = request.outro.map { it to QuestionCategory.OUTRO }
+        val cultureItems = request.culture.map { it to QuestionCategory.CULTURE }
+        val items = introItems + outroItems + cultureItems
 
         items.forEach { (item, category) ->
             if (item.id != null) {
@@ -63,7 +78,9 @@ class QuestionService(
         questionWriter.deleteAllByIdIn(existing.mapNotNull { it.id }.filterNot { it in retained })
 
         return items.map { (item, category) ->
-            val question = Question(item.id, null, category, item.content, item.sortOrder, item.requirementIds)
+            // CULTURE는 semesterId 할당, INTRO/OUTRO는 null
+            val effectiveSemesterId = if (category == QuestionCategory.CULTURE) semesterId else null
+            val question = Question(item.id, null, effectiveSemesterId, category, item.content, item.sortOrder, item.requirementIds)
             if (item.id == null) {
                 QuestionDto.from(questionWriter.save(question))
             } else {
@@ -81,15 +98,19 @@ class QuestionService(
         ) { "CULTURE 질문에는 CULTURE 요구조건 ID만 사용할 수 있습니다." }
     }
 
+    /**
+     * 특정 파트의 공통 질문을 생성·수정합니다.
+     * PART 질문은 [semester] 학기에 귀속됩니다. (예: "2026-1")
+     */
     @Transactional
-    fun upsertParts(partId: Long, request: UpdatePartQuestionsRequest): List<QuestionDto> {
+    fun upsertParts(partId: Long, semester: String, request: UpdatePartQuestionsRequest): List<QuestionDto> {
         partReader.readById(partId)
+        val semesterId = semesterReader.readByString(semester).id!!
         require(
             request.questions.mapNotNull { it.id }.size == request.questions.mapNotNull { it.id }.toSet().size,
         ) { "질문 ID가 중복되었습니다." }
 
-        val existing = questionReader.readAll()
-            .filter { it.partId == partId && it.category == QuestionCategory.PART }
+        val existing = questionReader.readAllByPartIdAndSemesterId(partId, semesterId)
         val existingById = existing.associateBy { it.id }
 
         request.questions.forEach { item ->
@@ -107,7 +128,7 @@ class QuestionService(
 
         return request.questions.map { item ->
             val question =
-                Question(item.id, partId, QuestionCategory.PART, item.content, item.sortOrder, item.requirementIds)
+                Question(item.id, partId, semesterId, QuestionCategory.PART, item.content, item.sortOrder, item.requirementIds)
             val savedQuestion = if (item.id == null) {
                 questionWriter.save(question)
             } else {
@@ -136,10 +157,23 @@ class QuestionService(
         ) { "파트 질문에는 TEAM, JOB, OTHER 요구조건 ID만 사용할 수 있습니다." }
     }
 
-    fun readAll(partId: Long): List<QuestionDto> {
+    /**
+     * 특정 파트 + 학기의 질문 목록을 조회합니다.
+     * INTRO / OUTRO 는 학기에 무관하게 공유되므로 전체 목록에서 조회합니다.
+     * CULTURE / PART 는 [semester] 학기에 귀속된 질문만 반환합니다. (예: "2026-1")
+     */
+    fun readAll(partId: Long, semester: String): List<QuestionDto> {
         partReader.readById(partId)
-        val questions = questionReader.readAll()
-            .filter { it.partId == null || it.partId == partId }
+        val semesterId = semesterReader.readByString(semester).id!!
+
+        val introOutroQuestions = questionReader.readAll()
+            .filter { it.partId == null && it.category in setOf(QuestionCategory.INTRO, QuestionCategory.OUTRO) }
+        val cultureQuestions = questionReader.readAllBySemesterId(semesterId)
+            .filter { it.partId == null && it.category == QuestionCategory.CULTURE }
+        val partQuestions = questionReader.readAllByPartIdAndSemesterId(partId, semesterId)
+
+        val questions = introOutroQuestions + cultureQuestions + partQuestions
+
         val requirements = requirementReader.readAllByIdIn(questions.flatMap { it.requirementIds }.distinct())
             .associateBy { it.id }
         return questions.map { question ->
@@ -152,3 +186,4 @@ class QuestionService(
         }
     }
 }
+

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/interviewQuestion/implement/Question.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/interviewQuestion/implement/Question.kt
@@ -5,6 +5,8 @@ import com.yourssu.scouter.recruiting.support.implement.exception.QuestionInvali
 class Question(
     val id: Long? = null,
     val partId: Long? = null,
+    /** CULTURE / PART 질문은 학기별로 관리됩니다. INTRO / OUTRO 는 null 입니다. */
+    val semesterId: Long? = null,
     val category: QuestionCategory,
     val content: String,
     val sortOrder: Int,
@@ -23,3 +25,4 @@ class Question(
         }
     }
 }
+

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/interviewQuestion/implement/QuestionReader.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/interviewQuestion/implement/QuestionReader.kt
@@ -16,4 +16,17 @@ class QuestionReader(
     fun readAllByIdIn(ids: Collection<Long>): List<Question> {
         return questionRepository.findAllByIdIn(ids)
     }
+
+    /** CULTURE/PART 질문을 학기 ID 기준으로 조회합니다. INTRO/OUTRO(semesterId=null)는 포함되지 않습니다. */
+    fun readAllBySemesterId(semesterId: Long): List<Question> {
+        return questionRepository.findAllBySemesterId(semesterId)
+            .sortedWith(compareBy({ it.category }, { it.partId ?: 0L }, { it.sortOrder }))
+    }
+
+    /** 특정 파트 + 학기의 PART 질문만 조회합니다. */
+    fun readAllByPartIdAndSemesterId(partId: Long, semesterId: Long): List<Question> {
+        return questionRepository.findAllByPartIdAndSemesterId(partId, semesterId)
+            .sortedBy { it.sortOrder }
+    }
 }
+

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/interviewQuestion/implement/QuestionRepository.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/interviewQuestion/implement/QuestionRepository.kt
@@ -6,9 +6,16 @@ interface QuestionRepository {
 
     fun findAllByIdIn(ids: Collection<Long>): List<Question>
 
+    /** CULTURE/PART 질문을 학기 ID 기준으로 조회합니다. */
+    fun findAllBySemesterId(semesterId: Long): List<Question>
+
+    /** partId 와 semesterId 를 모두 만족하는 PART 질문을 조회합니다. */
+    fun findAllByPartIdAndSemesterId(partId: Long, semesterId: Long): List<Question>
+
     fun update(question: Question)
 
     fun save(question: Question): Question
 
     fun deleteAllByIdIn(ids: Collection<Long>)
 }
+

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/interviewQuestion/storage/JpaQuestionRepository.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/interviewQuestion/storage/JpaQuestionRepository.kt
@@ -5,4 +5,9 @@ import org.springframework.data.jpa.repository.JpaRepository
 interface JpaQuestionRepository : JpaRepository<QuestionEntity, Long> {
 
     fun findAllByIdIn(ids: Collection<Long>): List<QuestionEntity>
+
+    fun findAllBySemesterId(semesterId: Long): List<QuestionEntity>
+
+    fun findAllByPartIdAndSemesterId(partId: Long, semesterId: Long): List<QuestionEntity>
 }
+

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/interviewQuestion/storage/QuestionEntity.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/interviewQuestion/storage/QuestionEntity.kt
@@ -22,6 +22,10 @@ class QuestionEntity(
     @Column(name = "part_id")
     val partId: Long? = null,
 
+    /** CULTURE / PART 질문은 학기별로 관리됩니다. INTRO / OUTRO 는 학기에 무관하게 공유됩니다. */
+    @Column(name = "semester_id")
+    val semesterId: Long? = null,
+
     @Column(nullable = false)
     @Enumerated(EnumType.STRING)
     val category: QuestionCategory,
@@ -36,6 +40,7 @@ class QuestionEntity(
     fun toDomain(requirementIds: List<Long> = emptyList()): Question = Question(
         id = id,
         partId = partId,
+        semesterId = semesterId,
         category = category,
         content = content,
         sortOrder = sortOrder,

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/interviewQuestion/storage/QuestionRepositoryImpl.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/interviewQuestion/storage/QuestionRepositoryImpl.kt
@@ -24,6 +24,20 @@ class QuestionRepositoryImpl(
         return entities.map { it.toDomain(requirementIdsByQuestionId[it.id].orEmpty()) }
     }
 
+    override fun findAllBySemesterId(semesterId: Long): List<Question> {
+        val entities = jpaQuestionRepository.findAllBySemesterId(semesterId)
+        val requirementIdsByQuestionId = readRequirementIdsByQuestionId(entities.mapNotNull { it.id })
+
+        return entities.map { it.toDomain(requirementIdsByQuestionId[it.id].orEmpty()) }
+    }
+
+    override fun findAllByPartIdAndSemesterId(partId: Long, semesterId: Long): List<Question> {
+        val entities = jpaQuestionRepository.findAllByPartIdAndSemesterId(partId, semesterId)
+        val requirementIdsByQuestionId = readRequirementIdsByQuestionId(entities.mapNotNull { it.id })
+
+        return entities.map { it.toDomain(requirementIdsByQuestionId[it.id].orEmpty()) }
+    }
+
     override fun update(question: Question) {
         val questionId = question.id!!
 
@@ -31,6 +45,7 @@ class QuestionRepositoryImpl(
             QuestionEntity(
                 id = questionId,
                 partId = question.partId,
+                semesterId = question.semesterId,
                 category = question.category,
                 content = question.content,
                 sortOrder = question.sortOrder,
@@ -47,6 +62,7 @@ class QuestionRepositoryImpl(
         val saved = jpaQuestionRepository.save(
             QuestionEntity(
                 partId = question.partId,
+                semesterId = question.semesterId,
                 category = question.category,
                 content = question.content,
                 sortOrder = question.sortOrder,
@@ -75,3 +91,4 @@ class QuestionRepositoryImpl(
             .mapValues { (_, mappings) -> mappings.map { it.partInterviewRequirementId } }
     }
 }
+

--- a/src/main/resources/db/migration/V43__add_semester_id_to_question.sql
+++ b/src/main/resources/db/migration/V43__add_semester_id_to_question.sql
@@ -1,0 +1,8 @@
+﻿-- question 테이블에 semester_id 컬럼 추가
+-- CULTURE / PART 질문은 학기별로 관리됩니다.
+-- INTRO / OUTRO 질문은 학기에 무관하게 공유되므로 NULL 허용입니다.
+ALTER TABLE question
+    ADD COLUMN semester_id BIGINT NULL,
+    ADD CONSTRAINT fk_question_semester
+        FOREIGN KEY (semester_id)
+            REFERENCES semester (id) ON DELETE SET NULL;

--- a/src/main/resources/templates/admin/requirements/global-questions.html
+++ b/src/main/resources/templates/admin/requirements/global-questions.html
@@ -385,6 +385,7 @@
 <!-- 템플릿용 요구조건 목록 (JSON) -->
 <script th:inline="javascript">
     const CULTURE_REQUIREMENTS = /*[[${cultureRequirements}]]*/ [];
+    const CURRENT_SEMESTER = /*[[${semester}]]*/ '';
 </script>
 
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
@@ -511,7 +512,7 @@
         const payload = { intro, culture, outro };
 
         try {
-            const res = await fetch('/admin/recruiting/questions/global', {
+            const res = await fetch(`/admin/recruiting/questions/global?semester=${encodeURIComponent(CURRENT_SEMESTER)}`, {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify(payload),

--- a/src/test/kotlin/com/yourssu/scouter/recruiting/interviewQuestion/business/AssignedQuestionServiceTest.kt
+++ b/src/test/kotlin/com/yourssu/scouter/recruiting/interviewQuestion/business/AssignedQuestionServiceTest.kt
@@ -80,16 +80,28 @@ class AssignedQuestionServiceTest {
 
     @Test
     fun `저장된 질문이 없으면 고정 질문과 파트 질문과 컬쳐 질문 옵션 4개를 반환한다`() {
+        val semesterId = 1L
         whenever(assignedQuestionReader.readAllByApplicantId(applicantId)).thenReturn(emptyList())
+        // INTRO/OUTRO: readAll()에서 반환
         whenever(questionReader.readAll()).thenReturn(
             listOf(
-                Question(1L, null, QuestionCategory.INTRO, "자기소개", 1),
-                Question(2L, null, QuestionCategory.OUTRO, "계획", 1),
-                Question(3L, null, QuestionCategory.CULTURE, "컬쳐1", 1, requirementIds = listOf(1L)),
-                Question(4L, null, QuestionCategory.CULTURE, "컬쳐2", 2, requirementIds = listOf(1L)),
-                Question(5L, null, QuestionCategory.CULTURE, "컬쳐3", 3, requirementIds = listOf(1L)),
-                Question(6L, null, QuestionCategory.CULTURE, "컬쳐4", 4, requirementIds = listOf(1L)),
-                Question(7L, partId, QuestionCategory.PART, "파트 질문", 1, requirementIds = listOf(901L)),
+                Question(1L, null, null, QuestionCategory.INTRO, "자기소개", 1),
+                Question(2L, null, null, QuestionCategory.OUTRO, "계획", 1),
+            ),
+        )
+        // CULTURE: readAllBySemesterId()에서 반환
+        whenever(questionReader.readAllBySemesterId(semesterId)).thenReturn(
+            listOf(
+                Question(3L, null, semesterId, QuestionCategory.CULTURE, "컬쳐1", 1, requirementIds = listOf(1L)),
+                Question(4L, null, semesterId, QuestionCategory.CULTURE, "컬쳐2", 2, requirementIds = listOf(1L)),
+                Question(5L, null, semesterId, QuestionCategory.CULTURE, "컬쳐3", 3, requirementIds = listOf(1L)),
+                Question(6L, null, semesterId, QuestionCategory.CULTURE, "컬쳐4", 4, requirementIds = listOf(1L)),
+            ),
+        )
+        // PART: readAllByPartIdAndSemesterId()에서 반환
+        whenever(questionReader.readAllByPartIdAndSemesterId(partId, semesterId)).thenReturn(
+            listOf(
+                Question(7L, partId, semesterId, QuestionCategory.PART, "파트 질문", 1, requirementIds = listOf(901L)),
             ),
         )
 
@@ -116,7 +128,7 @@ class AssignedQuestionServiceTest {
         val interviewerUserId = 100L
         val interviewerEmail = "interviewer@yourssu.com"
         val sourceQuestions = listOf(
-            Question(1L, null, QuestionCategory.INTRO, "자기소개", 1),
+            Question(1L, null, null, QuestionCategory.INTRO, "자기소개", 1),
         )
         val savedQuestions = listOf(
             AssignedQuestion(
@@ -148,10 +160,10 @@ class AssignedQuestionServiceTest {
     fun `저장한 컬쳐 질문 4개는 선택 여부와 함께 모두 반환한다`() {
         val interviewerUserId = 100L
         val sourceQuestions = listOf(
-            Question(1L, null, QuestionCategory.CULTURE, "컬쳐1", 1, requirementIds = listOf(1L)),
-            Question(2L, null, QuestionCategory.CULTURE, "컬쳐2", 2, requirementIds = listOf(1L)),
-            Question(3L, null, QuestionCategory.CULTURE, "컬쳐3", 3, requirementIds = listOf(1L)),
-            Question(4L, null, QuestionCategory.CULTURE, "컬쳐4", 4, requirementIds = listOf(1L)),
+            Question(1L, null, null, QuestionCategory.CULTURE, "컬쳐1", 1, requirementIds = listOf(1L)),
+            Question(2L, null, null, QuestionCategory.CULTURE, "컬쳐2", 2, requirementIds = listOf(1L)),
+            Question(3L, null, null, QuestionCategory.CULTURE, "컬쳐3", 3, requirementIds = listOf(1L)),
+            Question(4L, null, null, QuestionCategory.CULTURE, "컬쳐4", 4, requirementIds = listOf(1L)),
         )
         whenever(userReader.readById(interviewerUserId)).thenReturn(mock(User::class.java))
         whenever(questionReader.readAllByIdIn(listOf(1L, 2L, 3L, 4L))).thenReturn(sourceQuestions)
@@ -194,9 +206,9 @@ class AssignedQuestionServiceTest {
     fun `파트 질문의 content 변경은 인스턴스가 아닌 카탈로그에 반영된다`() {
         val interviewerUserId = 100L
         val sourceQuestions = listOf(
-            Question(1L, null, QuestionCategory.CULTURE, "컬쳐1", 1, requirementIds = listOf(1L)),
-            Question(2L, null, QuestionCategory.CULTURE, "컬쳐2", 2, requirementIds = listOf(1L)),
-            Question(7L, partId, QuestionCategory.PART, "카탈로그 파트 질문", 1, requirementIds = listOf(401L)),
+            Question(1L, null, null, QuestionCategory.CULTURE, "컬쳐1", 1, requirementIds = listOf(1L)),
+            Question(2L, null, null, QuestionCategory.CULTURE, "컬쳐2", 2, requirementIds = listOf(1L)),
+            Question(7L, partId, null, QuestionCategory.PART, "카탈로그 파트 질문", 1, requirementIds = listOf(401L)),
         )
         whenever(userReader.readById(interviewerUserId)).thenReturn(mock(User::class.java))
         whenever(questionReader.readAllByIdIn(listOf(1L, 2L, 7L))).thenReturn(sourceQuestions)
@@ -257,9 +269,9 @@ class AssignedQuestionServiceTest {
     fun `PART 질문에 요구조건이 없으면 예외를 발생시킨다`() {
         val interviewerUserId = 100L
         val sourceQuestions = listOf(
-            Question(1L, null, QuestionCategory.CULTURE, "컬쳐1", 1, requirementIds = listOf(1L)),
-            Question(2L, null, QuestionCategory.CULTURE, "컬쳐2", 2, requirementIds = listOf(1L)),
-            Question(7L, partId, QuestionCategory.PART, "카탈로그 파트 질문", 1, requirementIds = listOf(401L)),
+            Question(1L, null, null, QuestionCategory.CULTURE, "컬쳐1", 1, requirementIds = listOf(1L)),
+            Question(2L, null, null, QuestionCategory.CULTURE, "컬쳐2", 2, requirementIds = listOf(1L)),
+            Question(7L, partId, null, QuestionCategory.PART, "카탈로그 파트 질문", 1, requirementIds = listOf(401L)),
         )
         whenever(userReader.readById(interviewerUserId)).thenReturn(mock(User::class.java))
         whenever(questionReader.readAllByIdIn(listOf(1L, 2L, 7L))).thenReturn(sourceQuestions)
@@ -303,9 +315,10 @@ class AssignedQuestionServiceTest {
         val targetSourceQuestionId = 1L
 
         val sourceQuestions = listOf(
-            Question(targetSourceQuestionId, null, QuestionCategory.valueOf(targetCategory.name), "필수 질문", 1),
+            Question(targetSourceQuestionId, null, null, QuestionCategory.valueOf(targetCategory.name), "필수 질문", 1),
             Question(
                 targetSourceQuestionId + 1,
+                null,
                 null,
                 QuestionCategory.CULTURE,
                 "컬쳐 질문 1",
@@ -314,6 +327,7 @@ class AssignedQuestionServiceTest {
             ),
             Question(
                 targetSourceQuestionId + 2,
+                null,
                 null,
                 QuestionCategory.CULTURE,
                 "컬쳐 질문 2",

--- a/src/test/kotlin/com/yourssu/scouter/recruiting/interviewQuestion/business/QuestionServiceTest.kt
+++ b/src/test/kotlin/com/yourssu/scouter/recruiting/interviewQuestion/business/QuestionServiceTest.kt
@@ -1,6 +1,8 @@
 package com.yourssu.scouter.recruiting.interviewQuestion.business
 
 import com.yourssu.scouter.masterdata.part.implement.PartReader
+import com.yourssu.scouter.masterdata.semester.implement.SemesterReader
+import com.yourssu.scouter.masterdata.semester.implement.fixture.SemesterFixtureBuilder
 import com.yourssu.scouter.recruiting.interview.implement.InterviewRequirement
 import com.yourssu.scouter.recruiting.interview.implement.InterviewRequirementReader
 import com.yourssu.scouter.recruiting.interviewQuestion.application.dto.CreateQuestionsRequest
@@ -23,25 +25,34 @@ class QuestionServiceTest {
     private lateinit var questionReader: QuestionReader
     private lateinit var questionWriter: QuestionWriter
     private lateinit var requirementReader: InterviewRequirementReader
+    private lateinit var semesterReader: SemesterReader
     private lateinit var questionService: QuestionService
+
+    private val semesterId = 1L
+    private val semesterString = "2026-1"
 
     @BeforeEach
     fun setUp() {
         questionReader = mock(QuestionReader::class.java)
         questionWriter = mock(QuestionWriter::class.java)
         requirementReader = mock(InterviewRequirementReader::class.java)
+        semesterReader = mock(SemesterReader::class.java)
 
         questionService = QuestionService(
             questionReader = questionReader,
             partReader = mock(PartReader::class.java),
+            semesterReader = semesterReader,
             questionWriter = questionWriter,
             requirementReader = requirementReader,
         )
+
+        whenever(semesterReader.readByString(semesterString)).thenReturn(SemesterFixtureBuilder().id(semesterId).build())
     }
 
     @Test
     fun `INTRO, OUTRO, CULTURE 질문을 각각의 카테고리로 생성한다`() {
         whenever(questionReader.readAll()).thenReturn(emptyList())
+        whenever(questionReader.readAllBySemesterId(semesterId)).thenReturn(emptyList())
         whenever(requirementReader.readAllByIdIn(listOf(1L))).thenReturn(
             listOf(
                 InterviewRequirement(
@@ -54,12 +65,13 @@ class QuestionServiceTest {
             ),
         )
         whenever(questionWriter.save(any())).thenReturn(
-            Question(1L, null, QuestionCategory.INTRO, "자기소개", 1),
-            Question(2L, null, QuestionCategory.OUTRO, "마지막 한마디", 1),
-            Question(3L, null, QuestionCategory.CULTURE, "컬쳐 질문", 1, listOf(1L)),
+            Question(1L, null, null, QuestionCategory.INTRO, "자기소개", 1),
+            Question(2L, null, null, QuestionCategory.OUTRO, "마지막 한마디", 1),
+            Question(3L, null, semesterId, QuestionCategory.CULTURE, "컬쳐 질문", 1, listOf(1L)),
         )
 
         questionService.upsert(
+            semesterString,
             CreateQuestionsRequest(
                 intro = listOf(CreateQuestionsRequest.Item(content = "자기소개", sortOrder = 1)),
                 outro = listOf(CreateQuestionsRequest.Item(content = "마지막 한마디", sortOrder = 1)),
@@ -80,3 +92,4 @@ class QuestionServiceTest {
             .containsExactly(QuestionCategory.INTRO, QuestionCategory.OUTRO, QuestionCategory.CULTURE)
     }
 }
+

--- a/src/test/kotlin/com/yourssu/scouter/recruiting/interviewQuestion/implement/AssignedQuestionValidatorTest.kt
+++ b/src/test/kotlin/com/yourssu/scouter/recruiting/interviewQuestion/implement/AssignedQuestionValidatorTest.kt
@@ -19,10 +19,10 @@ class AssignedQuestionValidatorTest {
             catalogQuestion(4L, AssignedQuestionCategory.CULTURE, isSelected = false),
         )
         val sourceQuestionsById = mapOf<Long?, Question>(
-            1L to Question(1L, null, QuestionCategory.CULTURE, "질문1", 1, requirementIds = listOf(1L)),
-            2L to Question(2L, null, QuestionCategory.CULTURE, "질문2", 2, requirementIds = listOf(1L)),
-            3L to Question(3L, null, QuestionCategory.CULTURE, "질문3", 3, requirementIds = listOf(1L)),
-            4L to Question(4L, null, QuestionCategory.CULTURE, "질문4", 4, requirementIds = listOf(1L)),
+            1L to Question(1L, null, null, QuestionCategory.CULTURE, "질문1", 1, requirementIds = listOf(1L)),
+            2L to Question(2L, null, null, QuestionCategory.CULTURE, "질문2", 2, requirementIds = listOf(1L)),
+            3L to Question(3L, null, null, QuestionCategory.CULTURE, "질문3", 3, requirementIds = listOf(1L)),
+            4L to Question(4L, null, null, QuestionCategory.CULTURE, "질문4", 4, requirementIds = listOf(1L)),
         )
 
         assertThatThrownBy { validator.validate(questions, sourceQuestionsById, applicantPartId = 1L) }
@@ -47,8 +47,8 @@ class AssignedQuestionValidatorTest {
             catalogQuestion(2L, AssignedQuestionCategory.CULTURE, isSelected = true),
         )
         val sourceQuestionsById = mapOf<Long?, Question>(
-            1L to Question(1L, null, QuestionCategory.INTRO, "질문1", 1),
-            2L to Question(2L, null, QuestionCategory.CULTURE, "질문2", 2, requirementIds = listOf(1L)),
+            1L to Question(1L, null, null, QuestionCategory.INTRO, "질문1", 1),
+            2L to Question(2L, null, null, QuestionCategory.CULTURE, "질문2", 2, requirementIds = listOf(1L)),
         )
 
         assertThatThrownBy { validator.validate(questions, sourceQuestionsById, applicantPartId = 1L) }
@@ -63,9 +63,9 @@ class AssignedQuestionValidatorTest {
             catalogQuestion(3L, AssignedQuestionCategory.CULTURE, isSelected = true),
         )
         val sourceQuestionsById = mapOf<Long?, Question>(
-            1L to Question(1L, 2L, QuestionCategory.PART, "파트 질문", 1, requirementIds = listOf(1L)),
-            2L to Question(2L, null, QuestionCategory.CULTURE, "컬쳐 질문1", 1, requirementIds = listOf(1L)),
-            3L to Question(3L, null, QuestionCategory.CULTURE, "컬쳐 질문2", 2, requirementIds = listOf(1L)),
+            1L to Question(1L, 2L, null, QuestionCategory.PART, "파트 질문", 1, requirementIds = listOf(1L)),
+            2L to Question(2L, null, null, QuestionCategory.CULTURE, "컬쳐 질문1", 1, requirementIds = listOf(1L)),
+            3L to Question(3L, null, null, QuestionCategory.CULTURE, "컬쳐 질문2", 2, requirementIds = listOf(1L)),
         )
 
         assertThatThrownBy { validator.validate(questions, sourceQuestionsById, applicantPartId = 1L) }


### PR DESCRIPTION
## 📄 작업 내용

### 배경

기존 `Question`에는 학기 정보가 없어, 학기가 다른 `InterviewRequirement`가 질문에 포함될 수 있는 문제가 있었습니다.

이를 해결하기 위해 `Question`에 `semesterId`를 추가하고 질문 조회 및 API를 학기 기준으로 분리했습니다.

### 주요 변경사항

- `Question` / `QuestionEntity`에 `semesterId: Long?` 추가
  - `CULTURE` / `PART`: 학기 귀속
  - `INTRO` / `OUTRO`: 공통 질문으로 `null` 유지
- `QuestionRepository`, `QuestionReader`에 학기 기준 조회 메서드 추가
  - `findAllBySemesterId`
  - `findAllByPartIdAndSemesterId`
- `QuestionService`에 `SemesterReader` 추가 및 학기 기준으로 질문 생성/조회하도록 변경
- `AssignedQuestionService`에서 지원자의 `applicationSemester` 기준으로 공통 질문 조회
- 공통 질문 API에 학기 경로 추가

### API 변경

**PART 공통 질문**
- `GET /parts/{partId}/interviews/questions`
  → `GET /semesters/{semester}/parts/{partId}/interviews/questions`
- `PUT /parts/{partId}/interviews/questions`
  → `PUT /semesters/{semester}/parts/{partId}/interviews/questions`

**CULTURE 공통 질문**
- `PUT /interviews/questions`
  → `PUT /semesters/{semester}/interviews/questions`

> `{semester}`는 `2026-1` 형식이며, `SemesterReader.readByString()`을 통해 내부 ID로 변환됩니다.

지원자별 질문 조회 API(`GET /applicants/{applicantId}/interviews/questions`)는 URL 변경 없이 지원자의 학기 정보를 기준으로 조회하도록 변경했습니다.

### DB Migration

`V43__add_semester_id_to_question.sql`

- `question.semester_id` 컬럼 추가
- `semester.id` FK 추가
- `ON DELETE SET NULL` 적용
- 기존 데이터는 `NULL` 유지

Closes #406