### PR TITLE
[#411]; fix: 면접 평가 배점 및 서류 평가 배점 1점으로 상향

### DIFF
--- a/src/main/kotlin/com/yourssu/scouter/recruiting/rubric/application/dto/InterviewRubricUpdateRequest.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/rubric/application/dto/InterviewRubricUpdateRequest.kt
@@ -14,7 +14,12 @@ import jakarta.validation.constraints.Pattern
 @Schema(description = "면접 루브릭 등록 또는 수정 요청")
 data class InterviewRubricUpdateRequest(
     @field:NotNull
-    @field:Schema(description = "루브릭 수정 마감 시각(UTC ISO-8601)", example = "2026-08-01T09:00:00Z", type = "string", format = "date-time")
+    @field:Schema(
+        description = "루브릭 수정 마감 시각(UTC ISO-8601)",
+        example = "2026-08-01T09:00:00Z",
+        type = "string",
+        format = "date-time"
+    )
     val deadline: Instant,
 
     @field:NotEmpty
@@ -26,7 +31,11 @@ data class InterviewRubricUpdateRequest(
     data class GroupRequest(
         @field:NotBlank
         @field:Pattern(regexp = "^(JOB|CULTURE|TEAM)_FIT$", message = "group must be JOB_FIT, CULTURE_FIT, or TEAM_FIT")
-        @field:Schema(description = "평가 그룹", example = "CULTURE_FIT", allowableValues = ["JOB_FIT", "CULTURE_FIT", "TEAM_FIT"])
+        @field:Schema(
+            description = "평가 그룹",
+            example = "CULTURE_FIT",
+            allowableValues = ["JOB_FIT", "CULTURE_FIT", "TEAM_FIT"]
+        )
         val group: String,
 
         @field:NotEmpty
@@ -41,7 +50,7 @@ data class InterviewRubricUpdateRequest(
         @field:Schema(description = "항목 ID", example = "10")
         val itemId: Long,
 
-        @field:Min(0)
+        @field:Min(1)
         @field:Schema(description = "항목의 최대 배점. 0 이상", example = "10")
         val maxScore: Int
     )

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/rubric/application/dto/UpdateRubricRequest.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/rubric/application/dto/UpdateRubricRequest.kt
@@ -2,6 +2,7 @@ package com.yourssu.scouter.recruiting.rubric.application.dto
 
 import com.yourssu.scouter.recruiting.rubric.business.dto.UpdateRubricItemCommand
 import jakarta.validation.constraints.NotNull
+import jakarta.validation.constraints.Min
 
 data class UpdateRubricRequest(
 
@@ -9,6 +10,7 @@ data class UpdateRubricRequest(
     val sectionId: Long?,
 
     @field:NotNull
+    @field:Min(1)
     val maxScore: Int?,
 
     @field:NotNull

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/rubric/business/DocumentSectionService.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/rubric/business/DocumentSectionService.kt
@@ -31,6 +31,7 @@ class DocumentSectionService(
     @Transactional
     fun updateRubrics(partId: Long, items: List<UpdateRubricItemCommand>) {
         partReader.readById(partId)
+        require(items.all { it.maxScore > 0 }) { "평가 항목의 배점은 1점 이상 할당 되어야 합니다." }
         require(items.sumOf { it.maxScore } == 100) { "배점 합계는 100이어야 합니다." }
 
         val partSections = documentSectionReader.readAllByPartId(partId).associateBy { it.id }

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/rubric/implement/InterviewRubric.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/rubric/implement/InterviewRubric.kt
@@ -16,6 +16,8 @@ class InterviewRubric(
 ) {
 
     fun validateTotalScore() {
+        require(items.all { it.maxScore > 0 }) { "평가 항목의 배점은 1점 이상 할당 되어야 합니다." }
+
         // 배점 합계 100점 비즈니스 검증
         val totalScore = items.sumOf { it.maxScore }
         require(totalScore == 100) {


### PR DESCRIPTION
## Summary
- 면접/서류 루브릭 배점 입력 DTO에 `@Min(1)` 검증 추가 (0점 입력 차단)
- 면접 루브릭 확정(`InterviewRubric.validateTotalScore`) / 서류 루브릭 확정(`DocumentSectionService.updateRubrics`) 시점에 배점이 1점 이상인지 검증 추가
- 도메인 객체(`InterviewEvaluationItem`, `DocumentSection`) 생성자에는 검증을 두지 않음 — `maxScore=0`은 구글폼 동기화로 새 문항이 생성되거나 아직 저장되지 않은 루브릭 템플릿을 조회할 때 나타나는 정상적인 "미설정" 상태이기 때문

Closes #411

## Test plan
- [x] `./gradlew compileKotlin` 통과
- [ ] 면접/서류 루브릭 등록 API에 0점 포함 요청 시 400 응답 확인
- [ ] 구글폼 동기화로 신규 문항 생성 시 정상 동작 확인 (회귀 없음)
- [ ] 루브릭 미설정 상태에서 GET 조회 정상 동작 확인 (회귀 없음)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018LBQ6kV1TUAykgEjjoAxAp