### PR TITLE
[#416]; feat: 로그인 시 userId 자동 필링

### DIFF
--- a/src/main/kotlin/com/yourssu/scouter/auth/authentication/application/SwaggerOAuth2Controller.kt
+++ b/src/main/kotlin/com/yourssu/scouter/auth/authentication/application/SwaggerOAuth2Controller.kt
@@ -2,9 +2,10 @@ package com.yourssu.scouter.auth.authentication.application
 
 import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy
 import com.fasterxml.jackson.databind.annotation.JsonNaming
-import com.yourssu.scouter.auth.authentication.business.dto.LoginResult
 import com.yourssu.scouter.auth.authentication.business.OAuth2Service
+import com.yourssu.scouter.auth.authentication.business.dto.LoginResult
 import com.yourssu.scouter.auth.authentication.implement.OAuth2Type
+import com.yourssu.scouter.member.core.implement.MemberWriter
 import io.swagger.v3.oas.annotations.Hidden
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.http.ResponseEntity
@@ -14,9 +15,9 @@ import org.springframework.web.bind.annotation.RestController
 
 @Hidden
 @RestController
-class SwaggerOAuth2Controller(private val oauth2Service: OAuth2Service) {
+class SwaggerOAuth2Controller(private val oauth2Service: OAuth2Service, val memberWriter: MemberWriter) {
 
-    @Value("\${springdoc.swagger-ui.oauth2-redirect-url:http://localhost:8080/swagger-ui/oauth2-redirect.html}")
+    @Value($$"${springdoc.swagger-ui.oauth2-redirect-url:http://localhost:8080/swagger-ui/oauth2-redirect.html}")
     private lateinit var redirectUri: String
 
     @PostMapping("/oauth2/swagger/callback")
@@ -35,6 +36,8 @@ class SwaggerOAuth2Controller(private val oauth2Service: OAuth2Service) {
             referer = referer,
             redirectUriOverride = redirectUri,
         )
+
+        memberWriter.updateUserIdByEmail(loginResult.id, loginResult.email)
         val accessToken = loginResult.accessToken.substringAfter(" ")
         return ResponseEntity.ok(AuthResponse(accessToken))
     }

--- a/src/main/kotlin/com/yourssu/scouter/auth/authentication/business/LoginService.kt
+++ b/src/main/kotlin/com/yourssu/scouter/auth/authentication/business/LoginService.kt
@@ -6,14 +6,14 @@ import com.yourssu.scouter.auth.authentication.business.dto.LoginResult
 import com.yourssu.scouter.auth.authentication.implement.OAuth2Type
 import com.yourssu.scouter.member.core.business.dto.MemberDto
 import com.yourssu.scouter.member.core.implement.Member
-import com.yourssu.scouter.member.core.implement.MemberReader
+import com.yourssu.scouter.member.core.implement.MemberWriter
 import com.yourssu.scouter.member.support.exception.MemberNotRegisteredException
 import org.springframework.stereotype.Service
 
 @Service
 class LoginService(
     private val oauth2Service: OAuth2Service,
-    private val memberReader: MemberReader,
+    private val memberWriter: MemberWriter,
 ) {
 
     fun login(
@@ -29,8 +29,8 @@ class LoginService(
             redirectUriOverride = redirectUriOverride,
         )
 
-        val member: Member = memberReader.readByEmailOrNull(loginResult.email)
-            ?: throw MemberNotRegisteredException("등록된 멤버가 아닙니다. 로그인할 수 없습니다.")
+        val member = memberWriter.updateUserIdByEmail(loginResult.id, loginResult.email)
+            ?: throw MemberNotRegisteredException("등록된 멤버가 아닙니다.")
 
         return LoginWithMemberResult(
             accessToken = loginResult.accessToken,

--- a/src/main/kotlin/com/yourssu/scouter/member/core/application/dto/ReadActiveMemberResponse.kt
+++ b/src/main/kotlin/com/yourssu/scouter/member/core/application/dto/ReadActiveMemberResponse.kt
@@ -41,6 +41,8 @@ data class ReadActiveMemberListItemResponse(
     val isOnLeave: Boolean?,
     @field:Schema(description = "비고(민감정보 마스킹 시 null)", example = "메모")
     val note: String?,
+    @field:Schema(description = "로그인 user id", example = "12", types = ["Long", "null"])
+    val userId: Long?
 ) {
     companion object {
         fun from(activeMemberDto: ActiveMemberDto): ReadActiveMemberListItemResponse =
@@ -64,6 +66,7 @@ data class ReadActiveMemberListItemResponse(
                 grade = activeMemberDto.grade,
                 isOnLeave = activeMemberDto.isOnLeave,
                 note = activeMemberDto.member.note,
+                userId = activeMemberDto.member.userId
             )
     }
 }
@@ -101,7 +104,8 @@ data class ReadActiveMemberResponse(
     val isOnLeave: Boolean?,
     @field:Schema(description = "비고(민감정보 마스킹 시 null)", example = "메모")
     val note: String?,
-
+    @field:Schema(description = "로그인 user id", example = "12", types = ["Long", "null"])
+    val userId: Long?,
     @field:Schema(
         description = "민감정보(전화번호, 생년월일, 학번, 회비 납부, 비고)가 마스킹되어 null로 내려가는지 여부",
         example = "false",
@@ -131,6 +135,7 @@ data class ReadActiveMemberResponse(
             isOnLeave = activeMemberDto.isOnLeave,
             note = activeMemberDto.member.note,
             isSensitiveMasked = false,
+            userId = activeMemberDto.member.userId
         )
     }
 }

--- a/src/main/kotlin/com/yourssu/scouter/member/core/business/MemberService.kt
+++ b/src/main/kotlin/com/yourssu/scouter/member/core/business/MemberService.kt
@@ -1,41 +1,18 @@
 package com.yourssu.scouter.member.core.business
 
-import com.yourssu.scouter.member.core.business.dto.UpdateMemberInfoCommand
-
-import com.yourssu.scouter.member.core.business.dto.UpdateGraduatedMemberCommand
-
-import com.yourssu.scouter.member.core.business.dto.UpdateWithdrawnMemberCommand
-
-import com.yourssu.scouter.member.core.business.dto.UpdateCompletedMemberCommand
-
-import com.yourssu.scouter.member.core.business.dto.CreateMemberCommand
-
-import com.yourssu.scouter.member.core.business.dto.UpdateActiveMemberCommand
-
-import com.yourssu.scouter.member.core.business.dto.UpdateInactiveMemberCommand
-
-import com.yourssu.scouter.member.core.business.dto.WithdrawnMemberDto
-
-import com.yourssu.scouter.member.core.business.dto.InactiveMemberDto
-
-import com.yourssu.scouter.member.core.business.dto.GraduatedMemberDto
-
-import com.yourssu.scouter.member.core.business.dto.CompletedMemberDto
-
-import com.yourssu.scouter.member.core.business.dto.ActiveMemberDto
-
 import com.yourssu.scouter.masterdata.department.implement.Department
 import com.yourssu.scouter.masterdata.department.implement.DepartmentReader
 import com.yourssu.scouter.masterdata.part.implement.Part
 import com.yourssu.scouter.masterdata.part.implement.PartReader
-import com.yourssu.scouter.masterdata.support.converter.SemesterConverter
 import com.yourssu.scouter.masterdata.semester.implement.Semester
 import com.yourssu.scouter.masterdata.semester.implement.SemesterReader
+import com.yourssu.scouter.masterdata.support.converter.SemesterConverter
 import com.yourssu.scouter.masterdata.support.exception.SemesterNotFoundException
-import com.yourssu.scouter.member.support.exception.IllegalMemberUpdateException
+import com.yourssu.scouter.member.core.business.dto.*
+import com.yourssu.scouter.member.core.implement.*
 import com.yourssu.scouter.member.support.converter.MemberRoleConverter
 import com.yourssu.scouter.member.support.converter.MemberStateConverter
-import com.yourssu.scouter.member.core.implement.*
+import com.yourssu.scouter.member.support.exception.IllegalMemberUpdateException
 import org.springframework.stereotype.Service
 import java.time.Instant
 import java.time.LocalDate
@@ -180,8 +157,8 @@ class MemberService(
     private fun validateUpdateActiveCommand(command: UpdateActiveMemberCommand) {
         val hasMemberInfo = command.updateMemberInfoCommand != null
         val hasActiveOnlyField = command.isMembershipFeePaid != null ||
-            command.grade != null ||
-            command.isOnLeave != null
+                command.grade != null ||
+                command.isOnLeave != null
         if (hasMemberInfo && hasActiveOnlyField) {
             throw IllegalMemberUpdateException("회원 정보 수정과 액티브 전용 필드(회비/학년/재휴학) 수정을 동시에 요청할 수 없습니다.")
         }
@@ -211,7 +188,7 @@ class MemberService(
         }
 
         if (metadataSpecified) {
-            applyInactiveMetadataPatch(command.targetMemberId, command.inactiveMetadataPatch!!)
+            applyInactiveMetadataPatch(command.targetMemberId, command.inactiveMetadataPatch)
 
             return
         }
@@ -243,7 +220,10 @@ class MemberService(
             reason = mergePatchedNullableString(patch.reason, base.reason),
             smsReplied = patch.smsReplied ?: base.smsReplied,
             smsReplyDesiredPeriod = mergePatchedNullableString(patch.smsReplyDesiredPeriod, base.smsReplyDesiredPeriod),
-            activitySemestersLabel = mergePatchedNullableString(patch.activitySemestersLabel, base.activitySemestersLabel),
+            activitySemestersLabel = mergePatchedNullableString(
+                patch.activitySemestersLabel,
+                base.activitySemestersLabel
+            ),
             totalActiveSemesters = patch.totalActiveSemesters ?: base.totalActiveSemesters,
             totalInactiveSemesters = patch.totalInactiveSemesters ?: base.totalInactiveSemesters,
         )

--- a/src/main/kotlin/com/yourssu/scouter/member/core/business/dto/MemberDto.kt
+++ b/src/main/kotlin/com/yourssu/scouter/member/core/business/dto/MemberDto.kt
@@ -26,6 +26,7 @@ data class MemberDto(
     val stateUpdatedTime: Instant,
     val createdTime: Instant,
     val updatedTime: Instant,
+    val userId: Long? = null,
 ) {
 
     companion object {
@@ -47,6 +48,7 @@ data class MemberDto(
             stateUpdatedTime = member.stateUpdatedTime,
             createdTime = member.createdTime!!,
             updatedTime = member.updatedTime!!,
+            userId = member.userId,
         )
     }
 }

--- a/src/main/kotlin/com/yourssu/scouter/member/core/implement/Member.kt
+++ b/src/main/kotlin/com/yourssu/scouter/member/core/implement/Member.kt
@@ -57,11 +57,11 @@ class Member(
     }
 
     fun registerUser(userId: Long) =
-        if (this.userId == null) {
+        if (this.userId == userId) {
+            false
+        } else {
             this.userId = userId
             true
-        } else {
-            false
         }
 
     private fun makeRoleUpdatedMessage(newRole: MemberRole): String {

--- a/src/main/kotlin/com/yourssu/scouter/member/core/implement/Member.kt
+++ b/src/main/kotlin/com/yourssu/scouter/member/core/implement/Member.kt
@@ -24,6 +24,7 @@ class Member(
     val nicknameKorean: String,
     var state: MemberState,
     val joinDate: LocalDate,
+    var userId: Long? = null,
     var note: String,
     var stateUpdatedTime: Instant,
     createdTime: Instant? = null,
@@ -54,6 +55,14 @@ class Member(
 
         this.role = newRole
     }
+
+    fun registerUser(userId: Long) =
+        if (this.userId == null) {
+            this.userId = userId
+            true
+        } else {
+            false
+        }
 
     private fun makeRoleUpdatedMessage(newRole: MemberRole): String {
         val (currentYear, currentTerm) = Semester.of(LocalDate.now()).run { year to term.intValue }
@@ -87,6 +96,6 @@ class Member(
     }
 
     override fun hashCode(): Int {
-        return id?.hashCode() ?: 0
+        return id.hashCode()
     }
 }

--- a/src/main/kotlin/com/yourssu/scouter/member/core/implement/MemberWriter.kt
+++ b/src/main/kotlin/com/yourssu/scouter/member/core/implement/MemberWriter.kt
@@ -150,6 +150,15 @@ class MemberWriter(
         withdrawnMemberRepository.save(withdrawnMember)
     }
 
+    fun updateUserIdByEmail(userId: Long, email: String): Member? {
+        val member = memberRepository.findByEmail(email) ?: return null
+        return if (member.registerUser(userId)) {
+            memberRepository.save(member)
+        } else {
+            member
+        }
+    }
+
     fun update(toUpdate: Member) {
         memberRepository.save(toUpdate)
     }

--- a/src/main/kotlin/com/yourssu/scouter/member/core/storage/MemberEntity.kt
+++ b/src/main/kotlin/com/yourssu/scouter/member/core/storage/MemberEntity.kt
@@ -1,5 +1,6 @@
 package com.yourssu.scouter.member.core.storage
 
+import com.yourssu.scouter.auth.user.storage.UserEntity
 import com.yourssu.scouter.masterdata.part.implement.Part
 import com.yourssu.scouter.common.basetime.storage.BaseTimeEntity
 import com.yourssu.scouter.masterdata.department.storage.DepartmentEntity
@@ -60,7 +61,10 @@ class MemberEntity(
     @Column(nullable = false)
     val stateUpdatedTime: Instant,
 
-    ) : BaseTimeEntity() {
+    @Column(nullable = true)
+    val userId: Long? = null
+
+) : BaseTimeEntity() {
 
     companion object {
         fun from(member: Member) = MemberEntity(
@@ -78,6 +82,7 @@ class MemberEntity(
             joinDate = member.joinDate,
             note = member.note,
             stateUpdatedTime = member.stateUpdatedTime,
+            userId = member.userId,
         )
     }
 
@@ -99,6 +104,7 @@ class MemberEntity(
         stateUpdatedTime = stateUpdatedTime,
         createdTime = createdTime,
         updatedTime = updatedTime,
+        userId = userId
     )
 
     override fun equals(other: Any?): Boolean {
@@ -111,6 +117,6 @@ class MemberEntity(
     }
 
     override fun hashCode(): Int {
-        return id?.hashCode() ?: 0
+        return id.hashCode()
     }
 }

--- a/src/main/resources/db/migration/V44__add_user_id_fk_to_member.sql
+++ b/src/main/resources/db/migration/V44__add_user_id_fk_to_member.sql
@@ -1,0 +1,5 @@
+ALTER TABLE member
+    ADD COLUMN user_id BIGINT NULL,
+    ADD CONSTRAINT fk_user_id
+    FOREIGN KEY (user_id)
+        REFERENCES USERS (id) on DELETE SET NULL;

--- a/src/test/kotlin/com/yourssu/scouter/auth/authentication/business/LoginServiceTest.kt
+++ b/src/test/kotlin/com/yourssu/scouter/auth/authentication/business/LoginServiceTest.kt
@@ -3,7 +3,7 @@ package com.yourssu.scouter.auth.authentication.business
 import com.yourssu.scouter.auth.authentication.business.dto.LoginResult
 import com.yourssu.scouter.auth.authentication.implement.OAuth2Type
 import com.yourssu.scouter.member.core.fixture.MemberFixtureBuilder
-import com.yourssu.scouter.member.core.implement.MemberReader
+import com.yourssu.scouter.member.core.implement.MemberWriter
 import com.yourssu.scouter.member.support.exception.MemberNotRegisteredException
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
@@ -19,13 +19,13 @@ class LoginServiceTest {
 
     private lateinit var loginService: LoginService
     private lateinit var oauth2Service: OAuth2Service
-    private lateinit var memberReader: MemberReader
+    private lateinit var memberWriter: MemberWriter
 
     @BeforeEach
     fun setUp() {
         oauth2Service = mock(OAuth2Service::class.java)
-        memberReader = mock(MemberReader::class.java)
-        loginService = LoginService(oauth2Service, memberReader)
+        memberWriter = mock(MemberWriter::class.java)
+        loginService = LoginService(oauth2Service, memberWriter)
     }
 
     private fun createLoginResult(email: String = "hong@soongsil.ac.kr") = LoginResult(
@@ -54,7 +54,7 @@ class LoginServiceTest {
                     redirectUriOverride = null,
                 )
             ).thenReturn(loginResult)
-            whenever(memberReader.readByEmailOrNull("hong@soongsil.ac.kr")).thenReturn(member)
+            whenever(memberWriter.updateUserIdByEmail(loginResult.id, "hong@soongsil.ac.kr")).thenReturn(member)
 
             // when
             val result = loginService.login(
@@ -86,7 +86,7 @@ class LoginServiceTest {
                     redirectUriOverride = null,
                 )
             ).thenReturn(loginResult)
-            whenever(memberReader.readByEmailOrNull("unknown@gmail.com")).thenReturn(null)
+            whenever(memberWriter.updateUserIdByEmail(loginResult.id, "unknown@gmail.com")).thenReturn(null)
 
             // when & then
             assertThatThrownBy {
@@ -114,7 +114,7 @@ class LoginServiceTest {
                     redirectUriOverride = null,
                 )
             ).thenReturn(loginResult)
-            whenever(memberReader.readByEmailOrNull("hong@soongsil.ac.kr")).thenReturn(member)
+            whenever(memberWriter.updateUserIdByEmail(loginResult.id, "hong@soongsil.ac.kr")).thenReturn(member)
 
             // when
             val result = loginService.login(
@@ -150,7 +150,7 @@ class LoginServiceTest {
                     redirectUriOverride = null,
                 )
             ).thenReturn(loginResult)
-            whenever(memberReader.readByEmailOrNull("hong@soongsil.ac.kr")).thenReturn(member)
+            whenever(memberWriter.updateUserIdByEmail(loginResult.id, "hong@soongsil.ac.kr")).thenReturn(member)
 
             // when
             val result = loginService.login(


### PR DESCRIPTION
## Summary
- Member 엔티티에 `userId` 컬럼을 추가하고, OAuth2 로그인 시 이메일 기준으로 매칭되는 Member에 로그인 계정의 userId를 자동으로 채워 넣도록 구현
- `LoginService`와 Swagger OAuth2 콜백 컨트롤러 모두 `MemberWriter.updateUserIdByEmail`을 통해 필링 처리
- `Member`에 등록된 userId와 로그인한 계정의 userId가 다를 경우, 기존 값을 그대로 두지 않고 최신 값으로 갱신하도록 처리
- 표현 계층(`ReadActiveMemberResponse`)에 `userId` 필드 노출
- `user` 테이블 FK를 위한 마이그레이션 스크립트 추가

## Test plan
- [x] `./gradlew compileKotlin` 통과 확인
- [x] 로컬에서 Swagger OAuth2 로그인으로 `member.user_id`가 채워지는지 확인
- [ ] 동일 이메일로 다른 Google 계정 로그인 시 userId가 최신 값으로 갱신되는지 확인

Closes #416

🤖 Generated with [Claude Code](https://claude.com/claude-code)