### PR TITLE
[#422]; fix: sourceQuestionId 없는 신규 PART 질문 upsert 시 예외 발생하는 문제 수정

### DIFF
--- a/src/main/kotlin/com/yourssu/scouter/recruiting/interviewQuestion/business/AssignedQuestionService.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/interviewQuestion/business/AssignedQuestionService.kt
@@ -36,7 +36,6 @@ class AssignedQuestionService(
     private val evaluatorDirectory: EvaluatorDirectory,
     private val interviewRequirementLookup: InterviewRequirementLookup,
 ) {
-
     fun readByApplicantId(applicantId: Long): AssignedQuestionsDto {
         val applicant = applicantReader.readById(applicantId)
         val applicantPartId = applicant.part.id!!
@@ -58,28 +57,36 @@ class AssignedQuestionService(
     }
 
     @Transactional
-    fun upsert(applicantId: Long, command: SaveAssignedQuestionsCommand): AssignedQuestionsDto {
+    fun upsert(
+        applicantId: Long,
+        command: SaveAssignedQuestionsCommand,
+    ): AssignedQuestionsDto {
         val applicant = applicantReader.readById(applicantId)
         val applicantPartId = applicant.part.id!!
+        val applicantSemesterId = applicant.applicationSemester.id!!
 
-        val questions = command.questions.mapIndexed { index, question ->
-            userReader.readById(question.assignedInterviewerUserId)
+        val resolvedSourceQuestionIds = createNewPartQuestions(command.questions, applicantPartId, applicantSemesterId)
 
-            AssignedQuestion(
-                assignedInterviewerUserId = question.assignedInterviewerUserId,
-                applicantId = applicantId,
-                sourceQuestionId = question.sourceQuestionId,
-                content = if (question.category == AssignedQuestionCategory.PERSONAL) question.content else null,
-                category = question.category,
-                sortOrder = index,
-                isSelected = question.isSelected,
-                requirementIds = if (question.category == AssignedQuestionCategory.PERSONAL) {
-                    question.requirementIds
-                } else {
-                    emptyList()
-                },
-            )
-        }
+        val questions =
+            command.questions.mapIndexed { index, question ->
+                userReader.readById(question.assignedInterviewerUserId)
+
+                AssignedQuestion(
+                    assignedInterviewerUserId = question.assignedInterviewerUserId,
+                    applicantId = applicantId,
+                    sourceQuestionId = resolvedSourceQuestionIds[index] ?: question.sourceQuestionId,
+                    content = if (question.category == AssignedQuestionCategory.PERSONAL) question.content else null,
+                    category = question.category,
+                    sortOrder = index,
+                    isSelected = question.isSelected,
+                    requirementIds =
+                        if (question.category == AssignedQuestionCategory.PERSONAL) {
+                            question.requirementIds
+                        } else {
+                            emptyList()
+                        },
+                )
+            }
         val sourceQuestionsById = readSourceQuestionsById(questions)
         assignedQuestionValidator.validate(questions, sourceQuestionsById, applicantPartId)
 
@@ -93,6 +100,46 @@ class AssignedQuestionService(
         return AssignedQuestionsDto(
             questions = toAssignedQuestionDtos(saved, savedSourceQuestionsById, requirementsById),
         )
+    }
+
+    /**
+     * sourceQuestionId 없이 들어온 신규 PART 질문을 카탈로그 Question으로 먼저 저장하고,
+     * 발급된 id를 AssignedQuestion 생성 전에 미리 매칭시켜준다. (PART는 카탈로그 카테고리라
+     * AssignedQuestion 생성자가 sourceQuestionId를 필수로 요구하기 때문)
+     * 반환값은 command 내 index -> 새로 저장된 Question id.
+     */
+    private fun createNewPartQuestions(
+        questions: List<SaveAssignedQuestionCommand>,
+        applicantPartId: Long,
+        applicantSemesterId: Long,
+    ): Map<Int, Long> {
+        val newPartQuestions =
+            questions.withIndex().filter { (_, question) ->
+                question.category == AssignedQuestionCategory.PART && question.sourceQuestionId == null
+            }
+        if (newPartQuestions.isEmpty()) return emptyMap()
+
+        val existingPartQuestionCount =
+            questionReader.readAllByPartIdAndSemesterId(applicantPartId, applicantSemesterId).size
+
+        return newPartQuestions.mapIndexed { offset, (index, question) ->
+            val content =
+                question.content
+                    ?: throw QuestionInvalidException("신규 PART 질문은 content가 필요합니다.")
+
+            val saved =
+                questionWriter.save(
+                    Question(
+                        partId = applicantPartId,
+                        semesterId = applicantSemesterId,
+                        category = QuestionCategory.PART,
+                        content = content,
+                        sortOrder = existingPartQuestionCount + offset,
+                        requirementIds = question.requirementIds,
+                    ),
+                )
+            index to saved.id!!
+        }.toMap()
     }
 
     private fun updateCatalogQuestions(
@@ -120,32 +167,31 @@ class AssignedQuestionService(
                     }
 
                     QuestionCategory.PART -> {
-                        val updatedQuestion = Question(
-                            id = sourceQuestion.id,
-                            partId = sourceQuestion.partId,
-                            semesterId = sourceQuestion.semesterId,
-                            category = sourceQuestion.category,
-                            content = question.content ?: sourceQuestion.content,
-                            sortOrder = sourceQuestion.sortOrder,
-                            requirementIds = question.requirementIds,
-                        )
+                        val updatedQuestion =
+                            Question(
+                                id = sourceQuestion.id,
+                                partId = sourceQuestion.partId,
+                                semesterId = sourceQuestion.semesterId,
+                                category = sourceQuestion.category,
+                                content = question.content ?: sourceQuestion.content,
+                                sortOrder = sourceQuestion.sortOrder,
+                                requirementIds = question.requirementIds,
+                            )
                         questionWriter.update(updatedQuestion)
                     }
                 }
             }
     }
 
-    private fun readSourceQuestionsById(questions: List<AssignedQuestion>): Map<Long?, Question> {
-        return questionReader
+    private fun readSourceQuestionsById(questions: List<AssignedQuestion>): Map<Long?, Question> =
+        questionReader
             .readAllByIdIn(questions.mapNotNull { it.sourceQuestionId })
             .associateBy { it.id }
-    }
 
-    private fun readRequirementsById(applicant: Applicant): Map<Long?, InterviewRequirementProfile> {
-        return interviewRequirementLookup
+    private fun readRequirementsById(applicant: Applicant): Map<Long?, InterviewRequirementProfile> =
+        interviewRequirementLookup
             .findAllByPartIdAndSemester(applicant.part.id!!, applicant.applicationSemester)
             .associateBy { it.id }
-    }
 
     private fun toAssignedQuestionDtos(
         questions: List<AssignedQuestion>,
@@ -162,20 +208,21 @@ class AssignedQuestionService(
     }
 
     private fun readAssignedInterviewerNamesById(questions: List<AssignedQuestion>): Map<Long, String> {
-        val usersById = userReader
-            .readAllByIds(questions.map { it.assignedInterviewerUserId }.distinct())
-            .associateBy { it.id!! }
+        val usersById =
+            userReader
+                .readAllByIds(questions.map { it.assignedInterviewerUserId }.distinct())
+                .associateBy { it.id!! }
 
         return questions
             .map { it.assignedInterviewerUserId }
             .distinct()
             .mapNotNull { userId ->
                 val user = usersById[userId] ?: return@mapNotNull null
-                val name = evaluatorDirectory.findEvaluatorInfo(user.userInfo.email)?.nicknameEnglish
-                    ?: user.userInfo.name
+                val name =
+                    evaluatorDirectory.findEvaluatorInfo(user.userInfo.email)?.nicknameEnglish
+                        ?: user.userInfo.name
                 userId to name
-            }
-            .toMap()
+            }.toMap()
     }
 
     private fun readDefaultQuestions(
@@ -184,12 +231,16 @@ class AssignedQuestionService(
         requirementsById: Map<Long?, InterviewRequirementProfile>,
     ): List<AssignedQuestionDto> {
         // INTRO / OUTRO : 학기에 무관하게 전체 공유
-        val introOutroQuestions = questionReader.readAll()
-            .filter { it.partId == null && it.category in setOf(QuestionCategory.INTRO, QuestionCategory.OUTRO) }
+        val introOutroQuestions =
+            questionReader
+                .readAll()
+                .filter { it.partId == null && it.category in setOf(QuestionCategory.INTRO, QuestionCategory.OUTRO) }
 
         // CULTURE / PART : 지원자의 학기에 귀속된 질문만 조회
-        val cultureQuestions = questionReader.readAllBySemesterId(applicantSemesterId)
-            .filter { it.partId == null && it.category == QuestionCategory.CULTURE }
+        val cultureQuestions =
+            questionReader
+                .readAllBySemesterId(applicantSemesterId)
+                .filter { it.partId == null && it.category == QuestionCategory.CULTURE }
         val partQuestions = questionReader.readAllByPartIdAndSemesterId(applicantPartId, applicantSemesterId)
 
         val catalogQuestions = introOutroQuestions + cultureQuestions + partQuestions
@@ -205,18 +256,17 @@ class AssignedQuestionService(
                     category = question.category.toAssignedQuestionCategory(),
                     sortOrder = index,
                     isSelected = if (question.category == QuestionCategory.CULTURE) false else null,
-                    requirements = question.requirementIds.mapNotNull { requirementId ->
-                        requirementsById[requirementId]?.let { requirement ->
-                            QuestionRequirementDto(requirement.id, requirement.content)
-                        }
-                    },
+                    requirements =
+                        question.requirementIds.mapNotNull { requirementId ->
+                            requirementsById[requirementId]?.let { requirement ->
+                                QuestionRequirementDto(requirement.id, requirement.content)
+                            }
+                        },
                 )
             }
     }
 
-    private fun QuestionCategory.toAssignedQuestionCategory(): AssignedQuestionCategory {
-        return AssignedQuestionCategory.valueOf(name)
-    }
+    private fun QuestionCategory.toAssignedQuestionCategory(): AssignedQuestionCategory = AssignedQuestionCategory.valueOf(name)
 
     private fun AssignedQuestion.toDto(
         sourceQuestionsById: Map<Long?, Question>,
@@ -224,11 +274,12 @@ class AssignedQuestionService(
         assignedInterviewerNamesById: Map<Long, String>,
     ): AssignedQuestionDto {
         // 카탈로그 카테고리(INTRO/OUTRO/CULTURE/PART)는 요구조건을 원본 질문(Question)에서 가져오고, PERSONAL만 인스턴스 자체 값을 사용한다.
-        val effectiveRequirementIds = if (category == AssignedQuestionCategory.PERSONAL) {
-            requirementIds
-        } else {
-            sourceQuestionsById[sourceQuestionId]?.requirementIds.orEmpty()
-        }
+        val effectiveRequirementIds =
+            if (category == AssignedQuestionCategory.PERSONAL) {
+                requirementIds
+            } else {
+                sourceQuestionsById[sourceQuestionId]?.requirementIds.orEmpty()
+            }
 
         return AssignedQuestionDto(
             id = id!!,
@@ -239,11 +290,12 @@ class AssignedQuestionService(
             category = category,
             sortOrder = sortOrder,
             isSelected = isSelected,
-            requirements = effectiveRequirementIds.mapNotNull { requirementId ->
-                requirementsById[requirementId]?.let { requirement ->
-                    QuestionRequirementDto(requirement.id, requirement.content)
-                }
-            },
+            requirements =
+                effectiveRequirementIds.mapNotNull { requirementId ->
+                    requirementsById[requirementId]?.let { requirement ->
+                        QuestionRequirementDto(requirement.id, requirement.content)
+                    }
+                },
         )
     }
 }

--- a/src/test/kotlin/com/yourssu/scouter/recruiting/interviewQuestion/business/AssignedQuestionServiceTest.kt
+++ b/src/test/kotlin/com/yourssu/scouter/recruiting/interviewQuestion/business/AssignedQuestionServiceTest.kt
@@ -266,6 +266,86 @@ class AssignedQuestionServiceTest {
     }
 
     @Test
+    fun `sourceQuestionId가 없는 신규 PART 질문은 카탈로그에 저장되고 그 id로 배정된다`() {
+        val interviewerUserId = 100L
+        val newQuestionId = 99L
+        val cultureQuestions = listOf(
+            Question(1L, null, null, QuestionCategory.CULTURE, "컬쳐1", 1, requirementIds = listOf(1L)),
+            Question(2L, null, null, QuestionCategory.CULTURE, "컬쳐2", 2, requirementIds = listOf(1L)),
+        )
+
+        whenever(userReader.readById(interviewerUserId)).thenReturn(mock(User::class.java))
+        whenever(questionReader.readAllByPartIdAndSemesterId(partId, 1L)).thenReturn(emptyList())
+        whenever(questionWriter.save(any())).thenAnswer { invocation ->
+            val question = invocation.arguments[0] as Question
+            Question(
+                id = newQuestionId,
+                partId = question.partId,
+                semesterId = question.semesterId,
+                category = question.category,
+                content = question.content,
+                sortOrder = question.sortOrder,
+                requirementIds = question.requirementIds,
+            )
+        }
+
+        val newPartQuestion = Question(newQuestionId, partId, 1L, QuestionCategory.PART, "새 파트 질문", 0, requirementIds = listOf(501L))
+        whenever(questionReader.readAllByIdIn(listOf(1L, 2L, newQuestionId))).thenReturn(cultureQuestions + newPartQuestion)
+
+        val savedAssignedQuestions = listOf(
+            assignedCultureQuestion(21L, interviewerUserId, 1L, isSelected = true, sortOrder = 0),
+            assignedCultureQuestion(22L, interviewerUserId, 2L, isSelected = true, sortOrder = 1),
+            AssignedQuestion(
+                id = 20L,
+                assignedInterviewerUserId = interviewerUserId,
+                applicantId = applicantId,
+                sourceQuestionId = newQuestionId,
+                content = null,
+                category = AssignedQuestionCategory.PART,
+                sortOrder = 2,
+            ),
+        )
+        whenever(assignedQuestionWriter.replaceAll(any(), any())).thenReturn(savedAssignedQuestions)
+
+        val command = SaveAssignedQuestionsCommand(
+            questions = listOf(
+                SaveAssignedQuestionCommand(
+                    assignedInterviewerUserId = interviewerUserId,
+                    sourceQuestionId = 1L,
+                    content = null,
+                    category = AssignedQuestionCategory.CULTURE,
+                    isSelected = true,
+                ),
+                SaveAssignedQuestionCommand(
+                    assignedInterviewerUserId = interviewerUserId,
+                    sourceQuestionId = 2L,
+                    content = null,
+                    category = AssignedQuestionCategory.CULTURE,
+                    isSelected = true,
+                ),
+                SaveAssignedQuestionCommand(
+                    assignedInterviewerUserId = interviewerUserId,
+                    sourceQuestionId = null,
+                    content = "새 파트 질문",
+                    category = AssignedQuestionCategory.PART,
+                    requirementIds = listOf(501L),
+                ),
+            ),
+        )
+
+        val saved = assignedQuestionService.upsert(applicantId, command)
+
+        assertThat(saved.questions.last().sourceQuestionId).isEqualTo(newQuestionId)
+
+        val captor = argumentCaptor<Question>()
+        verify(questionWriter).save(captor.capture())
+        assertThat(captor.firstValue.id).isNull()
+        assertThat(captor.firstValue.partId).isEqualTo(partId)
+        assertThat(captor.firstValue.content).isEqualTo("새 파트 질문")
+        assertThat(captor.firstValue.requirementIds).containsExactly(501L)
+    }
+
+    @Test
     fun `PART 질문에 요구조건이 없으면 예외를 발생시킨다`() {
         val interviewerUserId = 100L
         val sourceQuestions = listOf(


### PR DESCRIPTION
## 문제

PART 카테고리는 카탈로그 질문(`Question`)이라 `AssignedQuestion` 생성자가 `sourceQuestionId`를 필수로 요구한다. 그래서 지원자별로 완전히 새로운 PART 질문을 `sourceQuestionId` 없이 저장하려고 하면 `AssignedQuestionService.upsert()`에서 예외가 발생해 저장이 불가능했다.

## 해결

`AssignedQuestionService.upsert()`에서 `category == PART && sourceQuestionId == null`인 항목을 먼저 카탈로그 `Question`으로 저장(`createNewPartQuestions`)하고, 발급된 id를 `AssignedQuestion` 생성 전에 index 기준으로 미리 매칭시켰다. 이후 검증/카탈로그 갱신/저장 흐름은 기존 카탈로그 질문을 참조하는 경우와 동일하게 동작한다. 기존에 있던 "이미 존재하는 PART 질문 수정 시 공유 카탈로그 row를 직접 update"하는 동작은 그대로 유지했다.

## 테스트

- `sourceQuestionId가 없는 신규 PART 질문은 카탈로그에 저장되고 그 id로 배정된다` 테스트 추가
- `interviewQuestion` 패키지 전체 테스트 통과 확인

Closes #422