### PR TITLE
[#424]; 평가 시 isLocked 필드 업데이트

### DIFF
--- a/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/business/InterviewEvaluationService.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/business/InterviewEvaluationService.kt
@@ -7,6 +7,7 @@ import com.yourssu.scouter.recruiting.evaluation.business.dto.*
 import com.yourssu.scouter.recruiting.evaluation.implement.*
 import com.yourssu.scouter.recruiting.rubric.implement.InterviewRubric
 import com.yourssu.scouter.recruiting.rubric.implement.InterviewRubricReader
+import com.yourssu.scouter.recruiting.rubric.implement.InterviewRubricWriter
 import com.yourssu.scouter.recruiting.rubric.implement.RubricGroupType
 import com.yourssu.scouter.recruiting.support.business.EvaluatorDirectory
 import com.yourssu.scouter.recruiting.support.implement.exception.InterviewEvaluationInvalidScoreException
@@ -23,6 +24,7 @@ class InterviewEvaluationService(
     private val finalEvaluationReader: FinalEvaluationReader,
     private val finalEvaluationWriter: FinalEvaluationWriter,
     private val interviewRubricReader: InterviewRubricReader,
+    private val interviewRubricWriter: InterviewRubricWriter,
     private val applicantReader: ApplicantReader,
     private val userReader: UserReader,
     private val evaluatorDirectory: EvaluatorDirectory,
@@ -85,6 +87,10 @@ class InterviewEvaluationService(
         )
 
         val savedEvaluation = interviewEvaluationWriter.write(evaluation)
+
+        if (!rubric.isLocked) {
+            interviewRubricWriter.save(rubric.lock())
+        }
 
         val existingFinal = finalEvaluationReader.readByApplicantIdAndEvaluatorUserId(
             command.applicantId,

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/rubric/implement/InterviewRubric.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/rubric/implement/InterviewRubric.kt
@@ -32,6 +32,17 @@ class InterviewRubric(
     }
 
 
+    fun lock(): InterviewRubric {
+        return InterviewRubric(
+            id = this.id,
+            partId = this.partId,
+            semester = this.semester,
+            deadline = this.deadline,
+            isLocked = true,
+            items = this.items,
+        )
+    }
+
     fun update(
         semester: Semester,
         deadline: Instant,


### PR DESCRIPTION
## 📄 작업 내용 요약
- 평가 시 해당 파트의 isLocked 필드를 1로 업데이트 하여 다른 필드간 결과 중복이 이루어지지 않게 합니다. 

## 📎 Issue 번호
closed #424 