### PR TITLE
[#419]; feat: 면접 개인 질문지 잠금 정책 구현

### DIFF
--- a/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/implement/InterviewEvaluationReader.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/implement/InterviewEvaluationReader.kt
@@ -23,4 +23,8 @@ class InterviewEvaluationReader(
     fun existsByInterviewEvaluationItemIdIn(itemIds: List<Long>): Boolean {
         return interviewEvaluationRepository.existsByInterviewEvaluationItemIdIn(itemIds)
     }
+
+    fun existsByApplicantId(applicantId: Long): Boolean {
+        return interviewEvaluationRepository.existsByApplicantId(applicantId)
+    }
 }

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/implement/InterviewEvaluationRepository.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/implement/InterviewEvaluationRepository.kt
@@ -6,4 +6,5 @@ interface InterviewEvaluationRepository {
     fun findAllByApplicantId(applicantId: Long): List<InterviewEvaluation>
     fun findAllByApplicantIdIn(applicantIds: List<Long>): List<InterviewEvaluation>
     fun existsByInterviewEvaluationItemIdIn(itemIds: List<Long>): Boolean
+    fun existsByApplicantId(applicantId: Long): Boolean
 }

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/storage/InterviewEvaluationRepositoryImpl.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/storage/InterviewEvaluationRepositoryImpl.kt
@@ -70,6 +70,10 @@ class InterviewEvaluationRepositoryImpl(
         return jpaInterviewEvaluationRepository.existsByInterviewEvaluationItemIdIn(itemIds)
     }
 
+    override fun existsByApplicantId(applicantId: Long): Boolean {
+        return jpaInterviewEvaluationRepository.existsByApplicantId(applicantId)
+    }
+
     private fun toDomain(
         applicantId: Long,
         evaluatorUserId: Long,

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/storage/JpaInterviewEvaluationRepository.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/storage/JpaInterviewEvaluationRepository.kt
@@ -7,4 +7,5 @@ interface JpaInterviewEvaluationRepository : JpaRepository<InterviewEvaluationEn
     fun findAllByApplicantId(applicantId: Long): List<InterviewEvaluationEntity>
     fun findAllByApplicantIdIn(applicantIds: List<Long>): List<InterviewEvaluationEntity>
     fun existsByInterviewEvaluationItemIdIn(itemIds: List<Long>): Boolean
+    fun existsByApplicantId(applicantId: Long): Boolean
 }

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/interviewQuestion/business/AssignedQuestionService.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/interviewQuestion/business/AssignedQuestionService.kt
@@ -3,6 +3,7 @@ package com.yourssu.scouter.recruiting.interviewQuestion.business
 import com.yourssu.scouter.auth.user.implement.UserReader
 import com.yourssu.scouter.recruiting.applicant.implement.Applicant
 import com.yourssu.scouter.recruiting.applicant.implement.ApplicantReader
+import com.yourssu.scouter.recruiting.evaluation.implement.InterviewEvaluationReader
 import com.yourssu.scouter.recruiting.interviewQuestion.business.dto.AssignedQuestionDto
 import com.yourssu.scouter.recruiting.interviewQuestion.business.dto.AssignedQuestionsDto
 import com.yourssu.scouter.recruiting.interviewQuestion.business.dto.QuestionRequirementDto
@@ -20,6 +21,7 @@ import com.yourssu.scouter.recruiting.interviewQuestion.implement.QuestionWriter
 import com.yourssu.scouter.recruiting.support.business.EvaluatorDirectory
 import com.yourssu.scouter.recruiting.support.business.InterviewRequirementLookup
 import com.yourssu.scouter.recruiting.support.business.InterviewRequirementProfile
+import com.yourssu.scouter.recruiting.support.implement.exception.AssignedQuestionLockedException
 import com.yourssu.scouter.recruiting.support.implement.exception.QuestionInvalidException
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -35,6 +37,7 @@ class AssignedQuestionService(
     private val userReader: UserReader,
     private val evaluatorDirectory: EvaluatorDirectory,
     private val interviewRequirementLookup: InterviewRequirementLookup,
+    private val interviewEvaluationReader: InterviewEvaluationReader,
 ) {
     fun readByApplicantId(applicantId: Long): AssignedQuestionsDto {
         val applicant = applicantReader.readById(applicantId)
@@ -61,6 +64,10 @@ class AssignedQuestionService(
         applicantId: Long,
         command: SaveAssignedQuestionsCommand,
     ): AssignedQuestionsDto {
+        if (interviewEvaluationReader.existsByApplicantId(applicantId)) {
+            throw AssignedQuestionLockedException("해당 지원자의 면접 평가가 존재해 질문지를 수정할 수 없습니다. applicantId=$applicantId")
+        }
+
         val applicant = applicantReader.readById(applicantId)
         val applicantPartId = applicant.part.id!!
         val applicantSemesterId = applicant.applicationSemester.id!!

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/support/implement/exception/AssignedQuestionLockedException.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/support/implement/exception/AssignedQuestionLockedException.kt
@@ -1,0 +1,8 @@
+package com.yourssu.scouter.recruiting.support.implement.exception
+
+import com.yourssu.scouter.common.exception.CustomException
+import org.springframework.http.HttpStatus
+
+class AssignedQuestionLockedException(
+    message: String,
+) : CustomException(message, "Question-007", HttpStatus.CONFLICT)

--- a/src/test/kotlin/com/yourssu/scouter/recruiting/interviewQuestion/business/AssignedQuestionServiceTest.kt
+++ b/src/test/kotlin/com/yourssu/scouter/recruiting/interviewQuestion/business/AssignedQuestionServiceTest.kt
@@ -9,12 +9,14 @@ import com.yourssu.scouter.masterdata.part.implement.fixture.PartFixtureBuilder
 import com.yourssu.scouter.masterdata.semester.implement.fixture.SemesterFixtureBuilder
 import com.yourssu.scouter.recruiting.applicant.implement.ApplicantReader
 import com.yourssu.scouter.recruiting.applicant.implement.fixture.ApplicantFixtureBuilder
+import com.yourssu.scouter.recruiting.evaluation.implement.InterviewEvaluationReader
 import com.yourssu.scouter.recruiting.interviewQuestion.business.dto.SaveAssignedQuestionCommand
 import com.yourssu.scouter.recruiting.interviewQuestion.business.dto.SaveAssignedQuestionsCommand
 import com.yourssu.scouter.recruiting.interviewQuestion.implement.*
 import com.yourssu.scouter.recruiting.support.business.EvaluatorDirectory
 import com.yourssu.scouter.recruiting.support.business.EvaluatorInfo
 import com.yourssu.scouter.recruiting.support.business.InterviewRequirementLookup
+import com.yourssu.scouter.recruiting.support.implement.exception.AssignedQuestionLockedException
 import com.yourssu.scouter.recruiting.support.implement.exception.QuestionInvalidException
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
@@ -39,6 +41,7 @@ class AssignedQuestionServiceTest {
     private lateinit var userReader: UserReader
     private lateinit var evaluatorDirectory: EvaluatorDirectory
     private lateinit var interviewRequirementLookup: InterviewRequirementLookup
+    private lateinit var interviewEvaluationReader: InterviewEvaluationReader
     private lateinit var assignedQuestionService: AssignedQuestionService
 
     private val applicantId = 1L
@@ -54,6 +57,7 @@ class AssignedQuestionServiceTest {
         userReader = mock(UserReader::class.java)
         evaluatorDirectory = mock(EvaluatorDirectory::class.java)
         interviewRequirementLookup = mock(InterviewRequirementLookup::class.java)
+        interviewEvaluationReader = mock(InterviewEvaluationReader::class.java)
 
         assignedQuestionService = AssignedQuestionService(
             assignedQuestionReader,
@@ -65,8 +69,10 @@ class AssignedQuestionServiceTest {
             userReader,
             evaluatorDirectory,
             interviewRequirementLookup,
+            interviewEvaluationReader,
         )
 
+        whenever(interviewEvaluationReader.existsByApplicantId(any())).thenReturn(false)
         whenever(applicantReader.readById(applicantId)).thenReturn(
             ApplicantFixtureBuilder()
                 .id(applicantId)
@@ -449,6 +455,27 @@ class AssignedQuestionServiceTest {
 
         assertThatThrownBy { assignedQuestionService.upsert(applicantId, command) }
             .isInstanceOf(QuestionInvalidException::class.java)
+    }
+
+    @Test
+    fun `제출된 면접 평가가 있으면 질문지 수정 시 예외를 발생시킨다`() {
+        val interviewerUserId = 100L
+        whenever(interviewEvaluationReader.existsByApplicantId(applicantId)).thenReturn(true)
+
+        val command = SaveAssignedQuestionsCommand(
+            questions = listOf(
+                SaveAssignedQuestionCommand(
+                    assignedInterviewerUserId = interviewerUserId,
+                    sourceQuestionId = 1L,
+                    content = null,
+                    category = AssignedQuestionCategory.CULTURE,
+                    isSelected = true,
+                ),
+            ),
+        )
+
+        assertThatThrownBy { assignedQuestionService.upsert(applicantId, command) }
+            .isInstanceOf(AssignedQuestionLockedException::class.java)
     }
 
     private fun assignedCultureQuestion(


### PR DESCRIPTION
## 📄 작업 내용 요약
- 제출된 면접 평가가 있는 지원자는 개인 질문지(AssignedQuestion) 전체 수정을 막도록 잠금 정책을 추가했습니다.
- 공통 루브릭 잠금(`InterviewRubricService.upsert`)과 동일하게, `AssignedQuestionService.upsert` 진입점에서 `applicantId` 기준으로 평가 존재 여부를 검사합니다. PERSONAL 카테고리 항목뿐 아니라 질문지 전체(PUT `/applicants/{applicantId}/interviews/questions`)를 잠그며, 이는 upsert가 유일한 수정 경로이기 때문입니다.
- `InterviewEvaluationRepository`에 `existsByApplicantId` 조회를 추가하고, 잠금 시 `AssignedQuestionLockedException`(Question-007, 409)을 던지도록 했습니다.

## 📎 Issue 번호
closed #419