### PR TITLE
[#429] 코멘트 응답 memberId → userId 전환, createdAt non-null화

### DIFF
--- a/src/main/kotlin/com/yourssu/scouter/recruiting/comment/application/dto/ReadDocumentCommentResponse.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/comment/application/dto/ReadDocumentCommentResponse.kt
@@ -9,12 +9,12 @@ import java.time.Instant
 data class ReadDocumentCommentAuthorResponse(
 
     @field:Schema(
-        description = "작성자 회원의 ID (동아리 부원 ID)",
+        description = "작성자 유저 ID",
         example = "101",
-        types = ["integer", "null"],
+        types = ["integer"],
         format = "int64",
     )
-    val memberId: Long?,
+    val userId: Long,
 
     @field:Schema(
         description = "작성자 닉네임 (영어 닉네임 또는 이름)",
@@ -32,7 +32,7 @@ data class ReadDocumentCommentAuthorResponse(
 ) {
     companion object {
         fun from(dto: DocumentCommentAuthorDto): ReadDocumentCommentAuthorResponse =
-            ReadDocumentCommentAuthorResponse(dto.memberId, dto.nickname, dto.part)
+            ReadDocumentCommentAuthorResponse(dto.userId, dto.nickname, dto.part)
     }
 }
 
@@ -43,7 +43,7 @@ data class ReadDocumentCommentResponse(
     val author: ReadDocumentCommentAuthorResponse,
     val parentCommentId: Long?,
     val isEdited: Boolean,
-    val createdAt: Instant?,
+    val createdAt: Instant,
 ) {
     companion object {
         fun from(dto: DocumentCommentDto): ReadDocumentCommentResponse = ReadDocumentCommentResponse(

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/comment/business/DocumentCommentService.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/comment/business/DocumentCommentService.kt
@@ -117,7 +117,7 @@ class DocumentCommentService(
         val info = evaluatorDirectory.findEvaluatorInfo(user.userInfo.email)
 
         return DocumentCommentAuthorDto(
-            memberId = info?.memberId,
+            userId = userId,
             nickname = info?.nicknameEnglish ?: user.userInfo.name,
             part = info?.partName ?: "",
         )

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/comment/business/dto/DocumentCommentDto.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/comment/business/dto/DocumentCommentDto.kt
@@ -4,7 +4,7 @@ import com.yourssu.scouter.recruiting.comment.implement.DocumentComment
 import java.time.Instant
 
 data class DocumentCommentAuthorDto(
-    val memberId: Long?,
+    val userId: Long,
     val nickname: String,
     val part: String,
 )
@@ -16,7 +16,7 @@ data class DocumentCommentDto(
     val author: DocumentCommentAuthorDto,
     val parentCommentId: Long?,
     val isEdited: Boolean,
-    val createdAt: Instant?,
+    val createdAt: Instant,
 ) {
     companion object {
         fun of(comment: DocumentComment, author: DocumentCommentAuthorDto): DocumentCommentDto = DocumentCommentDto(

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/comment/implement/DocumentComment.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/comment/implement/DocumentComment.kt
@@ -11,7 +11,7 @@ class DocumentComment(
     val parentCommentId: Long? = null,
     val category: CommentCategory = CommentCategory.DOCUMENT,
     val isEdited: Boolean = false,
-    val createdAt: Instant? = null,
+    val createdAt: Instant = Instant.now(),
 ) {
 
     val isReply: Boolean

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/comment/storage/DocumentCommentEntity.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/comment/storage/DocumentCommentEntity.kt
@@ -61,7 +61,7 @@ class DocumentCommentEntity(
         parentCommentId = parentCommentId,
         category = category,
         isEdited = isEdited,
-        createdAt = createdAt,
+        createdAt = createdAt!!,
     )
 
     override fun equals(other: Any?): Boolean {

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/comment/storage/DocumentCommentEntity.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/comment/storage/DocumentCommentEntity.kt
@@ -49,7 +49,7 @@ class DocumentCommentEntity(
 
     @CreatedDate
     @Column(nullable = false, updatable = false)
-    var createdAt: Instant? = null
+    var createdAt: Instant = Instant.now()
         protected set
 
     fun toDomain(): DocumentComment = DocumentComment(
@@ -61,7 +61,7 @@ class DocumentCommentEntity(
         parentCommentId = parentCommentId,
         category = category,
         isEdited = isEdited,
-        createdAt = createdAt!!,
+        createdAt = createdAt,
     )
 
     override fun equals(other: Any?): Boolean {

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/interview/application/dto/ReadInterviewCommentResponse.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/interview/application/dto/ReadInterviewCommentResponse.kt
@@ -60,10 +60,10 @@ data class ReadInterviewCommentResponse(
     @field:Schema(
         description = "작성 일시",
         example = "2026-08-19T03:00:00Z",
-        types = ["string", "null"],
+        types = ["string"],
         format = "date-time",
     )
-    val createdAt: Instant?,
+    val createdAt: Instant,
 ) {
     companion object {
         fun from(dto: DocumentCommentDto): ReadInterviewCommentResponse = ReadInterviewCommentResponse(

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/interview/business/InterviewCommentService.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/interview/business/InterviewCommentService.kt
@@ -92,7 +92,7 @@ class InterviewCommentService(
         val info = evaluatorDirectory.findEvaluatorInfo(user.userInfo.email)
 
         return DocumentCommentAuthorDto(
-            memberId = info?.memberId,
+            userId = userId,
             nickname = info?.nicknameEnglish ?: user.userInfo.name,
             part = info?.partName ?: "",
         )


### PR DESCRIPTION
## 요약
- Closes #429
- 서류/면접 코멘트 응답의 작성자 식별자를 `memberId`(nullable) → `userId`(non-null)로 전환
  - 멤버 조회 API가 userId를 노출하는 방향으로 정책이 바뀌어 더 이상 memberId로 우회할 필요가 없어짐
  - 기존 memberId는 user <> member가 1:1 대응되지 않아 nullable일 수밖에 없었음
- `createdAt`을 non-null로 수정
  - DB 컬럼(`document_comment.created_at`)은 원래 `NOT NULL`인데, 생성 이전에 있던 엔티티가 재사용되며 Kotlin 타입만 nullable로 역전파되어 있던 것을 바로잡음

## 변경 범위
- `DocumentComment` (도메인), `DocumentCommentEntity`
- `DocumentCommentDto`, `DocumentCommentAuthorDto`
- `DocumentCommentService`, `InterviewCommentService`
- `ReadDocumentCommentResponse`, `ReadInterviewCommentResponse`
- 위 타입을 재사용하는 서류평가 조회 응답(`ReadEvaluationViewResponse`)도 영향 범위에 포함

## 테스트
- [x] `./gradlew compileKotlin` / `compileTestKotlin` 통과
- [ ] `./gradlew test` — 이번 변경과 무관한 기존 실패(로컬 환경에 `applicant-sync-mapping-data.yml` 리소스 부재로 인한 ApplicationContext 로드 실패) 존재. 코멘트 관련 테스트는 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EgYwbkTpEtpFGenE3b7nG5