### PR TITLE
[#432] feat: 내 정보 응답에 멤버 조회 응답을 포함하도록 개선

### DIFF
--- a/src/main/kotlin/com/yourssu/scouter/member/core/application/dto/MeResponse.kt
+++ b/src/main/kotlin/com/yourssu/scouter/member/core/application/dto/MeResponse.kt
@@ -1,70 +1,20 @@
 package com.yourssu.scouter.member.core.application.dto
 
 import com.yourssu.scouter.member.core.business.dto.MeResult
-import com.yourssu.scouter.member.support.converter.MemberRoleConverter
-import com.yourssu.scouter.member.support.converter.MemberStateConverter
-import com.yourssu.scouter.member.support.converter.NicknameConverter
 import io.swagger.v3.oas.annotations.media.Schema
-import java.time.Instant
-import java.time.LocalDate
 
 @Schema(description = "내 정보 응답")
 data class MeResponse(
     @field:Schema(description = "구글 프로필 이미지 URL")
     val profileImageUrl: String,
-    @field:Schema(description = "멤버 ID", example = "1")
-    val memberId: Long,
-    @field:Schema(description = "이름", example = "홍길동")
-    val name: String,
-    @field:Schema(description = "이메일", example = "hong@soongsil.ac.kr")
-    val email: String,
-    @field:Schema(description = "전화번호", example = "010-1234-5678")
-    val phoneNumber: String,
-    @field:Schema(description = "생년월일", example = "2000-01-01")
-    val birthDate: LocalDate,
-    @field:Schema(description = "학과", example = "컴퓨터학부")
-    val department: String,
-    @field:Schema(description = "학번", example = "20210001")
-    val studentId: String,
-    @field:Schema(description = "소속 파트 목록")
-    val parts: List<ReadDivisionAndPartInMemberResponse>,
-    @field:Schema(description = "역할", example = "MEMBER")
-    val role: String,
-    @field:Schema(description = "닉네임", example = "piki(피키)")
-    val nickname: String,
-    @field:Schema(description = "상태", example = "활동")
-    val state: String,
-    @field:Schema(description = "가입일", example = "2024-03-01")
-    val joinDate: LocalDate,
-    @field:Schema(description = "상태 변경 시간")
-    val stateUpdatedTime: Instant,
-    @field:Schema(description = "생성 시간")
-    val createdTime: Instant,
-    @field:Schema(description = "수정 시간")
-    val updatedTime: Instant,
+    @field:Schema(description = "멤버 조회 응답")
+    val member: MemberResponse,
 ) {
 
     companion object {
         fun from(result: MeResult): MeResponse = MeResponse(
             profileImageUrl = result.profileImageUrl,
-            memberId = result.member.id,
-            name = result.member.name,
-            email = result.member.email,
-            phoneNumber = result.member.phoneNumber,
-            birthDate = result.member.birthDate,
-            department = result.member.department.name,
-            studentId = result.member.studentId,
-            parts = result.member.parts.map { ReadDivisionAndPartInMemberResponse.from(it) },
-            role = MemberRoleConverter.convertToString(result.member.role),
-            nickname = NicknameConverter.combine(
-                nicknameEnglish = result.member.nicknameEnglish,
-                nicknameKorean = result.member.nicknameKorean,
-            ),
-            state = MemberStateConverter.convertToString(result.member.state),
-            joinDate = result.member.joinDate,
-            stateUpdatedTime = result.member.stateUpdatedTime,
-            createdTime = result.member.createdTime,
-            updatedTime = result.member.updatedTime,
+            member = MemberResponse.from(result.member),
         )
     }
 }

--- a/src/main/kotlin/com/yourssu/scouter/member/core/application/dto/MemberResponse.kt
+++ b/src/main/kotlin/com/yourssu/scouter/member/core/application/dto/MemberResponse.kt
@@ -1,0 +1,70 @@
+package com.yourssu.scouter.member.core.application.dto
+
+import com.yourssu.scouter.member.core.business.dto.MemberDto
+import com.yourssu.scouter.member.support.converter.MemberRoleConverter
+import com.yourssu.scouter.member.support.converter.MemberStateConverter
+import com.yourssu.scouter.member.support.converter.NicknameConverter
+import io.swagger.v3.oas.annotations.media.Schema
+import java.time.Instant
+import java.time.LocalDate
+
+@Schema(description = "멤버 조회 응답")
+data class MemberResponse(
+    @field:Schema(description = "멤버 ID", example = "1")
+    val memberId: Long,
+    @field:Schema(description = "로그인 user id", example = "12", types = ["Long", "null"])
+    val userId: Long?,
+    @field:Schema(description = "이름", example = "홍길동")
+    val name: String,
+    @field:Schema(description = "이메일", example = "hong@soongsil.ac.kr")
+    val email: String,
+    @field:Schema(description = "전화번호", example = "010-1234-5678")
+    val phoneNumber: String,
+    @field:Schema(description = "생년월일", example = "2000-01-01")
+    val birthDate: LocalDate,
+    @field:Schema(description = "학과", example = "컴퓨터학부")
+    val department: String,
+    @field:Schema(description = "학번", example = "20210001")
+    val studentId: String,
+    @field:Schema(description = "소속 파트 목록")
+    val parts: List<ReadDivisionAndPartInMemberResponse>,
+    @field:Schema(description = "역할", example = "MEMBER")
+    val role: String,
+    @field:Schema(description = "닉네임", example = "piki(피키)")
+    val nickname: String,
+    @field:Schema(description = "상태", example = "활동")
+    val state: String,
+    @field:Schema(description = "가입일", example = "2024-03-01")
+    val joinDate: LocalDate,
+    @field:Schema(description = "상태 변경 시간")
+    val stateUpdatedTime: Instant,
+    @field:Schema(description = "생성 시간")
+    val createdTime: Instant,
+    @field:Schema(description = "수정 시간")
+    val updatedTime: Instant,
+) {
+
+    companion object {
+        fun from(member: MemberDto): MemberResponse = MemberResponse(
+            memberId = member.id,
+            userId = member.userId,
+            name = member.name,
+            email = member.email,
+            phoneNumber = member.phoneNumber,
+            birthDate = member.birthDate,
+            department = member.department.name,
+            studentId = member.studentId,
+            parts = member.parts.map { ReadDivisionAndPartInMemberResponse.from(it) },
+            role = MemberRoleConverter.convertToString(member.role),
+            nickname = NicknameConverter.combine(
+                nicknameEnglish = member.nicknameEnglish,
+                nicknameKorean = member.nicknameKorean,
+            ),
+            state = MemberStateConverter.convertToString(member.state),
+            joinDate = member.joinDate,
+            stateUpdatedTime = member.stateUpdatedTime,
+            createdTime = member.createdTime,
+            updatedTime = member.updatedTime,
+        )
+    }
+}


### PR DESCRIPTION
## 작업 내용
- close #432
- 멤버 조회 응답에 재사용 가능한 공용 `MemberResponse` DTO를 신설했습니다 (`userId` 포함).
- `MeResponse`가 개별 필드를 직접 갖는 대신 `member: MemberResponse` 필드를 갖도록 변경했습니다.

## 이유
- `GET /members/me` 응답에서 로그인 유저의 `userId`를 함께 조회할 수 있도록 하기 위함입니다.
- Me 응답과 멤버 조회 응답의 필드가 항상 동기화되도록 하기 위함입니다.

## 변경 전/후
```diff
- MeResponse(profileImageUrl, memberId, name, email, ...)
+ MeResponse(profileImageUrl, member: MemberResponse(memberId, userId, name, email, ...))
```

## Test plan
- [x] `compileKotlin`, `compileTestKotlin` 통과
- [x] `MeServiceTest`, `LoginServiceTest` 통과
- [ ] 스웨거 스펙 변경에 따른 프론트엔드 연동 확인 필요 (breaking change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)