### PR TITLE
[#431]; 서류/면접 평가 데드라인 수정 페이지 구현

### DIFF
--- a/src/main/kotlin/com/yourssu/scouter/admin/AdminDeadlineController.kt
+++ b/src/main/kotlin/com/yourssu/scouter/admin/AdminDeadlineController.kt
@@ -1,0 +1,129 @@
+package com.yourssu.scouter.admin
+
+import com.yourssu.scouter.masterdata.part.business.PartService
+import com.yourssu.scouter.masterdata.support.converter.SemesterConverter
+import com.yourssu.scouter.recruiting.deadline.business.PartDocumentDeadlineService
+import com.yourssu.scouter.recruiting.rubric.business.InterviewRubricService
+import org.springframework.http.ResponseEntity
+import org.springframework.stereotype.Controller
+import org.springframework.ui.Model
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.ResponseBody
+import java.time.Instant
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+
+@Controller
+@RequestMapping("/admin/recruiting/deadlines")
+class AdminDeadlineController(
+    private val partService: PartService,
+    private val partDocumentDeadlineService: PartDocumentDeadlineService,
+    private val interviewRubricService: InterviewRubricService,
+) {
+
+    data class DeadlineDetail(
+        val rawInstant: Instant?,
+        val formattedInput: String?,
+    )
+
+    data class PartDeadlineItem(
+        val partId: Long,
+        val partName: String,
+        val divisionName: String,
+        val documentDeadline: DeadlineDetail,
+        val interviewDeadline: DeadlineDetail,
+        val interviewError: String? = null,
+    )
+
+    @GetMapping
+    fun deadlinePage(
+        @RequestParam(required = false) semester: String?,
+        model: Model,
+    ): String {
+        val resolvedSemester = semester ?: SemesterConverter.convertToIntString(LocalDate.now())
+        val parts = partService.readAll().partDtos
+
+        val items = parts.map { part ->
+            val docDeadlineInstant = runCatching {
+                partDocumentDeadlineService.readByPartId(part.id).deadline
+            }.getOrNull()
+
+            var interviewErrorMsg: String? = null
+            val intDeadlineInstant = runCatching {
+                interviewRubricService.readDeadline(part.id, resolvedSemester)
+            }.onFailure {
+                interviewErrorMsg = it.message ?: "면접 루브릭 미생성"
+            }.getOrNull()
+
+            PartDeadlineItem(
+                partId = part.id,
+                partName = part.name,
+                divisionName = part.division.name,
+                documentDeadline = DeadlineDetail(docDeadlineInstant, formatForInput(docDeadlineInstant)),
+                interviewDeadline = DeadlineDetail(intDeadlineInstant, formatForInput(intDeadlineInstant)),
+                interviewError = interviewErrorMsg,
+            )
+        }
+
+        model.addAttribute("semester", resolvedSemester)
+        model.addAttribute("items", items)
+
+        return "admin/deadlines"
+    }
+
+    @PostMapping("/documents")
+    @ResponseBody
+    fun updateDocumentDeadline(
+        @RequestParam partId: Long,
+        @RequestParam deadline: String,
+    ): ResponseEntity<Map<String, Any?>> {
+        return runCatching {
+            val instant = parseToInstant(deadline)
+            partDocumentDeadlineService.upsert(partId, instant)
+        }.fold(
+            onSuccess = { ResponseEntity.ok(mapOf("success" to true)) },
+            onFailure = { ResponseEntity.badRequest().body(mapOf("error" to (it.message ?: "오류가 발생했습니다."))) },
+        )
+    }
+
+    @PostMapping("/interviews")
+    @ResponseBody
+    fun updateInterviewDeadline(
+        @RequestParam partId: Long,
+        @RequestParam semester: String,
+        @RequestParam deadline: String,
+    ): ResponseEntity<Map<String, Any?>> {
+        return runCatching {
+            val instant = parseToInstant(deadline)
+            interviewRubricService.updateDeadline(partId, semester, instant)
+        }.fold(
+            onSuccess = { ResponseEntity.ok(mapOf("success" to true)) },
+            onFailure = { ResponseEntity.badRequest().body(mapOf("error" to (it.message ?: "오류가 발생했습니다."))) },
+        )
+    }
+
+    private fun formatForInput(instant: Instant?): String? {
+        if (instant == null) return null
+        return DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm")
+            .withZone(SEOUL_ZONE)
+            .format(instant)
+    }
+
+    private fun parseToInstant(dateTimeStr: String): Instant {
+        val trimmed = dateTimeStr.trim()
+        return runCatching { Instant.parse(trimmed) }
+            .getOrElse {
+                val localDateTime = LocalDateTime.parse(trimmed)
+                localDateTime.atZone(SEOUL_ZONE).toInstant()
+            }
+    }
+
+    companion object {
+        private val SEOUL_ZONE = ZoneId.of("Asia/Seoul")
+    }
+}

--- a/src/main/resources/templates/admin/deadlines.html
+++ b/src/main/resources/templates/admin/deadlines.html
@@ -1,0 +1,336 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>SCOUTER ADMIN - 평가 데드라인 관리</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.0/font/bootstrap-icons.css">
+    <link rel="stylesheet" as="style" crossorigin href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/static/pretendard.min.css" />
+    <style>
+        * {
+            font-family: "Pretendard Variable", Pretendard, -apple-system, BlinkMacSystemFont, system-ui, Roboto, sans-serif;
+            letter-spacing: -0.01em;
+        }
+
+        body {
+            background-color: #f7f9fb;
+            color: #1e293b;
+        }
+
+        /* 메인 컨테이너 */
+        .scouter-wrapper {
+            max-width: 1080px;
+            padding: 40px 48px;
+        }
+
+        /* 상단 네비게이션 헤더 */
+        .page-header {
+            margin-bottom: 28px;
+        }
+        .page-title {
+            font-size: 1.5rem;
+            font-weight: 700;
+            color: #0f172a;
+            letter-spacing: -0.02em;
+        }
+
+        /* 레퍼런스 스타일 라운드 카드 */
+        .deadline-card {
+            background: #ffffff;
+            border: 1px solid #eef2f6;
+            border-radius: 18px;
+            padding: 26px 30px;
+            margin-bottom: 20px;
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.02);
+            transition: all 0.2s ease;
+        }
+        .deadline-card:hover {
+            border-color: #e2e8f0;
+            box-shadow: 0 4px 16px rgba(0, 0, 0, 0.04);
+        }
+
+        /* 레퍼런스 퍼플 넘버 배지 */
+        .num-badge {
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            min-width: 28px;
+            height: 28px;
+            padding: 0 8px;
+            border-radius: 8px;
+            background-color: #f1f3fe;
+            color: #6366f1;
+            font-weight: 700;
+            font-size: 0.85rem;
+        }
+
+        /* 소프트 뱃지 (HR, 운영 등) */
+        .badge-pill-soft {
+            background-color: #f1f5f9;
+            color: #475569;
+            font-weight: 600;
+            font-size: 0.8rem;
+            padding: 4px 10px;
+            border-radius: 6px;
+        }
+
+        /* 입력 그룹 컨테이너 박스 */
+        .field-group-card {
+            background-color: #fafbfc;
+            border: 1px solid #f1f4f8;
+            border-radius: 12px;
+            padding: 16px 18px;
+        }
+
+        .field-label {
+            font-size: 0.88rem;
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 10px;
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+        }
+
+        /* 인풋 폼 스타일링 */
+        .form-control-custom {
+            background-color: #ffffff;
+            border: 1px solid #e2e8f0;
+            border-radius: 8px;
+            padding: 8px 12px;
+            font-size: 0.88rem;
+            color: #334155;
+            transition: border-color 0.15s ease;
+        }
+        .form-control-custom:focus {
+            background-color: #ffffff;
+            border-color: #6366f1;
+            box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.1);
+            outline: none;
+        }
+
+        /* 세련된 저장 버튼 */
+        .btn-save {
+            background-color: #0f172a;
+            color: #ffffff;
+            font-weight: 500;
+            font-size: 0.82rem;
+            border-radius: 8px;
+            padding: 8px 14px;
+            border: none;
+            transition: background 0.15s ease;
+        }
+        .btn-save:hover {
+            background-color: #334155;
+            color: #ffffff;
+        }
+
+        /* 현재 설정 텍스트 */
+        .current-status {
+            font-size: 0.78rem;
+            color: #64748b;
+            margin-top: 8px;
+        }
+        .current-status b {
+            color: #0f172a;
+            font-weight: 600;
+        }
+
+        /* 토스트 알림 */
+        .save-toast {
+            position: fixed;
+            bottom: 28px;
+            right: 28px;
+            z-index: 9999;
+        }
+        .custom-toast {
+            border-radius: 12px;
+            padding: 12px 18px;
+            font-size: 0.9rem;
+            box-shadow: 0 10px 25px rgba(0,0,0,0.1);
+        }
+    </style>
+    <link rel="icon" type="image/svg+xml" href="/images/logo.svg">
+</head>
+<body class="d-flex min-vh-100">
+
+<!-- 사이드바 인클루드 -->
+<div th:replace="~{admin/fragments/nav :: sidebar}" th:with="currentMenu='deadlines'"></div>
+
+<!-- 메인 컨텐츠 영역 -->
+<div class="flex-grow-1 scouter-wrapper">
+
+    <!-- 상단 페이지 헤더 -->
+    <div class="page-header d-flex justify-content-between align-items-center flex-wrap gap-3">
+        <div>
+            <div class="d-flex align-items-center gap-2 mb-1">
+                <span class="num-badge">Recruit</span>
+                <h2 class="page-title mb-0">평가 데드라인 관리</h2>
+            </div>
+            <p class="text-muted small mb-0 ps-1">파트별 서류 평가 및 면접 평가 마감일을 설정합니다.</p>
+        </div>
+
+        <div class="d-flex align-items-center gap-2 bg-white p-2 rounded-3 border" style="border-color: #eef2f6 !important;">
+            <span class="text-muted small ps-1" style="font-size: 0.8rem; font-weight: 600;">적용 학기</span>
+            <input type="text" id="semester-input" class="form-control-custom py-1 px-2" style="width: 100px; font-size: 0.85rem;" th:value="${semester}" placeholder="예: 2026-1">
+            <button type="button" class="btn-save py-1 px-3" onclick="location.href='/admin/recruiting/deadlines?semester=' + encodeURIComponent(document.getElementById('semester-input').value)">학기 변경</button>
+        </div>
+    </div>
+
+    <!-- 카드 리스트 영역 -->
+    <div class="deadline-container">
+        <div th:each="item, stat : ${items}" class="deadline-card">
+
+            <!-- 파트 타이틀 바 -->
+            <div class="d-flex align-items-center justify-content-between mb-3">
+                <div class="d-flex align-items-center gap-2">
+                    <span class="num-badge" th:text="${stat.count < 10 ? '0' + stat.count : stat.count}">01</span>
+                    <span class="badge-pill-soft" th:text="${item.divisionName}">운영</span>
+                    <h5 class="mb-0 fw-bold" style="color: #0f172a; font-size: 1.05rem;" th:text="${item.partName}">Head lead</h5>
+                </div>
+                <span class="text-muted small" style="font-size: 0.78rem;">파트 ID <span th:text="${item.partId}">1</span></span>
+            </div>
+
+            <!-- 서류 / 면접 2열 배치 -->
+            <div class="row g-3">
+                <!-- 1. 서류 평가 데드라인 -->
+                <div class="col-md-6">
+                    <div class="field-group-card h-100 d-flex flex-column justify-content-between">
+                        <div>
+                            <div class="field-label">
+                                <span><i class="bi bi-file-text me-1 text-primary"></i> 서류 평가 마감일</span>
+                            </div>
+                            <div class="d-flex gap-2">
+                                <input type="datetime-local" class="form-control form-control-custom"
+                                       th:id="'doc-deadline-' + ${item.partId}"
+                                       th:value="${item.documentDeadline.formattedInput}">
+                                <button class="btn-save text-nowrap" type="button"
+                                        th:onclick="'saveDocumentDeadline(' + ${item.partId} + ')'">
+                                    저장
+                                </button>
+                            </div>
+                        </div>
+                        <div class="current-status">
+                            현재 설정: <b th:text="${item.documentDeadline.formattedInput != null ? item.documentDeadline.formattedInput : '미설정'}">2026-07-26T08:59</b>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- 2. 면접 평가 데드라인 -->
+                <div class="col-md-6">
+                    <div th:if="${item.interviewError == null}" class="field-group-card h-100 d-flex flex-column justify-content-between">
+                        <div>
+                            <div class="field-label">
+                                <span><i class="bi bi-chat-square-text me-1 text-primary"></i> 면접 평가 마감일 (<span th:text="${semester}">26-2</span>)</span>
+                            </div>
+                            <div class="d-flex gap-2">
+                                <input type="datetime-local" class="form-control form-control-custom"
+                                       th:id="'int-deadline-' + ${item.partId}"
+                                       th:value="${item.interviewDeadline.formattedInput}">
+                                <button class="btn-save text-nowrap" type="button"
+                                        th:onclick="'saveInterviewDeadline(' + ${item.partId} + ')'">
+                                    저장
+                                </button>
+                            </div>
+                        </div>
+                        <div class="current-status">
+                            현재 설정: <b th:text="${item.interviewDeadline.formattedInput != null ? item.interviewDeadline.formattedInput : '미설정'}">2026-10-08T23:50</b>
+                        </div>
+                    </div>
+
+                    <!-- 루브릭 미작성 fallback -->
+                    <div th:if="${item.interviewError != null}" class="field-group-card h-100 d-flex flex-column justify-content-center" style="background-color: #fafafa;">
+                        <div class="d-flex align-items-center gap-2 mb-1">
+                            <span class="badge" style="background-color: #fef3c7; color: #b45309; font-weight: 600; font-size: 0.75rem;">면접 루브릭 미생성</span>
+                        </div>
+                        <span class="text-muted" style="font-size: 0.8rem;">해당 학기의 면접 요구조건이 먼저 등록되어야 합니다.</span>
+                    </div>
+                </div>
+            </div>
+
+        </div>
+    </div>
+</div>
+
+<!-- 알림 Toast -->
+<div class="save-toast">
+    <div id="toast" class="toast custom-toast align-items-center border-0 text-bg-dark" role="alert">
+        <div class="d-flex align-items-center">
+            <div class="toast-body p-0 pe-2" id="toast-message"></div>
+            <button type="button" class="btn-close btn-close-white ms-auto" data-bs-dismiss="toast"></button>
+        </div>
+    </div>
+</div>
+
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+<script th:inline="javascript">
+    const SEMESTER = /*[[${semester}]]*/ '';
+
+    async function saveDocumentDeadline(partId) {
+        const input = document.getElementById('doc-deadline-' + partId);
+        const deadlineVal = input.value;
+        if (!deadlineVal) {
+            showToast('✕ 마감일 날짜 및 시간을 입력해 주세요.', true);
+            return;
+        }
+
+        const params = new URLSearchParams();
+        params.append('partId', partId);
+        params.append('deadline', deadlineVal);
+
+        try {
+            const res = await fetch('/admin/recruiting/deadlines/documents', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+                body: params
+            });
+            const data = await res.json();
+            if (data.success) {
+                showToast('✓ 서류 평가 마감일이 저장되었습니다.');
+            } else {
+                showToast('✕ ' + (data.error || '저장에 실패했습니다.'), true);
+            }
+        } catch (e) {
+            showToast('✕ 오류가 발생했습니다.', true);
+        }
+    }
+
+    async function saveInterviewDeadline(partId) {
+        const input = document.getElementById('int-deadline-' + partId);
+        const deadlineVal = input.value;
+        if (!deadlineVal) {
+            showToast('✕ 마감일 날짜 및 시간을 입력해 주세요.', true);
+            return;
+        }
+
+        const params = new URLSearchParams();
+        params.append('partId', partId);
+        params.append('semester', SEMESTER);
+        params.append('deadline', deadlineVal);
+
+        try {
+            const res = await fetch('/admin/recruiting/deadlines/interviews', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+                body: params
+            });
+            const data = await res.json();
+            if (data.success) {
+                showToast('✓ 면접 평가 마감일이 저장되었습니다.');
+            } else {
+                showToast('✕ ' + (data.error || '저장에 실패했습니다.'), true);
+            }
+        } catch (e) {
+            showToast('✕ 오류가 발생했습니다.', true);
+        }
+    }
+
+    function showToast(message, isError = false) {
+        const toast = document.getElementById('toast');
+        document.getElementById('toast-message').textContent = message;
+        toast.className = `toast custom-toast align-items-center border-0 ${isError ? 'text-bg-danger' : 'text-bg-dark'}`;
+        new bootstrap.Toast(toast, { delay: 2500 }).show();
+    }
+</script>
+</body>
+</html>

--- a/src/main/resources/templates/admin/fragments/nav.html
+++ b/src/main/resources/templates/admin/fragments/nav.html
@@ -93,6 +93,13 @@
                 전역 면접 질문
             </a>
         </li>
+        <li>
+            <a href="/admin/recruiting/deadlines"
+               th:classappend="${currentMenu == 'deadlines'} ? ' active' : ''"
+               class="admin-nav-link">
+                평가 데드라인 관리
+            </a>
+        </li>
     </ul>
 </nav>
 </th:block>


### PR DESCRIPTION
## 📄 작업 내용 요약
- hr 어드민 페이지에 서류, 면접 평가 데드라인 수정 페이지를 추가했습니다. 

<img width="2879" height="1412" alt="image" src="https://github.com/user-attachments/assets/cd51ef58-7293-4217-959a-ebc79f8ff151" />

- 아직 서류 평가 도메인에는 학기 정보가 없어서 따로 학기 정보를 명시하진 않았습니다. 

## 📎 Issue 번호
closed #431 
