### PR TITLE
[#439] feat: 파트별 면접 루브릭 초기화 API 추가

### DIFF
--- a/src/main/kotlin/com/yourssu/scouter/recruiting/rubric/application/DevRubricAdminController.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/rubric/application/DevRubricAdminController.kt
@@ -1,0 +1,63 @@
+package com.yourssu.scouter.recruiting.rubric.application
+
+import com.yourssu.scouter.auth.support.annotation.AuthUser
+import com.yourssu.scouter.auth.support.resolver.AuthUserInfo
+import com.yourssu.scouter.member.core.business.MemberPrivacyService
+import com.yourssu.scouter.member.support.exception.MemberAccessDeniedException
+import com.yourssu.scouter.recruiting.rubric.business.InterviewRubricService
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.validation.constraints.Pattern
+import org.springframework.context.annotation.Profile
+import org.springframework.http.ResponseEntity
+import org.springframework.validation.annotation.Validated
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RestController
+
+/**
+ * local, dev 프로필 전용. QA를 위해 파트/학기별 면접 루브릭을 초기화할 수 있게 함.
+ * 운영(prod) 환경에는 이 컨트롤러가 아예 등록되지 않는다.
+ */
+@Profile("local", "dev")
+@Tag(name = "[DEV] 면접 루브릭 초기화")
+@RestController
+@Validated
+class DevRubricAdminController(
+    private val interviewRubricService: InterviewRubricService,
+    private val memberPrivacyService: MemberPrivacyService,
+) {
+
+    @Operation(
+        summary = "면접 루브릭 초기화 (QA용)",
+        description = "해당 파트·학기의 면접 루브릭을 삭제합니다. 삭제 후에는 면접 요구조건 기반의 미저장 템플릿으로 다시 조회됩니다. " +
+            "해당 루브릭 항목을 참조하는 면접 평가가 남아있으면 초기화할 수 없습니다. 스카우터 팀원만 호출 가능.",
+    )
+    @ApiResponses(
+        ApiResponse(responseCode = "204", description = "삭제 성공"),
+        ApiResponse(responseCode = "403", description = "스카우터 팀원이 아님"),
+        ApiResponse(responseCode = "409", description = "해당 파트에 면접 평가가 존재해 초기화할 수 없음"),
+        ApiResponse(responseCode = "404", description = "파트를 찾을 수 없음"),
+    )
+    @DeleteMapping("/internal/dev/parts/{partId}/interviews/rubrics/{semester}")
+    fun resetByPartIdAndSemester(
+        @AuthUser authUserInfo: AuthUserInfo,
+        @Parameter(description = "파트 ID", example = "3") @PathVariable partId: Long,
+        @Parameter(description = "학기 식별자. YYYY-1 또는 YYYY-2 형식", example = "2026-1")
+        @PathVariable @Pattern(regexp = "^\\d{4}-[12]$", message = "semester must use YYYY-1 or YYYY-2 format") semester: String,
+    ): ResponseEntity<Unit> {
+        requireScouterTeamMember(authUserInfo.userId)
+        interviewRubricService.resetByPartIdAndSemester(partId, semester)
+
+        return ResponseEntity.noContent().build()
+    }
+
+    private fun requireScouterTeamMember(userId: Long) {
+        if (!memberPrivacyService.isScouterTeamMember(userId)) {
+            throw MemberAccessDeniedException("이 API는 스카우터 팀원만 사용할 수 있습니다.")
+        }
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/rubric/business/InterviewRubricService.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/rubric/business/InterviewRubricService.kt
@@ -133,4 +133,19 @@ class InterviewRubricService(
             .getByPartIdAndSemester(partId, Semester.of(semester))
             .deadline
     }
+
+    @Transactional
+    fun resetByPartIdAndSemester(partId: Long, semester: String) {
+        partReader.readById(partId)
+
+        val resolvedSemester = Semester.of(semester)
+        val existing = interviewRubricReader.findByPartIdAndSemester(partId, resolvedSemester) ?: return
+
+        val itemIds = existing.items.mapNotNull { it.id }
+        if (itemIds.isNotEmpty() && interviewEvaluationReader.existsByInterviewEvaluationItemIdIn(itemIds)) {
+            throw RubricLockedException("해당 파트에 면접 평가가 존재해 루브릭을 초기화할 수 없습니다. 평가 데이터를 먼저 삭제해 주세요.")
+        }
+
+        interviewRubricWriter.deleteByPartIdAndSemester(partId, resolvedSemester)
+    }
 }

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/rubric/implement/InterviewRubricWriter.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/rubric/implement/InterviewRubricWriter.kt
@@ -1,5 +1,8 @@
 package com.yourssu.scouter.recruiting.rubric.implement
 
+import com.yourssu.scouter.masterdata.semester.implement.Semester
+
 interface InterviewRubricWriter {
     fun save(interviewRubric: InterviewRubric): InterviewRubric
+    fun deleteByPartIdAndSemester(partId: Long, semester: Semester)
 }

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/rubric/storage/InterviewRubricRepositoryImpl.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/rubric/storage/InterviewRubricRepositoryImpl.kt
@@ -44,4 +44,9 @@ class InterviewRubricRepositoryImpl(
         val savedEntity = jpaRepository.save(entity)
         return mapper.toDomain(savedEntity)
     }
+
+    override fun deleteByPartIdAndSemester(partId: Long, semester: Semester) {
+        val semesterEntity = jpaSemesterRepository.findByYearAndTerm(semester.year, semester.term) ?: return
+        jpaRepository.deleteByPartIdAndSemester(partId, semesterEntity)
+    }
 }

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/rubric/storage/JpaInterviewRubricRepository.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/rubric/storage/JpaInterviewRubricRepository.kt
@@ -6,4 +6,6 @@ import org.springframework.data.jpa.repository.JpaRepository
 interface JpaInterviewRubricRepository : JpaRepository<InterviewRubricEntity, Long> {
 
     fun findByPartIdAndSemester(partId: Long, semester: SemesterEntity): InterviewRubricEntity?
+
+    fun deleteByPartIdAndSemester(partId: Long, semester: SemesterEntity)
 }


### PR DESCRIPTION
## Summary
- QA를 위한 임시 API로, 파트+학기 기준 면접 루브릭(`interview_rubric`)을 초기화(삭제)하는 API를 추가했습니다.
- #426 에서 만든 지원자별 서류/면접 평가 데이터 삭제 API와 함께 사용하는 것을 전제로 합니다. (루브릭을 초기화하기 전에 해당 파트의 면접 평가를 먼저 지워야 하는 경우가 있습니다.)
- `DELETE /internal/dev/parts/{partId}/interviews/rubrics/{semester}`
  - 삭제 후에는 기존 `GET /parts/{partId}/interviews/rubrics/{semester}`에서 면접 요구조건 기반의 미저장 템플릿(maxScore=0)으로 다시 조회됩니다.
  - 루브릭 항목(`InterviewEvaluationItemEntity`)을 참조하는 면접 평가가 남아있으면 `RubricLockedException`(409)을 던져 초기화를 막습니다. → 먼저 #426 의 면접 평가 삭제 API를 호출해야 합니다.
  - `interview_rubric`은 `cascade=ALL, orphanRemoval=true`로 하위 항목을 물고 있어 별도 item 삭제 없이 루브릭만 지우면 됩니다.
- #426 과 동일한 컨벤션으로 `@Profile("local", "dev")` 컨트롤러(`DevRubricAdminController`)에 배치해 prod에는 노출되지 않습니다. 인증도 스카우터 팀원 여부만 확인합니다.

## Test plan
- [x] `./gradlew compileKotlin compileTestKotlin` 통과 확인
- [ ] 로컬 환경에 gitignore된 `applicant-sync-mapping-data.yml`이 없어 Spring 컨텍스트를 로드하는 테스트를 로컬에서 실행하지 못했습니다. CI에서 확인 부탁드립니다.
- [ ] 루브릭 삭제/잠금 가드 관련 리포지토리·서비스 테스트는 아직 없습니다. 필요 시 추가하겠습니다.

Closes #439

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UrFFQv6qakvY9LwyoQMNRg