### PR TITLE
[#442]; fix: 파트별 요구조건 저장 시 전역 요구조건 id 섞여 들어와 저장 실패하는 문제 수정

### DIFF
--- a/src/main/kotlin/com/yourssu/scouter/recruiting/interview/business/InterviewRequirementService.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/interview/business/InterviewRequirementService.kt
@@ -8,6 +8,7 @@ import com.yourssu.scouter.recruiting.interview.implement.InterviewRequirement
 import com.yourssu.scouter.recruiting.interview.implement.InterviewRequirementReader
 import com.yourssu.scouter.recruiting.interview.implement.InterviewRequirementWriter
 import com.yourssu.scouter.recruiting.rubric.implement.RubricGroupType
+import com.yourssu.scouter.recruiting.interview.application.dto.UpdateInterviewRequirementItemRequest
 import com.yourssu.scouter.recruiting.interview.application.dto.UpdateInterviewRequirementRequest
 import com.yourssu.scouter.masterdata.semester.implement.SemesterReader
 import com.yourssu.scouter.recruiting.rubric.implement.InterviewRubricReader
@@ -64,20 +65,25 @@ class InterviewRequirementService(
             }
         }
 
+        // readByPartIdAndSemester()는 culture/team/job에 전역(part 없는) 요구조건도 함께 내려주므로,
+        // 다른 카테고리를 그대로 echo해서 저장 요청을 보내는 어드민 폼에서는 전역 항목의 id가 섞여 들어올 수 있다.
+        // 이 파트가 실제로 소유하지 않은 id는 저장 대상에서 제외해 "범위에 없는 id" 오류 없이 무시한다.
+        val ownIds = partInterviewRequirementReader.readAllByPartIdAndSemester(partId, semester)
+            .mapNotNull { it.id }
+            .toSet()
+
         val domains = mutableListOf<InterviewRequirement>()
 
-        request.culture.forEach {
-            domains.add(InterviewRequirement(it.id, partId, semesterId, RubricGroupType.CULTURE, it.content))
+        fun collectOwn(items: List<UpdateInterviewRequirementItemRequest>, type: RubricGroupType) {
+            items.filter { it.id == null || it.id in ownIds }
+                .forEach { domains.add(InterviewRequirement(it.id, partId, semesterId, type, it.content)) }
         }
-        request.team.forEach {
-            domains.add(InterviewRequirement(it.id, partId, semesterId, RubricGroupType.TEAM, it.content))
-        }
-        request.job.forEach {
-            domains.add(InterviewRequirement(it.id, partId, semesterId, RubricGroupType.JOB, it.content))
-        }
-        request.other.forEach {
-            domains.add(InterviewRequirement(it.id, partId, semesterId, RubricGroupType.OTHER, it.content))
-        }
+
+        collectOwn(request.culture, RubricGroupType.CULTURE)
+        collectOwn(request.team, RubricGroupType.TEAM)
+        collectOwn(request.job, RubricGroupType.JOB)
+        // OTHER는 readByPartIdAndSemester()가 항상 전역 항목만 내려주는 것과 대칭으로,
+        // 파트 범위 저장에서는 다루지 않는다 (전역 전용 카테고리).
 
         partInterviewRequirementWriter.saveAll(domains, partId, semester)
         syncRubric(partId, semester)

--- a/src/test/kotlin/com/yourssu/scouter/recruiting/interview/business/InterviewRequirementServiceTest.kt
+++ b/src/test/kotlin/com/yourssu/scouter/recruiting/interview/business/InterviewRequirementServiceTest.kt
@@ -1,0 +1,97 @@
+package com.yourssu.scouter.recruiting.interview.business
+
+import com.yourssu.scouter.masterdata.part.implement.PartReader
+import com.yourssu.scouter.masterdata.part.implement.fixture.PartFixtureBuilder
+import com.yourssu.scouter.masterdata.semester.implement.SemesterReader
+import com.yourssu.scouter.masterdata.semester.implement.fixture.SemesterFixtureBuilder
+import com.yourssu.scouter.recruiting.evaluation.implement.InterviewEvaluationReader
+import com.yourssu.scouter.recruiting.interview.application.dto.UpdateInterviewRequirementItemRequest
+import com.yourssu.scouter.recruiting.interview.application.dto.UpdateInterviewRequirementRequest
+import com.yourssu.scouter.recruiting.interview.implement.InterviewRequirement
+import com.yourssu.scouter.recruiting.interview.implement.InterviewRequirementReader
+import com.yourssu.scouter.recruiting.interview.implement.InterviewRequirementWriter
+import com.yourssu.scouter.recruiting.rubric.implement.InterviewRubricReader
+import com.yourssu.scouter.recruiting.rubric.implement.InterviewRubricWriter
+import com.yourssu.scouter.recruiting.rubric.implement.RubricGroupType
+import org.assertj.core.api.Assertions.assertThatCode
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+@Suppress("NonAsciiCharacters")
+class InterviewRequirementServiceTest {
+
+    private lateinit var partInterviewRequirementReader: InterviewRequirementReader
+    private lateinit var partInterviewRequirementWriter: InterviewRequirementWriter
+    private lateinit var partReader: PartReader
+    private lateinit var semesterReader: SemesterReader
+    private lateinit var interviewRubricReader: InterviewRubricReader
+    private lateinit var interviewEvaluationReader: InterviewEvaluationReader
+    private lateinit var interviewRubricWriter: InterviewRubricWriter
+    private lateinit var service: InterviewRequirementService
+
+    private val partId = 10L
+    private val semester = SemesterFixtureBuilder().id(1L).build()
+
+    @BeforeEach
+    fun setUp() {
+        partInterviewRequirementReader = mock(InterviewRequirementReader::class.java)
+        partInterviewRequirementWriter = mock(InterviewRequirementWriter::class.java)
+        partReader = mock(PartReader::class.java)
+        semesterReader = mock(SemesterReader::class.java)
+        interviewRubricReader = mock(InterviewRubricReader::class.java)
+        interviewEvaluationReader = mock(InterviewEvaluationReader::class.java)
+        interviewRubricWriter = mock(InterviewRubricWriter::class.java)
+
+        service = InterviewRequirementService(
+            partInterviewRequirementReader,
+            partInterviewRequirementWriter,
+            partReader,
+            semesterReader,
+            interviewRubricReader,
+            interviewEvaluationReader,
+            interviewRubricWriter,
+        )
+
+        whenever(partReader.readById(partId)).thenReturn(PartFixtureBuilder().id(partId).build())
+        whenever(semesterReader.read(semester)).thenReturn(semester)
+        whenever(interviewRubricReader.findByPartIdAndSemester(partId, semester)).thenReturn(null)
+        whenever(partInterviewRequirementReader.readAllApplicableByPartIdAndSemester(any(), any()))
+            .thenReturn(emptyList())
+        whenever(partInterviewRequirementWriter.saveAll(any(), any(), any())).thenReturn(emptyList())
+    }
+
+    @Test
+    fun `다른 카테고리에 섞여 들어온 전역 요구조건 id는 저장 대상에서 조용히 제외한다`() {
+        // given: 전역 CULTURE 요구조건(101)이 있고, 이 파트가 소유한 TEAM 요구조건은 없다
+        val globalCultureId = 101L
+        whenever(partInterviewRequirementReader.readAllByPartIdAndSemester(partId, semester))
+            .thenReturn(emptyList())
+
+        // team-fit 페이지에서 새 TEAM 요구조건을 추가하면서, 건드리지 않은 culture 목록은
+        // 화면에 표시됐던 전역 항목 id(101)를 그대로 echo해서 보낸다
+        val request = UpdateInterviewRequirementRequest(
+            culture = listOf(UpdateInterviewRequirementItemRequest(globalCultureId, "전역 문화 적합성")),
+            team = listOf(UpdateInterviewRequirementItemRequest(null, "새 팀워크 요구조건")),
+            job = emptyList(),
+            other = emptyList(),
+        )
+
+        // when / then: "해당 범위에 존재하지 않는 요구조건 ID" 예외 없이 저장되어야 한다
+        assertThatCode { service.saveAll(partId, semester, request) }.doesNotThrowAnyException()
+
+        val captor = argumentCaptor<List<InterviewRequirement>>()
+        verify(partInterviewRequirementWriter).saveAll(captor.capture(), any(), any())
+
+        val saved = captor.firstValue
+        // 전역 culture 항목(101)은 이 파트 저장 대상에 포함되지 않아야 한다
+        assertThatCode {
+            require(saved.none { it.id == globalCultureId }) { "전역 요구조건이 파트 범위 저장에 포함됨" }
+        }.doesNotThrowAnyException()
+        require(saved.any { it.rubricType == RubricGroupType.TEAM && it.content == "새 팀워크 요구조건" })
+    }
+}


### PR DESCRIPTION
## 요약
- team-fit/job-fit 어드민 페이지에서 요구조건을 추가할 때 `해당 범위에 존재하지 않는 요구조건 ID입니다` 오류로 저장이 실패하던 버그 수정
- `readByPartIdAndSemester`가 culture/team/job에 전역(part 없음) 요구조건까지 섞어 반환하는데, 저장 시 수정하지 않은 카테고리를 그대로 echo하는 어드민 폼 구조상 전역 항목 id가 파트 범위 저장 요청에 섞여 들어가 발생한 문제
- 파트가 실제로 소유하지 않은 id는 저장 대상에서 조용히 제외하도록 `InterviewRequirementService.saveAll` 수정
- `other` 카테고리는 조회 시 항상 전역 항목만 내려주는 것과 대칭되도록 파트 범위 저장 대상에서 제외 (미사용 상태인 `/other` 페이지가 향후 활성화될 경우 발생할 수 있는 데이터 유실/질문 삭제 잠재 버그 예방)

Closes #442

## Test plan
- [x] `InterviewRequirementServiceTest` 추가: 전역 culture 항목 id가 team-fit 저장 요청에 echo되어도 예외 없이 저장되고, 전역 항목은 저장 대상에서 제외됨을 검증
- [x] 기존 `InterviewRequirementRepositoryImplTest` 통과 확인
- [x] `./gradlew compileKotlin` 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)