### PR TITLE
[#445]; feat: 서류 평가 문항 배점 0점 초기화 API 추가 (dev 전용)

### DIFF
--- a/src/main/kotlin/com/yourssu/scouter/recruiting/rubric/application/DevDocumentRubricAdminController.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/rubric/application/DevDocumentRubricAdminController.kt
@@ -1,0 +1,60 @@
+package com.yourssu.scouter.recruiting.rubric.application
+
+import com.yourssu.scouter.auth.support.annotation.AuthUser
+import com.yourssu.scouter.auth.support.resolver.AuthUserInfo
+import com.yourssu.scouter.member.core.business.MemberPrivacyService
+import com.yourssu.scouter.member.support.exception.MemberAccessDeniedException
+import com.yourssu.scouter.recruiting.rubric.business.DocumentSectionService
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.context.annotation.Profile
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.PatchMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+/**
+ * local, dev 프로필 전용. QA를 위해 파트의 서류 평가 문항 배점을 일괄 0점으로 초기화할 수 있게 함.
+ * 운영(prod) 환경에는 이 컨트롤러가 아예 등록되지 않는다.
+ */
+@Profile("local", "dev")
+@Tag(name = "[DEV] 서류 평가 문항 배점 초기화")
+@RestController
+@RequestMapping("/internal/dev/parts/{partId}/documents/rubrics")
+class DevDocumentRubricAdminController(
+    private val documentSectionService: DocumentSectionService,
+    private val memberPrivacyService: MemberPrivacyService,
+) {
+
+    @Operation(
+        summary = "서류 평가 문항 배점 초기화 (QA용)",
+        description = "해당 파트의 모든 서류 평가 문항 배점을 0으로 초기화합니다. " +
+            "해당 문항을 참조하는 서류 평가가 남아있으면 초기화할 수 없습니다. 스카우터 팀원만 호출 가능.",
+    )
+    @ApiResponses(
+        ApiResponse(responseCode = "200", description = "초기화 성공"),
+        ApiResponse(responseCode = "403", description = "스카우터 팀원이 아님"),
+        ApiResponse(responseCode = "409", description = "해당 파트에 서류 평가가 존재해 초기화할 수 없음"),
+        ApiResponse(responseCode = "404", description = "파트를 찾을 수 없음"),
+    )
+    @PatchMapping("/reset-max-scores")
+    fun resetMaxScoresToZero(
+        @AuthUser authUserInfo: AuthUserInfo,
+        @Parameter(description = "파트 ID", example = "1") @PathVariable partId: Long,
+    ): ResponseEntity<Unit> {
+        requireScouterTeamMember(authUserInfo.userId)
+        documentSectionService.resetMaxScoresToZero(partId)
+
+        return ResponseEntity.ok().build()
+    }
+
+    private fun requireScouterTeamMember(userId: Long) {
+        if (!memberPrivacyService.isScouterTeamMember(userId)) {
+            throw MemberAccessDeniedException("이 API는 스카우터 팀원만 사용할 수 있습니다.")
+        }
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/rubric/business/DocumentSectionService.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/rubric/business/DocumentSectionService.kt
@@ -59,6 +59,33 @@ class DocumentSectionService(
         documentSectionWriter.writeAll(updated)
     }
 
+    // local, dev 프로필 전용 QA API. 파트의 모든 서류 평가 문항 배점을 0으로 초기화한다.
+    @Transactional
+    fun resetMaxScoresToZero(partId: Long) {
+        partReader.readById(partId)
+
+        val sections = documentSectionReader.readAllByPartId(partId)
+        if (sections.isEmpty()) {
+            return
+        }
+
+        val sectionIds = sections.mapNotNull { it.id }
+        if (documentEvaluationReader.existsBySectionIdIn(sectionIds)) {
+            throw RubricLockedException("해당 파트에 서류 평가가 존재해 배점을 초기화할 수 없습니다. 평가 데이터를 먼저 삭제해 주세요.")
+        }
+
+        val reset = sections.map { section ->
+            DocumentSection(
+                id = section.id,
+                partId = section.partId,
+                question = section.question,
+                maxScore = 0,
+                criterionDetail = section.criterionDetail,
+            )
+        }
+        documentSectionWriter.writeAll(reset)
+    }
+
     // 구글폼 동기화 시 서술형 질문에서 문항을 자동 생성한다 [B1]. 질문 텍스트가 이미 있으면 기존 문항을 그대로 재사용하고,
     // 새 질문 텍스트만 배점 0 / 지표 빈 문자열로 생성한다 (배점·지표는 이후 PUT rubrics로 채운다).
     @Transactional


### PR DESCRIPTION
## Summary
- `DocumentSectionService.resetMaxScoresToZero(partId)` 추가: 파트의 모든 서류 평가 문항 배점을 0으로 일괄 초기화. 해당 문항을 참조하는 서류 평가가 존재하면 `RubricLockedException`으로 거부 (기존 `updateRubrics`, 면접 루브릭 초기화와 동일한 정책)
- `DevDocumentRubricAdminController` 추가: `PATCH /internal/dev/parts/{partId}/documents/rubrics/reset-max-scores`, `local`/`dev` 프로필 전용, 스카우터 팀원만 호출 가능 (기존 `DevRubricAdminController`, `DevEvaluationAdminController` 패턴 참고)

Closes #445

## Test plan
- [x] `./gradlew compileKotlin` 성공 확인
- [ ] dev 서버에서 스카우터 팀원 계정으로 API 호출해 배점이 0으로 초기화되는지 확인
- [ ] 서류 평가가 존재하는 파트에 호출 시 409 응답 확인