### PR TITLE
refactor : memberId 지정

### DIFF
--- a/src/main/kotlin/com/yourssu/scouter/recruiting/interviewQuestion/application/dto/ReadAssignedQuestionResponse.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/interviewQuestion/application/dto/ReadAssignedQuestionResponse.kt
@@ -8,11 +8,11 @@ data class ReadAssignedQuestionResponse(
     @field:Schema(description = "배정 질문 ID (초기 기본 질문인 경우 null)", nullable = true)
     val id: Long?,
 
-    @field:Schema(description = "Assigned interviewer user ID (null for initial default questions)", nullable = true)
-    val assignedInterviewerUserId: Long?,
+    @field:Schema(description = "Assigned member ID (null for initial default questions)", nullable = true)
+    val assignedMemberId: Long?,
 
-    @field:Schema(description = "배정된 면접관 영어 닉네임", nullable = true)
-    val assignedInterviewerName: String?,
+    @field:Schema(description = "배정된 면접관 영어 닉네임/이름", nullable = true)
+    val assignedMemberName: String?,
 
     @field:Schema(description = "카탈로그 원본 질문 ID (개인 질문인 경우 null)", nullable = true)
     val sourceQuestionId: Long?,
@@ -32,8 +32,8 @@ data class ReadAssignedQuestionResponse(
     companion object {
         fun from(dto: AssignedQuestionDto): ReadAssignedQuestionResponse = ReadAssignedQuestionResponse(
             id = dto.id,
-            assignedInterviewerUserId = dto.assignedInterviewerUserId,
-            assignedInterviewerName = dto.assignedInterviewerName,
+            assignedMemberId = dto.assignedMemberId,
+            assignedMemberName = dto.assignedMemberName,
             sourceQuestionId = dto.sourceQuestionId,
             content = dto.content,
             category = dto.category,

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/interviewQuestion/application/dto/SaveAssignedQuestionRequest.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/interviewQuestion/application/dto/SaveAssignedQuestionRequest.kt
@@ -8,8 +8,8 @@ import jakarta.validation.constraints.NotNull
 data class SaveAssignedQuestionRequest(
 
     @field:NotNull
-    @field:Schema(description = "배정할 면접관 유저 ID")
-    val assignedInterviewerUserId: Long?,
+    @field:Schema(description = "배정할 면접관 멤버 ID")
+    val assignedMemberId: Long?,
 
     @field:Schema(description = "카탈로그 원본 질문 ID (개인 질문인 경우 null)", nullable = true)
     val sourceQuestionId: Long?,
@@ -30,7 +30,7 @@ data class SaveAssignedQuestionRequest(
     val requirementIds: List<Long>? = null,
 ) {
     fun toCommand(): SaveAssignedQuestionCommand = SaveAssignedQuestionCommand(
-        assignedInterviewerUserId = assignedInterviewerUserId!!,
+        assignedMemberId = assignedMemberId!!,
         sourceQuestionId = sourceQuestionId,
         content = content,
         category = category!!,

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/interviewQuestion/business/AssignedQuestionService.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/interviewQuestion/business/AssignedQuestionService.kt
@@ -1,6 +1,6 @@
 package com.yourssu.scouter.recruiting.interviewQuestion.business
 
-import com.yourssu.scouter.auth.user.implement.UserReader
+import com.yourssu.scouter.member.core.implement.MemberReader
 import com.yourssu.scouter.recruiting.applicant.implement.Applicant
 import com.yourssu.scouter.recruiting.applicant.implement.ApplicantReader
 import com.yourssu.scouter.recruiting.evaluation.implement.InterviewEvaluationReader
@@ -18,7 +18,6 @@ import com.yourssu.scouter.recruiting.interviewQuestion.implement.Question
 import com.yourssu.scouter.recruiting.interviewQuestion.implement.QuestionCategory
 import com.yourssu.scouter.recruiting.interviewQuestion.implement.QuestionReader
 import com.yourssu.scouter.recruiting.interviewQuestion.implement.QuestionWriter
-import com.yourssu.scouter.recruiting.support.business.EvaluatorDirectory
 import com.yourssu.scouter.recruiting.support.business.InterviewRequirementLookup
 import com.yourssu.scouter.recruiting.support.business.InterviewRequirementProfile
 import com.yourssu.scouter.recruiting.support.implement.exception.AssignedQuestionLockedException
@@ -34,8 +33,7 @@ class AssignedQuestionService(
     private val questionWriter: QuestionWriter,
     private val assignedQuestionValidator: AssignedQuestionValidator,
     private val applicantReader: ApplicantReader,
-    private val userReader: UserReader,
-    private val evaluatorDirectory: EvaluatorDirectory,
+    private val memberReader: MemberReader,
     private val interviewRequirementLookup: InterviewRequirementLookup,
     private val interviewEvaluationReader: InterviewEvaluationReader,
 ) {
@@ -76,10 +74,10 @@ class AssignedQuestionService(
 
         val questions =
             command.questions.mapIndexed { index, question ->
-                userReader.readById(question.assignedInterviewerUserId)
+                memberReader.readById(question.assignedMemberId)
 
                 AssignedQuestion(
-                    assignedInterviewerUserId = question.assignedInterviewerUserId,
+                    assignedMemberId = question.assignedMemberId,
                     applicantId = applicantId,
                     sourceQuestionId = resolvedSourceQuestionIds[index] ?: question.sourceQuestionId,
                     content = if (question.category == AssignedQuestionCategory.PERSONAL) question.content else null,
@@ -205,30 +203,23 @@ class AssignedQuestionService(
         sourceQuestionsById: Map<Long?, Question>,
         requirementsById: Map<Long?, InterviewRequirementProfile>,
     ): List<AssignedQuestionDto> {
-        val assignedInterviewerNamesById = readAssignedInterviewerNamesById(questions)
+        val assignedMemberNamesById = readAssignedMemberNamesById(questions)
 
         return questions
             .sortedBy { it.sortOrder }
             .map { question ->
-                question.toDto(sourceQuestionsById, requirementsById, assignedInterviewerNamesById)
+                question.toDto(sourceQuestionsById, requirementsById, assignedMemberNamesById)
             }
     }
 
-    private fun readAssignedInterviewerNamesById(questions: List<AssignedQuestion>): Map<Long, String> {
-        val usersById =
-            userReader
-                .readAllByIds(questions.map { it.assignedInterviewerUserId }.distinct())
-                .associateBy { it.id!! }
-
+    private fun readAssignedMemberNamesById(questions: List<AssignedQuestion>): Map<Long, String> {
         return questions
-            .map { it.assignedInterviewerUserId }
+            .map { it.assignedMemberId }
             .distinct()
-            .mapNotNull { userId ->
-                val user = usersById[userId] ?: return@mapNotNull null
-                val name =
-                    evaluatorDirectory.findEvaluatorInfo(user.userInfo.email)?.nicknameEnglish
-                        ?: user.userInfo.name
-                userId to name
+            .mapNotNull { memberId ->
+                val member = runCatching { memberReader.readById(memberId) }.getOrNull() ?: return@mapNotNull null
+                val name = member.nicknameEnglish.ifBlank { member.name }
+                memberId to name
             }.toMap()
     }
 
@@ -256,8 +247,8 @@ class AssignedQuestionService(
             .mapIndexed { index, question ->
                 AssignedQuestionDto(
                     id = null,
-                    assignedInterviewerUserId = null,
-                    assignedInterviewerName = null,
+                    assignedMemberId = null,
+                    assignedMemberName = null,
                     sourceQuestionId = question.id,
                     content = question.content,
                     category = question.category.toAssignedQuestionCategory(),
@@ -278,7 +269,7 @@ class AssignedQuestionService(
     private fun AssignedQuestion.toDto(
         sourceQuestionsById: Map<Long?, Question>,
         requirementsById: Map<Long?, InterviewRequirementProfile>,
-        assignedInterviewerNamesById: Map<Long, String>,
+        assignedMemberNamesById: Map<Long, String>,
     ): AssignedQuestionDto {
         // 카탈로그 카테고리(INTRO/OUTRO/CULTURE/PART)는 요구조건을 원본 질문(Question)에서 가져오고, PERSONAL만 인스턴스 자체 값을 사용한다.
         val effectiveRequirementIds =
@@ -290,8 +281,8 @@ class AssignedQuestionService(
 
         return AssignedQuestionDto(
             id = id!!,
-            assignedInterviewerUserId = assignedInterviewerUserId,
-            assignedInterviewerName = assignedInterviewerNamesById[assignedInterviewerUserId],
+            assignedMemberId = assignedMemberId,
+            assignedMemberName = assignedMemberNamesById[assignedMemberId],
             sourceQuestionId = sourceQuestionId,
             content = content ?: sourceQuestionsById[sourceQuestionId]?.content.orEmpty(),
             category = category,

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/interviewQuestion/business/dto/AssignedQuestionDto.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/interviewQuestion/business/dto/AssignedQuestionDto.kt
@@ -4,8 +4,8 @@ import com.yourssu.scouter.recruiting.interviewQuestion.implement.AssignedQuesti
 
 data class AssignedQuestionDto(
     val id: Long?,
-    val assignedInterviewerUserId: Long?,
-    val assignedInterviewerName: String?,
+    val assignedMemberId: Long?,
+    val assignedMemberName: String?,
     val sourceQuestionId: Long?,
     val content: String,
     val category: AssignedQuestionCategory,

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/interviewQuestion/business/dto/SaveAssignedQuestionCommand.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/interviewQuestion/business/dto/SaveAssignedQuestionCommand.kt
@@ -3,7 +3,7 @@ package com.yourssu.scouter.recruiting.interviewQuestion.business.dto
 import com.yourssu.scouter.recruiting.interviewQuestion.implement.AssignedQuestionCategory
 
 data class SaveAssignedQuestionCommand(
-    val assignedInterviewerUserId: Long,
+    val assignedMemberId: Long,
     val sourceQuestionId: Long?,
     val content: String?,
     val category: AssignedQuestionCategory,

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/interviewQuestion/implement/AssignedQuestion.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/interviewQuestion/implement/AssignedQuestion.kt
@@ -4,7 +4,7 @@ import com.yourssu.scouter.recruiting.support.implement.exception.AssignedQuesti
 
 class AssignedQuestion(
     val id: Long? = null,
-    val assignedInterviewerUserId: Long,
+    val assignedMemberId: Long,
     val applicantId: Long,
     val sourceQuestionId: Long?,
     val content: String?,

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/interviewQuestion/storage/AssignedQuestionEntity.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/interviewQuestion/storage/AssignedQuestionEntity.kt
@@ -19,8 +19,8 @@ class AssignedQuestionEntity(
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     val id: Long? = null,
 
-    @Column(name = "assigned_interviewer_user_id", nullable = false)
-    val assignedInterviewerUserId: Long,
+    @Column(name = "assigned_member_id", nullable = false)
+    val assignedMemberId: Long,
 
     @Column(name = "applicant_id", nullable = false)
     val applicantId: Long,
@@ -44,7 +44,7 @@ class AssignedQuestionEntity(
 
     fun toDomain(requirementIds: List<Long> = emptyList()): AssignedQuestion = AssignedQuestion(
         id = id,
-        assignedInterviewerUserId = assignedInterviewerUserId,
+        assignedMemberId = assignedMemberId,
         applicantId = applicantId,
         sourceQuestionId = sourceQuestionId,
         content = content,

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/interviewQuestion/storage/AssignedQuestionRepositoryImpl.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/interviewQuestion/storage/AssignedQuestionRepositoryImpl.kt
@@ -28,7 +28,7 @@ class AssignedQuestionRepositoryImpl(
 
         val entities = questions.map { question ->
             AssignedQuestionEntity(
-                assignedInterviewerUserId = question.assignedInterviewerUserId,
+                assignedMemberId = question.assignedMemberId,
                 applicantId = applicantId,
                 category = question.category,
                 sourceQuestionId = question.sourceQuestionId,

--- a/src/main/resources/db/migration/V46__rename_assigned_interviewer_user_id_to_assigned_member_id.sql
+++ b/src/main/resources/db/migration/V46__rename_assigned_interviewer_user_id_to_assigned_member_id.sql
@@ -1,0 +1,2 @@
+ALTER TABLE assigned_question
+    RENAME COLUMN assigned_interviewer_user_id TO assigned_member_id;

--- a/src/test/kotlin/com/yourssu/scouter/recruiting/interviewQuestion/business/AssignedQuestionServiceTest.kt
+++ b/src/test/kotlin/com/yourssu/scouter/recruiting/interviewQuestion/business/AssignedQuestionServiceTest.kt
@@ -1,20 +1,23 @@
 package com.yourssu.scouter.recruiting.interviewQuestion.business
 
-import com.yourssu.scouter.auth.authentication.implement.OAuth2Type
-import com.yourssu.scouter.auth.user.implement.TokenInfo
-import com.yourssu.scouter.auth.user.implement.User
-import com.yourssu.scouter.auth.user.implement.UserInfo
-import com.yourssu.scouter.auth.user.implement.UserReader
 import com.yourssu.scouter.masterdata.part.implement.fixture.PartFixtureBuilder
 import com.yourssu.scouter.masterdata.semester.implement.fixture.SemesterFixtureBuilder
+import com.yourssu.scouter.member.core.fixture.MemberFixtureBuilder
+import com.yourssu.scouter.member.core.implement.MemberReader
 import com.yourssu.scouter.recruiting.applicant.implement.ApplicantReader
 import com.yourssu.scouter.recruiting.applicant.implement.fixture.ApplicantFixtureBuilder
 import com.yourssu.scouter.recruiting.evaluation.implement.InterviewEvaluationReader
 import com.yourssu.scouter.recruiting.interviewQuestion.business.dto.SaveAssignedQuestionCommand
 import com.yourssu.scouter.recruiting.interviewQuestion.business.dto.SaveAssignedQuestionsCommand
-import com.yourssu.scouter.recruiting.interviewQuestion.implement.*
-import com.yourssu.scouter.recruiting.support.business.EvaluatorDirectory
-import com.yourssu.scouter.recruiting.support.business.EvaluatorInfo
+import com.yourssu.scouter.recruiting.interviewQuestion.implement.AssignedQuestion
+import com.yourssu.scouter.recruiting.interviewQuestion.implement.AssignedQuestionCategory
+import com.yourssu.scouter.recruiting.interviewQuestion.implement.AssignedQuestionReader
+import com.yourssu.scouter.recruiting.interviewQuestion.implement.AssignedQuestionValidator
+import com.yourssu.scouter.recruiting.interviewQuestion.implement.AssignedQuestionWriter
+import com.yourssu.scouter.recruiting.interviewQuestion.implement.Question
+import com.yourssu.scouter.recruiting.interviewQuestion.implement.QuestionCategory
+import com.yourssu.scouter.recruiting.interviewQuestion.implement.QuestionReader
+import com.yourssu.scouter.recruiting.interviewQuestion.implement.QuestionWriter
 import com.yourssu.scouter.recruiting.support.business.InterviewRequirementLookup
 import com.yourssu.scouter.recruiting.support.implement.exception.AssignedQuestionLockedException
 import com.yourssu.scouter.recruiting.support.implement.exception.QuestionInvalidException
@@ -23,8 +26,8 @@ import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
-import org.mockito.Mockito.mock
 import org.junit.jupiter.params.provider.EnumSource
+import org.mockito.Mockito.mock
 import org.mockito.Mockito.verify
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
@@ -38,8 +41,7 @@ class AssignedQuestionServiceTest {
     private lateinit var questionReader: QuestionReader
     private lateinit var questionWriter: QuestionWriter
     private lateinit var applicantReader: ApplicantReader
-    private lateinit var userReader: UserReader
-    private lateinit var evaluatorDirectory: EvaluatorDirectory
+    private lateinit var memberReader: MemberReader
     private lateinit var interviewRequirementLookup: InterviewRequirementLookup
     private lateinit var interviewEvaluationReader: InterviewEvaluationReader
     private lateinit var assignedQuestionService: AssignedQuestionService
@@ -54,8 +56,7 @@ class AssignedQuestionServiceTest {
         questionReader = mock(QuestionReader::class.java)
         questionWriter = mock(QuestionWriter::class.java)
         applicantReader = mock(ApplicantReader::class.java)
-        userReader = mock(UserReader::class.java)
-        evaluatorDirectory = mock(EvaluatorDirectory::class.java)
+        memberReader = mock(MemberReader::class.java)
         interviewRequirementLookup = mock(InterviewRequirementLookup::class.java)
         interviewEvaluationReader = mock(InterviewEvaluationReader::class.java)
 
@@ -66,8 +67,7 @@ class AssignedQuestionServiceTest {
             questionWriter,
             AssignedQuestionValidator(),
             applicantReader,
-            userReader,
-            evaluatorDirectory,
+            memberReader,
             interviewRequirementLookup,
             interviewEvaluationReader,
         )
@@ -81,7 +81,6 @@ class AssignedQuestionServiceTest {
                 .build(),
         )
         whenever(interviewRequirementLookup.findAllByPartIdAndSemester(any(), any())).thenReturn(emptyList())
-        whenever(userReader.readAllByIds(any())).thenReturn(emptyList())
     }
 
     @Test
@@ -124,22 +123,21 @@ class AssignedQuestionServiceTest {
             .allSatisfy { assertThat(it.isSelected).isNull() }
         assertThat(result.questions).allSatisfy {
             assertThat(it.id).isNull()
-            assertThat(it.assignedInterviewerUserId).isNull()
-            assertThat(it.assignedInterviewerName).isNull()
+            assertThat(it.assignedMemberId).isNull()
+            assertThat(it.assignedMemberName).isNull()
         }
     }
 
     @Test
     fun `저장된 질문은 배정된 면접관 영어 닉네임을 반환한다`() {
-        val interviewerUserId = 100L
-        val interviewerEmail = "interviewer@yourssu.com"
+        val interviewerMemberId = 100L
         val sourceQuestions = listOf(
             Question(1L, null, null, QuestionCategory.INTRO, "자기소개", 1),
         )
         val savedQuestions = listOf(
             AssignedQuestion(
                 id = 11L,
-                assignedInterviewerUserId = interviewerUserId,
+                assignedMemberId = interviewerMemberId,
                 applicantId = applicantId,
                 sourceQuestionId = 1L,
                 content = null,
@@ -149,43 +147,42 @@ class AssignedQuestionServiceTest {
         )
         whenever(assignedQuestionReader.readAllByApplicantId(applicantId)).thenReturn(savedQuestions)
         whenever(questionReader.readAllByIdIn(listOf(1L))).thenReturn(sourceQuestions)
-        whenever(userReader.readAllByIds(listOf(interviewerUserId))).thenReturn(
-            listOf(user(interviewerUserId, "면접관", interviewerEmail)),
-        )
-        whenever(evaluatorDirectory.findEvaluatorInfo(interviewerEmail)).thenReturn(
-            EvaluatorInfo(memberId = 1L, nicknameEnglish = "piki", partName = "Backend"),
+        whenever(memberReader.readById(interviewerMemberId)).thenReturn(
+            MemberFixtureBuilder().id(interviewerMemberId).name("면접관").build(),
         )
 
         val result = assignedQuestionService.readByApplicantId(applicantId)
 
-        assertThat(result.questions.single().assignedInterviewerName).isEqualTo("piki")
-        assertThat(result.questions.single().assignedInterviewerUserId).isEqualTo(interviewerUserId)
+        assertThat(result.questions.single().assignedMemberName).isEqualTo("piki")
+        assertThat(result.questions.single().assignedMemberId).isEqualTo(interviewerMemberId)
     }
 
     @Test
     fun `저장한 컬쳐 질문 4개는 선택 여부와 함께 모두 반환한다`() {
-        val interviewerUserId = 100L
+        val interviewerMemberId = 100L
         val sourceQuestions = listOf(
             Question(1L, null, null, QuestionCategory.CULTURE, "컬쳐1", 1, requirementIds = listOf(1L)),
             Question(2L, null, null, QuestionCategory.CULTURE, "컬쳐2", 2, requirementIds = listOf(1L)),
             Question(3L, null, null, QuestionCategory.CULTURE, "컬쳐3", 3, requirementIds = listOf(1L)),
             Question(4L, null, null, QuestionCategory.CULTURE, "컬쳐4", 4, requirementIds = listOf(1L)),
         )
-        whenever(userReader.readById(interviewerUserId)).thenReturn(mock(User::class.java))
+        whenever(memberReader.readById(interviewerMemberId)).thenReturn(
+            MemberFixtureBuilder().id(interviewerMemberId).name("면접관").build(),
+        )
         whenever(questionReader.readAllByIdIn(listOf(1L, 2L, 3L, 4L))).thenReturn(sourceQuestions)
 
         val savedQuestions = listOf(
-            assignedCultureQuestion(11L, interviewerUserId, 1L, isSelected = true, sortOrder = 0),
-            assignedCultureQuestion(12L, interviewerUserId, 2L, isSelected = true, sortOrder = 1),
-            assignedCultureQuestion(13L, interviewerUserId, 3L, isSelected = false, sortOrder = 2),
-            assignedCultureQuestion(14L, interviewerUserId, 4L, isSelected = false, sortOrder = 3),
+            assignedCultureQuestion(11L, interviewerMemberId, 1L, isSelected = true, sortOrder = 0),
+            assignedCultureQuestion(12L, interviewerMemberId, 2L, isSelected = true, sortOrder = 1),
+            assignedCultureQuestion(13L, interviewerMemberId, 3L, isSelected = false, sortOrder = 2),
+            assignedCultureQuestion(14L, interviewerMemberId, 4L, isSelected = false, sortOrder = 3),
         )
         whenever(assignedQuestionWriter.replaceAll(any(), any())).thenReturn(savedQuestions)
 
         val command = SaveAssignedQuestionsCommand(
             questions = sourceQuestions.mapIndexed { index, question ->
                 SaveAssignedQuestionCommand(
-                    assignedInterviewerUserId = interviewerUserId,
+                    assignedMemberId = interviewerMemberId,
                     sourceQuestionId = question.id,
                     content = null,
                     category = AssignedQuestionCategory.CULTURE,
@@ -210,21 +207,23 @@ class AssignedQuestionServiceTest {
 
     @Test
     fun `파트 질문의 content 변경은 인스턴스가 아닌 카탈로그에 반영된다`() {
-        val interviewerUserId = 100L
+        val interviewerMemberId = 100L
         val sourceQuestions = listOf(
             Question(1L, null, null, QuestionCategory.CULTURE, "컬쳐1", 1, requirementIds = listOf(1L)),
             Question(2L, null, null, QuestionCategory.CULTURE, "컬쳐2", 2, requirementIds = listOf(1L)),
             Question(7L, partId, null, QuestionCategory.PART, "카탈로그 파트 질문", 1, requirementIds = listOf(401L)),
         )
-        whenever(userReader.readById(interviewerUserId)).thenReturn(mock(User::class.java))
+        whenever(memberReader.readById(interviewerMemberId)).thenReturn(
+            MemberFixtureBuilder().id(interviewerMemberId).build(),
+        )
         whenever(questionReader.readAllByIdIn(listOf(1L, 2L, 7L))).thenReturn(sourceQuestions)
 
         val savedQuestions = listOf(
-            assignedCultureQuestion(11L, interviewerUserId, 1L, isSelected = true, sortOrder = 0),
-            assignedCultureQuestion(12L, interviewerUserId, 2L, isSelected = true, sortOrder = 1),
+            assignedCultureQuestion(11L, interviewerMemberId, 1L, isSelected = true, sortOrder = 0),
+            assignedCultureQuestion(12L, interviewerMemberId, 2L, isSelected = true, sortOrder = 1),
             AssignedQuestion(
                 id = 17L,
-                assignedInterviewerUserId = interviewerUserId,
+                assignedMemberId = interviewerMemberId,
                 applicantId = applicantId,
                 sourceQuestionId = 7L,
                 content = null,
@@ -237,21 +236,21 @@ class AssignedQuestionServiceTest {
         val command = SaveAssignedQuestionsCommand(
             questions = listOf(
                 SaveAssignedQuestionCommand(
-                    assignedInterviewerUserId = interviewerUserId,
+                    assignedMemberId = interviewerMemberId,
                     sourceQuestionId = 1L,
                     content = null,
                     category = AssignedQuestionCategory.CULTURE,
                     isSelected = true,
                 ),
                 SaveAssignedQuestionCommand(
-                    assignedInterviewerUserId = interviewerUserId,
+                    assignedMemberId = interviewerMemberId,
                     sourceQuestionId = 2L,
                     content = null,
                     category = AssignedQuestionCategory.CULTURE,
                     isSelected = true,
                 ),
                 SaveAssignedQuestionCommand(
-                    assignedInterviewerUserId = interviewerUserId,
+                    assignedMemberId = interviewerMemberId,
                     sourceQuestionId = 7L,
                     content = "새로 수정한 파트 질문",
                     category = AssignedQuestionCategory.PART,
@@ -273,14 +272,16 @@ class AssignedQuestionServiceTest {
 
     @Test
     fun `sourceQuestionId가 없는 신규 PART 질문은 카탈로그에 저장되고 그 id로 배정된다`() {
-        val interviewerUserId = 100L
+        val interviewerMemberId = 100L
         val newQuestionId = 99L
         val cultureQuestions = listOf(
             Question(1L, null, null, QuestionCategory.CULTURE, "컬쳐1", 1, requirementIds = listOf(1L)),
             Question(2L, null, null, QuestionCategory.CULTURE, "컬쳐2", 2, requirementIds = listOf(1L)),
         )
 
-        whenever(userReader.readById(interviewerUserId)).thenReturn(mock(User::class.java))
+        whenever(memberReader.readById(interviewerMemberId)).thenReturn(
+            MemberFixtureBuilder().id(interviewerMemberId).build(),
+        )
         whenever(questionReader.readAllByPartIdAndSemesterId(partId, 1L)).thenReturn(emptyList())
         whenever(questionWriter.save(any())).thenAnswer { invocation ->
             val question = invocation.arguments[0] as Question
@@ -299,11 +300,11 @@ class AssignedQuestionServiceTest {
         whenever(questionReader.readAllByIdIn(listOf(1L, 2L, newQuestionId))).thenReturn(cultureQuestions + newPartQuestion)
 
         val savedAssignedQuestions = listOf(
-            assignedCultureQuestion(21L, interviewerUserId, 1L, isSelected = true, sortOrder = 0),
-            assignedCultureQuestion(22L, interviewerUserId, 2L, isSelected = true, sortOrder = 1),
+            assignedCultureQuestion(21L, interviewerMemberId, 1L, isSelected = true, sortOrder = 0),
+            assignedCultureQuestion(22L, interviewerMemberId, 2L, isSelected = true, sortOrder = 1),
             AssignedQuestion(
                 id = 20L,
-                assignedInterviewerUserId = interviewerUserId,
+                assignedMemberId = interviewerMemberId,
                 applicantId = applicantId,
                 sourceQuestionId = newQuestionId,
                 content = null,
@@ -316,21 +317,21 @@ class AssignedQuestionServiceTest {
         val command = SaveAssignedQuestionsCommand(
             questions = listOf(
                 SaveAssignedQuestionCommand(
-                    assignedInterviewerUserId = interviewerUserId,
+                    assignedMemberId = interviewerMemberId,
                     sourceQuestionId = 1L,
                     content = null,
                     category = AssignedQuestionCategory.CULTURE,
                     isSelected = true,
                 ),
                 SaveAssignedQuestionCommand(
-                    assignedInterviewerUserId = interviewerUserId,
+                    assignedMemberId = interviewerMemberId,
                     sourceQuestionId = 2L,
                     content = null,
                     category = AssignedQuestionCategory.CULTURE,
                     isSelected = true,
                 ),
                 SaveAssignedQuestionCommand(
-                    assignedInterviewerUserId = interviewerUserId,
+                    assignedMemberId = interviewerMemberId,
                     sourceQuestionId = null,
                     content = "새 파트 질문",
                     category = AssignedQuestionCategory.PART,
@@ -353,33 +354,35 @@ class AssignedQuestionServiceTest {
 
     @Test
     fun `PART 질문에 요구조건이 없으면 예외를 발생시킨다`() {
-        val interviewerUserId = 100L
+        val interviewerMemberId = 100L
         val sourceQuestions = listOf(
             Question(1L, null, null, QuestionCategory.CULTURE, "컬쳐1", 1, requirementIds = listOf(1L)),
             Question(2L, null, null, QuestionCategory.CULTURE, "컬쳐2", 2, requirementIds = listOf(1L)),
             Question(7L, partId, null, QuestionCategory.PART, "카탈로그 파트 질문", 1, requirementIds = listOf(401L)),
         )
-        whenever(userReader.readById(interviewerUserId)).thenReturn(mock(User::class.java))
+        whenever(memberReader.readById(interviewerMemberId)).thenReturn(
+            MemberFixtureBuilder().id(interviewerMemberId).build(),
+        )
         whenever(questionReader.readAllByIdIn(listOf(1L, 2L, 7L))).thenReturn(sourceQuestions)
 
         val command = SaveAssignedQuestionsCommand(
             questions = listOf(
                 SaveAssignedQuestionCommand(
-                    assignedInterviewerUserId = interviewerUserId,
+                    assignedMemberId = interviewerMemberId,
                     sourceQuestionId = 1L,
                     content = null,
                     category = AssignedQuestionCategory.CULTURE,
                     isSelected = true,
                 ),
                 SaveAssignedQuestionCommand(
-                    assignedInterviewerUserId = interviewerUserId,
+                    assignedMemberId = interviewerMemberId,
                     sourceQuestionId = 2L,
                     content = null,
                     category = AssignedQuestionCategory.CULTURE,
                     isSelected = true,
                 ),
                 SaveAssignedQuestionCommand(
-                    assignedInterviewerUserId = interviewerUserId,
+                    assignedMemberId = interviewerMemberId,
                     sourceQuestionId = 7L,
                     content = "파트 질문",
                     category = AssignedQuestionCategory.PART,
@@ -397,7 +400,7 @@ class AssignedQuestionServiceTest {
     fun `INTRO, OUTRO 질문에 요구조건을 지정하면 예외를 발생시킨다`(
         targetCategory: AssignedQuestionCategory
     ) {
-        val interviewerUserId = 100L
+        val interviewerMemberId = 100L
         val targetSourceQuestionId = 1L
 
         val sourceQuestions = listOf(
@@ -422,20 +425,22 @@ class AssignedQuestionServiceTest {
             ),
         )
 
-        whenever(userReader.readById(interviewerUserId)).thenReturn(mock(User::class.java))
+        whenever(memberReader.readById(interviewerMemberId)).thenReturn(
+            MemberFixtureBuilder().id(interviewerMemberId).build(),
+        )
         whenever(questionReader.readAllByIdIn(any())).thenReturn(sourceQuestions)
 
         val command = SaveAssignedQuestionsCommand(
             questions = listOf(
                 SaveAssignedQuestionCommand(
-                    assignedInterviewerUserId = interviewerUserId,
+                    assignedMemberId = interviewerMemberId,
                     sourceQuestionId = targetSourceQuestionId,
                     content = null,
                     category = targetCategory,
                     requirementIds = listOf(1L),
                 ),
                 SaveAssignedQuestionCommand(
-                    assignedInterviewerUserId = interviewerUserId,
+                    assignedMemberId = interviewerMemberId,
                     sourceQuestionId = targetSourceQuestionId + 1,
                     content = null,
                     isSelected = true,
@@ -443,7 +448,7 @@ class AssignedQuestionServiceTest {
                     requirementIds = listOf(1L),
                 ),
                 SaveAssignedQuestionCommand(
-                    assignedInterviewerUserId = interviewerUserId,
+                    assignedMemberId = interviewerMemberId,
                     sourceQuestionId = targetSourceQuestionId + 2,
                     content = null,
                     isSelected = true,
@@ -459,13 +464,13 @@ class AssignedQuestionServiceTest {
 
     @Test
     fun `제출된 면접 평가가 있으면 질문지 수정 시 예외를 발생시킨다`() {
-        val interviewerUserId = 100L
+        val interviewerMemberId = 100L
         whenever(interviewEvaluationReader.existsByApplicantId(applicantId)).thenReturn(true)
 
         val command = SaveAssignedQuestionsCommand(
             questions = listOf(
                 SaveAssignedQuestionCommand(
-                    assignedInterviewerUserId = interviewerUserId,
+                    assignedMemberId = interviewerMemberId,
                     sourceQuestionId = 1L,
                     content = null,
                     category = AssignedQuestionCategory.CULTURE,
@@ -480,39 +485,20 @@ class AssignedQuestionServiceTest {
 
     private fun assignedCultureQuestion(
         id: Long,
-        interviewerUserId: Long,
+        interviewerMemberId: Long,
         sourceQuestionId: Long,
         isSelected: Boolean,
         sortOrder: Int,
     ): AssignedQuestion {
         return AssignedQuestion(
             id = id,
-            assignedInterviewerUserId = interviewerUserId,
+            assignedMemberId = interviewerMemberId,
             applicantId = applicantId,
             sourceQuestionId = sourceQuestionId,
             content = null,
             category = AssignedQuestionCategory.CULTURE,
             sortOrder = sortOrder,
             isSelected = isSelected,
-        )
-    }
-
-    private fun user(id: Long, name: String, email: String): User {
-        return User(
-            id = id,
-            userInfo = UserInfo(
-                name = name,
-                email = email,
-                profileImageUrl = "",
-                oauthId = "oauth-$id",
-                oauth2Type = OAuth2Type.GOOGLE,
-            ),
-            tokenInfo = TokenInfo(
-                tokenPrefix = "Bearer",
-                accessToken = "access-token",
-                refreshToken = "refresh-token",
-                accessTokenExpiresIn = 3600L,
-            ),
         )
     }
 }

--- a/src/test/kotlin/com/yourssu/scouter/recruiting/interviewQuestion/implement/AssignedQuestionTest.kt
+++ b/src/test/kotlin/com/yourssu/scouter/recruiting/interviewQuestion/implement/AssignedQuestionTest.kt
@@ -13,7 +13,7 @@ class AssignedQuestionTest {
     fun `카탈로그 질문은 sourceQuestionId가 필요하다`() {
         assertThatThrownBy {
             AssignedQuestion(
-                assignedInterviewerUserId = 1L,
+                assignedMemberId = 1L,
                 applicantId = 1L,
                 sourceQuestionId = null,
                 content = null,
@@ -28,7 +28,7 @@ class AssignedQuestionTest {
     fun `전역 질문은 content를 직접 가질 수 없다`(questionCategory: AssignedQuestionCategory) {
         assertThatThrownBy {
             AssignedQuestion(
-                assignedInterviewerUserId = 1L,
+                assignedMemberId = 1L,
                 applicantId = 1L,
                 sourceQuestionId = 1L,
                 content = "직접 수정한 질문",
@@ -42,7 +42,7 @@ class AssignedQuestionTest {
     fun `컬쳐 질문은 content를 직접 가질 수 없다`() {
         assertThatThrownBy {
             AssignedQuestion(
-                assignedInterviewerUserId = 1L,
+                assignedMemberId = 1L,
                 applicantId = 1L,
                 sourceQuestionId = 1L,
                 content = "직접 수정한 질문",
@@ -56,7 +56,7 @@ class AssignedQuestionTest {
     fun `파트 질문은 카탈로그 기반이라 content를 직접 가질 수 없다`() {
         assertThatThrownBy {
             AssignedQuestion(
-                assignedInterviewerUserId = 1L,
+                assignedMemberId = 1L,
                 applicantId = 1L,
                 sourceQuestionId = 1L,
                 content = "직접 수정한 질문",
@@ -70,7 +70,7 @@ class AssignedQuestionTest {
     fun `개인 질문은 content가 필요하다`() {
         assertThatThrownBy {
             AssignedQuestion(
-                assignedInterviewerUserId = 1L,
+                assignedMemberId = 1L,
                 applicantId = 1L,
                 sourceQuestionId = null,
                 content = null,
@@ -85,7 +85,7 @@ class AssignedQuestionTest {
     fun `카탈로그 질문은 요구조건을 직접 가질 수 없다`() {
         assertThatThrownBy {
             AssignedQuestion(
-                assignedInterviewerUserId = 1L,
+                assignedMemberId = 1L,
                 applicantId = 1L,
                 sourceQuestionId = 1L,
                 content = null,
@@ -100,7 +100,7 @@ class AssignedQuestionTest {
     fun `개인 질문은 요구조건이 최소 1개 필요하다`() {
         assertThatThrownBy {
             AssignedQuestion(
-                assignedInterviewerUserId = 1L,
+                assignedMemberId = 1L,
                 applicantId = 1L,
                 sourceQuestionId = null,
                 content = "개인 질문",

--- a/src/test/kotlin/com/yourssu/scouter/recruiting/interviewQuestion/implement/AssignedQuestionValidatorTest.kt
+++ b/src/test/kotlin/com/yourssu/scouter/recruiting/interviewQuestion/implement/AssignedQuestionValidatorTest.kt
@@ -78,7 +78,7 @@ class AssignedQuestionValidatorTest {
         isSelected: Boolean? = null,
     ): AssignedQuestion {
         return AssignedQuestion(
-            assignedInterviewerUserId = 1L,
+            assignedMemberId = 1L,
             applicantId = 1L,
             sourceQuestionId = sourceQuestionId,
             content = null,

--- a/src/test/kotlin/com/yourssu/scouter/recruiting/interviewQuestion/storage/AssignedQuestionRepositoryImplTest.kt
+++ b/src/test/kotlin/com/yourssu/scouter/recruiting/interviewQuestion/storage/AssignedQuestionRepositoryImplTest.kt
@@ -93,14 +93,14 @@ class AssignedQuestionRepositoryImplTest {
         assertThat(replaced).hasSize(1)
         assertThat(found).hasSize(1)
         assertThat(found[0].content).isEqualTo("새 질문")
-        assertThat(found[0].assignedInterviewerUserId).isEqualTo(interviewerUserId)
+        assertThat(found[0].assignedMemberId).isEqualTo(interviewerUserId)
         assertThat(found[0].isSelected).isTrue()
         assertThat(found[0].requirementIds).containsExactly(11L, 12L)
     }
 
     private fun personalQuestion(content: String, sortOrder: Int, requirementIds: List<Long>): AssignedQuestion {
         return AssignedQuestion(
-            assignedInterviewerUserId = interviewerUserId,
+            assignedMemberId = interviewerUserId,
             applicantId = applicantId,
             sourceQuestionId = null,
             content = content,


### PR DESCRIPTION
## 📄 작업 내용 요약
1. 면접 질문자 식별자 변경 /applicants/{applicantId}/interivews/questions

기존: assignedInterviewerUserId

변경: assignedMemberId

면접 질문 저장 API의 요청 필드명을 위와 같이 변경

2. 면접 질문자 지정 기준 변경

해당 학기의 Active Member 조회 API에서 반환되는 memberId를 기준으로 면접 질문자를 지정할 수 있도록 수정

기존처럼 userId가 존재하는 멤버만 지정 가능한 것이 아니라, Active Member의 memberId를 그대로 사용하여 지정 가능하도록 변경

3. 프론트엔드 반영

해당 학기의 Active Member 조회 결과의 memberId를 그대로 사용하여 지정 가능한 면접 질문자 토글에 노출

질문지 저장 API 호출 시 선택한 면접 질문자의 memberId를 assignedMemberId 값으로 전달

## 📎 Issue 번호
closed #450 
