### PR TITLE
[#453]; refactor: 지원자 상태(state)를 요청/응답 DTO에서 Enum으로 사용하도록 변경

### DIFF
--- a/src/main/kotlin/com/yourssu/scouter/recruiting/applicant/application/dto/CreateApplicantRequest.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/applicant/application/dto/CreateApplicantRequest.kt
@@ -18,12 +18,9 @@ data class CreateApplicantRequest(
     @field:NotBlank(message = "이름을 입력하지 않았습니다.")
     val name: String,
 
-    @field:NotBlank(message = "상태를 입력하지 않았습니다.")
-    @field:Schema(
-        example = "UNDER_REVIEW",
-        description = "UNDER_REVIEW | DOCUMENT_ACCEPTED | DOCUMENT_REJECTED | ASSIGNMENT_ACCEPTED | ASSIGNMENT_REJECTED | INTERVIEW_ACCEPTED | INTERVIEW_REJECTED | INCUBATING_REJECTED | FINAL_ACCEPTED"
-    )
-    val state: String,
+    @field:NotNull(message = "상태를 입력하지 않았습니다.")
+    @field:Schema(example = "UNDER_REVIEW")
+    val state: ApplicantState,
 
     @field:NotNull(message = "지원일을 입력하지 않았습니다.")
     @field:Schema(pattern = "yyyy-MM-dd", example = "2025-11-10")
@@ -65,8 +62,7 @@ data class CreateApplicantRequest(
     fun toCommand(): CreateApplicantCommand = CreateApplicantCommand(
         partId = partId,
         name = name,
-        state = runCatching { ApplicantState.valueOf(state) }
-            .getOrElse { throw IllegalArgumentException("허용되지 않는 state 값입니다: $state") },
+        state = state,
         applicationDate = applicationDate,
         email = email,
         phoneNumber = phoneNumber,

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/applicant/application/dto/ReadApplicantResponse.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/applicant/application/dto/ReadApplicantResponse.kt
@@ -1,6 +1,7 @@
 package com.yourssu.scouter.recruiting.applicant.application.dto
 
 import com.yourssu.scouter.recruiting.applicant.business.dto.ApplicantDto
+import com.yourssu.scouter.recruiting.applicant.implement.ApplicantState
 import java.time.Instant
 import java.time.LocalDate
 import java.time.ZoneOffset
@@ -15,7 +16,7 @@ data class ReadApplicantResponse(
 
     val name: String,
 
-    val state: String,
+    val state: ApplicantState,
 
     val applicationDate: LocalDate,
 
@@ -48,7 +49,7 @@ data class ReadApplicantResponse(
             division = applicantDto.part.division.name,
             part = applicantDto.part.name,
             name = applicantDto.name,
-            state = applicantDto.state.name,
+            state = applicantDto.state,
             applicationDate = applicantDto.applicationDateTime.atZone(ZoneOffset.UTC).toLocalDate(),
             applicationSemester = applicantDto.applicationSemester.toString(),
             email = applicantDto.email,

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/applicant/application/dto/UpdateApplicantRequest.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/applicant/application/dto/UpdateApplicantRequest.kt
@@ -13,8 +13,8 @@ data class UpdateApplicantRequest(
 
     val name: String? = null,
 
-    @field:Schema(example = "UNDER_REVIEW", description = "UNDER_REVIEW | DOCUMENT_ACCEPTED | DOCUMENT_REJECTED | ASSIGNMENT_ACCEPTED | ASSIGNMENT_REJECTED | INTERVIEW_ACCEPTED | INTERVIEW_REJECTED | INCUBATING_REJECTED | FINAL_ACCEPTED")
-    val state: String? = null,
+    @field:Schema(example = "UNDER_REVIEW")
+    val state: ApplicantState? = null,
 
     val applicationDate: LocalDate? = null,
 
@@ -47,10 +47,7 @@ data class UpdateApplicantRequest(
         targetApplicantId = applicantId,
         partId = partId,
         name = name,
-        state = state?.let {
-            runCatching { ApplicantState.valueOf(it) }
-                .getOrElse { throw IllegalArgumentException("허용되지 않는 state 값입니다: $it") }
-        },
+        state = state,
         applicationDate = applicationDate,
         email = email,
         phoneNumber = phoneNumber,

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/applicant/business/ApplicantService.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/applicant/business/ApplicantService.kt
@@ -24,6 +24,7 @@ import com.yourssu.scouter.masterdata.semester.implement.Semester
 import com.yourssu.scouter.masterdata.semester.implement.SemesterReader
 import com.yourssu.scouter.recruiting.evaluation.implement.DocumentEvaluation
 import com.yourssu.scouter.recruiting.evaluation.implement.DocumentEvaluationReader
+import com.yourssu.scouter.recruiting.support.business.utils.ApplicantStateConverter
 import org.springframework.stereotype.Service
 
 @Service
@@ -76,10 +77,7 @@ class ApplicantService(
             applicants = applicants.filter { it.name.contains(name, ignoreCase = true) }
         }
         if (!states.isNullOrEmpty()) {
-            val applicantStates: List<ApplicantState> = states.map { state ->
-                runCatching { ApplicantState.valueOf(state) }
-                    .getOrElse { throw IllegalArgumentException("허용되지 않는 state 값입니다: $state") }
-            }
+            val applicantStates: List<ApplicantState> = states.map(ApplicantStateConverter::convertToEnum)
             applicants = applicants.filter { it.state in applicantStates }
         }
         if (semesterId != null) {

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/support/business/utils/ApplicantStateConverter.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/support/business/utils/ApplicantStateConverter.kt
@@ -1,0 +1,10 @@
+package com.yourssu.scouter.recruiting.support.business.utils
+
+import com.yourssu.scouter.recruiting.applicant.implement.ApplicantState
+
+object ApplicantStateConverter {
+
+    fun convertToEnum(state: String): ApplicantState =
+        runCatching { ApplicantState.valueOf(state) }
+            .getOrElse { throw IllegalArgumentException("허용되지 않는 state 값입니다: $state") }
+}


### PR DESCRIPTION
## 변경 사항
- CreateApplicantRequest.state / UpdateApplicantRequest.state / ReadApplicantResponse.state를 String에서 ApplicantState Enum으로 변경
  - Jackson이 역/직렬화 시점에 자동으로 값 검증을 수행하며, 잘못된 값은 기존과 동일하게 400(Request-Validation-Fail)으로 응답됩니다.
- 컨트롤러 쿼리 파라미터(`states`)처럼 응답 형식을 직접 제어해야 하는 곳은 문자열 파싱이 여전히 필요해, 중복돼 있던 `ApplicantState.valueOf` 파싱/에러 메시지 로직을 `recruiting/support/business/utils/ApplicantStateConverter`로 추출했습니다.

## 배경
같은 파싱 보일러플레이트가 CreateApplicantRequest, UpdateApplicantRequest, ApplicantService 세 곳에 중복되어 있었습니다. Request/Response DTO 필드를 Enum 타입으로 바꿔 각 DTO에서의 중복은 제거하고, 여전히 문자열로 들어오는 쿼리 파라미터 변환 로직만 공용 컨버터로 모았습니다.

Closes #453