### PR TITLE
[#462]; fix: 파트에 평가 존재 시 공통질문 신규 생성/변경을 차단

### DIFF
--- a/src/main/kotlin/com/yourssu/scouter/recruiting/interviewQuestion/business/AssignedQuestionService.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/interviewQuestion/business/AssignedQuestionService.kt
@@ -70,20 +70,43 @@ class AssignedQuestionService(
         val applicantPartId = applicant.part.id!!
         val applicantSemesterId = applicant.applicationSemester.id!!
 
-        val resolvedSourceQuestionIds = createNewPartQuestions(command.questions, applicantPartId, applicantSemesterId)
+        // 같은 파트의 다른 지원자가 이미 면접 평가를 받았다면, 그 평가가 근거한 파트 공유 질문(카탈로그)이
+        // 아직 평가받지 않은 지원자의 요청으로 우회 수정되지 않도록 파트 단위로 잠근다.
+        val partLocked = isPartLocked(applicantPartId, applicantSemesterId)
 
-        val questions =
-            command.questions.mapIndexed { index, question ->
+        val resolvedSourceQuestionIds =
+            createNewPartQuestions(command.questions, applicantPartId, applicantSemesterId, partLocked)
+
+        val existingQuestionsByKey = if (partLocked) {
+            assignedQuestionReader.readAllByApplicantId(applicantId).associateBy { it.category to it.sourceQuestionId }
+        } else {
+            emptyMap()
+        }
+
+        val questions = command.questions.withIndex()
+            .filterNot { (_, question) ->
+                // 파트가 잠긴 상태에서 신규 PART 질문 생성 요청은 조용히 무시한다.
+                partLocked && question.category == AssignedQuestionCategory.PART && question.sourceQuestionId == null
+            }
+            .mapIndexed { sortOrder, (originalIndex, question) ->
                 memberReader.readById(question.assignedMemberId)
+
+                val sourceQuestionId = resolvedSourceQuestionIds[originalIndex] ?: question.sourceQuestionId
+                // 파트가 잠긴 상태에서 CULTURE 선택 변경 요청은 조용히 무시하고 기존 선택 상태를 유지한다.
+                val isSelected = if (partLocked && question.category == AssignedQuestionCategory.CULTURE) {
+                    existingQuestionsByKey[question.category to sourceQuestionId]?.isSelected ?: false
+                } else {
+                    question.isSelected
+                }
 
                 AssignedQuestion(
                     assignedMemberId = question.assignedMemberId,
                     applicantId = applicantId,
-                    sourceQuestionId = resolvedSourceQuestionIds[index] ?: question.sourceQuestionId,
+                    sourceQuestionId = sourceQuestionId,
                     content = if (question.category == AssignedQuestionCategory.PERSONAL) question.content else null,
                     category = question.category,
-                    sortOrder = index,
-                    isSelected = question.isSelected,
+                    sortOrder = sortOrder,
+                    isSelected = isSelected,
                     requirementIds =
                         if (question.category == AssignedQuestionCategory.PERSONAL) {
                             question.requirementIds ?: emptyList()
@@ -95,7 +118,7 @@ class AssignedQuestionService(
         val sourceQuestionsById = readSourceQuestionsById(questions)
         assignedQuestionValidator.validate(questions, sourceQuestionsById, applicantPartId)
 
-        updateCatalogQuestions(command.questions, sourceQuestionsById)
+        updateCatalogQuestions(command.questions, sourceQuestionsById, partLocked)
 
         val saved = assignedQuestionWriter.replaceAll(applicantId, questions)
 
@@ -117,7 +140,10 @@ class AssignedQuestionService(
         questions: List<SaveAssignedQuestionCommand>,
         applicantPartId: Long,
         applicantSemesterId: Long,
+        partLocked: Boolean,
     ): Map<Int, Long> {
+        if (partLocked) return emptyMap()
+
         val newPartQuestions =
             questions.withIndex().filter { (_, question) ->
                 question.category == AssignedQuestionCategory.PART && question.sourceQuestionId == null
@@ -150,9 +176,11 @@ class AssignedQuestionService(
     private fun updateCatalogQuestions(
         questions: List<SaveAssignedQuestionCommand>,
         sourceQuestionsById: Map<Long?, Question>,
+        partLocked: Boolean,
     ) {
         // 카탈로그 카테고리(INTRO/OUTRO/CULTURE/PART)의 content와 요구조건은 인스턴스가 아닌 원본 질문(Question)에 매핑된다.
         // INTRO/OUTRO/CULTURE는 이 요청으로 값을 변경할 수 없고, PART만 여기서 갱신 가능하다.
+        // 단, 같은 파트의 다른 지원자가 이미 평가를 받아 파트가 잠긴 경우에는 PART 질문 변경 요청도 조용히 무시한다.
         questions
             .filter { it.sourceQuestionId != null }
             .forEach { question ->
@@ -172,6 +200,8 @@ class AssignedQuestionService(
                     }
 
                     QuestionCategory.PART -> {
+                        if (partLocked) return@forEach
+
                         val updatedQuestion =
                             Question(
                                 id = sourceQuestion.id,
@@ -186,6 +216,15 @@ class AssignedQuestionService(
                     }
                 }
             }
+    }
+
+    private fun isPartLocked(partId: Long, semesterId: Long): Boolean {
+        val applicantIdsInPart = applicantReader.readByPartId(partId)
+            .filter { it.applicationSemester.id == semesterId }
+            .mapNotNull { it.id }
+        if (applicantIdsInPart.isEmpty()) return false
+
+        return interviewEvaluationReader.readAllByApplicantIdIn(applicantIdsInPart).isNotEmpty()
     }
 
     private fun readSourceQuestionsById(questions: List<AssignedQuestion>): Map<Long?, Question> =


### PR DESCRIPTION
## Summary

* 같은 파트의 다른 지원자가 이미 면접 평가를 받은 경우, 아직 평가받지 않은 지원자의 질문지 upsert 요청으로 파트 공유 질문(카탈로그)이 우회 수정되는 문제를 차단합니다.
* `AssignedQuestionService.upsert()`에 파트 단위 잠금(`isPartLocked`)을 추가하고, 잠긴 상태에서는 다음 요청을 조용히 무시합니다.
  * 신규 PART 질문 생성 (`sourceQuestionId = null`)
  * 기존 PART 질문의 content/requirementIds 변경
  * CULTURE `isSelected` 변경 (기존 값 유지)
* 새 테이블/스키마 변경 없이 기존 Reader만 조합해서 구현했습니다 (`applicantReader.readByPartId` + `interviewEvaluationReader.readAllByApplicantIdIn`).

Closes yourssu/Yourssu-Scouter-Backend#462

## Note

* CULTURE `isSelected`가 지원자 개인 데이터가 아니라 파트 단위로 공유돼야 하는 개념이라는 논의가 있었으나, 구조 변경(파트-질문 매핑 테이블 도입)은 다른 작업과의 충돌 우려로 이번 PR 범위에서 제외했습니다. 이번 변경은 현재 스키마를 유지한 채 기존 엔티티 값을 조회해 우회 수정만 막는 임시 조치입니다.
* 알려진 엣지케이스: 같은 파트에 이미 평가받은 지원자가 있고, 아직 질문지를 한 번도 저장한 적 없는 다른 지원자가 처음 upsert를 시도하면 CULTURE 선택 개수(2개) 검증에 걸려 실패합니다. 파트 단위 선택 구조로 리팩토링하면 해소됩니다.

## Test plan

- [X] `./gradlew compileKotlin` 통과 확인
- [ ] 같은 파트 내 지원자 A(평가 완료) / B(미평가) 시나리오로 upsert 무시 동작 수동 확인