### PR TITLE
[#466]; 평가자 상태/조회 응답에 닉네임 필드 추가

### DIFF
--- a/src/main/kotlin/com/yourssu/scouter/member/core/implement/MemberEvaluatorDirectory.kt
+++ b/src/main/kotlin/com/yourssu/scouter/member/core/implement/MemberEvaluatorDirectory.kt
@@ -5,6 +5,8 @@ import com.yourssu.scouter.recruiting.support.business.EvaluatorInfo
 import com.yourssu.scouter.recruiting.support.business.EvaluatorSummary
 import org.springframework.stereotype.Component
 
+import com.yourssu.scouter.member.support.converter.NicknameConverter
+
 @Component
 class MemberEvaluatorDirectory(
     private val memberReader: MemberReader,
@@ -13,13 +15,21 @@ class MemberEvaluatorDirectory(
     override fun findEvaluatorsByPartId(partId: Long): List<EvaluatorSummary> =
         memberReader.readAllActive()
             .filter { activeMember -> activeMember.member.parts.any { it.id == partId } }
-            .map { EvaluatorSummary(email = it.member.email, name = it.member.name, memberId = it.member.id!!) }
+            .map {
+                EvaluatorSummary(
+                    email = it.member.email,
+                    name = it.member.name,
+                    nickname = NicknameConverter.combine(it.member.nicknameEnglish, it.member.nicknameKorean),
+                    memberId = it.member.id!!,
+                )
+            }
 
     override fun findEvaluatorInfo(email: String): EvaluatorInfo? {
         val member = memberReader.readAllActive().find { it.member.email == email }?.member ?: return null
         return EvaluatorInfo(
             memberId = member.id,
             nicknameEnglish = member.nicknameEnglish,
+            nicknameKorean = member.nicknameKorean,
             partName = member.parts.firstOrNull()?.name,
         )
     }

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/application/dto/ReadEvaluatorStatusResponse.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/application/dto/ReadEvaluatorStatusResponse.kt
@@ -12,11 +12,13 @@ data class ReadEvaluatorStatusResponse(
     val userId: Long?,
     @field:Schema(description = "평가자 이름", example = "홍길동", nullable = false)
     val name: String,
+    @field:Schema(description = "평가자 닉네임", example = "gildong(길동)", nullable = false)
+    val nickname: String,
     @field:Schema(description = "평가 작성 상태", example = "SUBMITTED", allowableValues = ["NOT_STARTED", "IN_PROGRESS", "SUBMITTED"], nullable = false)
     val status: EvaluationStatus,
 ) {
     companion object {
         fun from(dto: EvaluatorStatusDto): ReadEvaluatorStatusResponse =
-            ReadEvaluatorStatusResponse(dto.memberId, dto.userId, dto.name, dto.status)
+            ReadEvaluatorStatusResponse(dto.memberId, dto.userId, dto.name, dto.nickname, dto.status)
     }
 }

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/application/dto/ReadOtherDocumentEvaluationResponse.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/application/dto/ReadOtherDocumentEvaluationResponse.kt
@@ -3,6 +3,7 @@ package com.yourssu.scouter.recruiting.evaluation.application.dto
 import com.yourssu.scouter.recruiting.evaluation.business.dto.OtherDocumentEvaluationDto
 import com.yourssu.scouter.recruiting.evaluation.business.dto.OtherDocumentEvaluationItemDto
 import com.yourssu.scouter.recruiting.evaluation.implement.DocumentResult
+import io.swagger.v3.oas.annotations.media.Schema
 
 data class ReadOtherDocumentEvaluationItemResponse(
     val sectionId: Long,
@@ -15,9 +16,14 @@ data class ReadOtherDocumentEvaluationItemResponse(
     }
 }
 
+@Schema(description = "다른 평가자의 서류 평가 조회 응답")
 data class ReadOtherDocumentEvaluationResponse(
+    @field:Schema(description = "평가자 사용자 ID", example = "23", nullable = false)
     val evaluatorId: Long,
+    @field:Schema(description = "평가자 이름", example = "홍길동", nullable = false)
     val evaluatorName: String,
+    @field:Schema(description = "평가자 닉네임", example = "gildong(길동)", nullable = false)
+    val evaluatorNickname: String,
     val totalScore: Int,
     val result: DocumentResult,
     val overallComment: String,
@@ -27,6 +33,7 @@ data class ReadOtherDocumentEvaluationResponse(
         fun from(dto: OtherDocumentEvaluationDto): ReadOtherDocumentEvaluationResponse = ReadOtherDocumentEvaluationResponse(
             evaluatorId = dto.evaluatorId,
             evaluatorName = dto.evaluatorName,
+            evaluatorNickname = dto.evaluatorNickname,
             totalScore = dto.totalScore,
             result = dto.result,
             overallComment = dto.overallComment,

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/application/dto/ReadOtherInterviewEvaluationResponse.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/application/dto/ReadOtherInterviewEvaluationResponse.kt
@@ -24,6 +24,8 @@ data class ReadOtherInterviewEvaluationResponse(
     val evaluatorId: Long,
     @field:Schema(description = "평가자 이름", example = "홍길동", nullable = false)
     val evaluatorName: String,
+    @field:Schema(description = "평가자 닉네임", example = "gildong(길동)", nullable = false)
+    val evaluatorNickname: String,
     @field:Schema(description = "평가 항목 점수의 합계", example = "85", nullable = false)
     val totalScore: Int,
     @field:Schema(description = "면접 평가 결과", example = "FINAL_PASS", allowableValues = ["PENDING", "FINAL_PASS", "INTERVIEW_FAIL"], nullable = false)
@@ -37,6 +39,7 @@ data class ReadOtherInterviewEvaluationResponse(
         fun from(dto: OtherInterviewEvaluationDto): ReadOtherInterviewEvaluationResponse = ReadOtherInterviewEvaluationResponse(
             evaluatorId = dto.evaluatorId,
             evaluatorName = dto.evaluatorName,
+            evaluatorNickname = dto.evaluatorNickname,
             totalScore = dto.totalScore,
             result = dto.result,
             overallComment = dto.overallComment,

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/business/DocumentEvaluationService.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/business/DocumentEvaluationService.kt
@@ -27,6 +27,7 @@ import com.yourssu.scouter.recruiting.rubric.implement.DocumentSectionReader
 import com.yourssu.scouter.recruiting.support.business.EvaluatorDirectory
 import com.yourssu.scouter.recruiting.support.implement.exception.DocumentEvaluationInvalidScoreException
 import com.yourssu.scouter.recruiting.support.implement.exception.DocumentSectionNotFoundException
+import com.yourssu.scouter.member.support.converter.NicknameConverter
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.Instant
@@ -100,9 +101,15 @@ class DocumentEvaluationService(
         return evaluations.map { evaluation ->
             val masked = evaluation.maskedFor(viewerHasSubmitted)
             val evaluator: User? = evaluators[evaluation.evaluatorUserId]
+            val evaluatorInfo = evaluator?.let { evaluatorDirectory.findEvaluatorInfo(it.userInfo.email) }
+            val nickname = if (evaluatorInfo?.nicknameEnglish != null && evaluatorInfo.nicknameKorean != null) {
+                NicknameConverter.combine(evaluatorInfo.nicknameEnglish, evaluatorInfo.nicknameKorean)
+            } else ""
+
             OtherDocumentEvaluationDto(
                 evaluatorId = evaluation.evaluatorUserId,
                 evaluatorName = evaluator?.userInfo?.name ?: "",
+                evaluatorNickname = nickname,
                 totalScore = evaluation.totalScore(),
                 result = evaluation.result,
                 overallComment = masked.overallComment,
@@ -132,7 +139,13 @@ class DocumentEvaluationService(
                 else -> EvaluationStatus.IN_PROGRESS
             }
 
-            EvaluatorStatusDto(memberId = evaluator.memberId, userId = user?.id, name = evaluator.name, status = status)
+            EvaluatorStatusDto(
+                memberId = evaluator.memberId,
+                userId = user?.id,
+                name = evaluator.name,
+                nickname = evaluator.nickname,
+                status = status
+            )
         }
     }
 

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/business/InterviewEvaluationService.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/business/InterviewEvaluationService.kt
@@ -12,6 +12,7 @@ import com.yourssu.scouter.recruiting.rubric.implement.RubricGroupType
 import com.yourssu.scouter.recruiting.support.business.EvaluatorDirectory
 import com.yourssu.scouter.recruiting.support.implement.exception.InterviewEvaluationInvalidScoreException
 import com.yourssu.scouter.recruiting.support.implement.exception.InterviewEvaluationItemNotFoundException
+import com.yourssu.scouter.member.support.converter.NicknameConverter
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDateTime
@@ -131,12 +132,18 @@ class InterviewEvaluationService(
 
         return finalEvaluations.map { finalEval ->
             val evaluator = evaluators[finalEval.evaluatorUserId]
+            val evaluatorInfo = evaluator?.let { evaluatorDirectory.findEvaluatorInfo(it.userInfo.email) }
+            val nickname = if (evaluatorInfo?.nicknameEnglish != null && evaluatorInfo.nicknameKorean != null) {
+                NicknameConverter.combine(evaluatorInfo.nicknameEnglish, evaluatorInfo.nicknameKorean)
+            } else ""
+
             val comment = if (viewerHasSubmitted) finalEval.overallComment else "" // 내 평가를 제출하지 않았다면 다른 사람의 총평을 볼수 없게 한다.
             val evaluation = evaluationsByEvaluator[finalEval.evaluatorUserId]
 
             OtherInterviewEvaluationDto(
                 evaluatorId = finalEval.evaluatorUserId,
                 evaluatorName = evaluator?.userInfo?.name ?: "",
+                evaluatorNickname = nickname,
                 totalScore = finalEval.score,
                 result = finalEval.interviewResult,
                 overallComment = comment,
@@ -167,6 +174,7 @@ class InterviewEvaluationService(
                 memberId = evaluator.memberId,
                 userId = user?.id,
                 name = evaluator.name,
+                nickname = evaluator.nickname,
                 status = status
             )
         }

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/business/dto/EvaluatorStatusDto.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/business/dto/EvaluatorStatusDto.kt
@@ -6,5 +6,6 @@ data class EvaluatorStatusDto(
     val memberId: Long,
     val userId: Long?,
     val name: String,
+    val nickname: String,
     val status: EvaluationStatus,
 )

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/business/dto/OtherDocumentEvaluationDto.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/business/dto/OtherDocumentEvaluationDto.kt
@@ -11,6 +11,7 @@ data class OtherDocumentEvaluationItemDto(
 data class OtherDocumentEvaluationDto(
     val evaluatorId: Long,
     val evaluatorName: String,
+    val evaluatorNickname: String,
     val totalScore: Int,
     val result: DocumentResult,
     val overallComment: String,

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/business/dto/OtherInterviewEvaluationDto.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/evaluation/business/dto/OtherInterviewEvaluationDto.kt
@@ -5,6 +5,7 @@ import com.yourssu.scouter.recruiting.evaluation.implement.InterviewResult
 data class OtherInterviewEvaluationDto(
     val evaluatorId: Long,
     val evaluatorName: String,
+    val evaluatorNickname: String,
     val totalScore: Int,
     val result: InterviewResult,
     val overallComment: String,

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/support/business/EvaluatorDirectory.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/support/business/EvaluatorDirectory.kt
@@ -8,11 +8,13 @@ interface EvaluatorDirectory {
 data class EvaluatorSummary(
     val email: String,
     val name: String,
+    val nickname: String,
     val memberId: Long,
 )
 
 data class EvaluatorInfo(
     val memberId: Long?,
     val nicknameEnglish: String?,
+    val nicknameKorean: String?,
     val partName: String?,
 )

--- a/src/test/kotlin/com/yourssu/scouter/recruiting/evaluation/business/InterviewEvaluationServiceNicknameTest.kt
+++ b/src/test/kotlin/com/yourssu/scouter/recruiting/evaluation/business/InterviewEvaluationServiceNicknameTest.kt
@@ -1,0 +1,127 @@
+package com.yourssu.scouter.recruiting.evaluation.business
+
+import com.yourssu.scouter.auth.user.implement.User
+import com.yourssu.scouter.auth.user.implement.UserInfo
+import com.yourssu.scouter.auth.user.implement.UserReader
+import com.yourssu.scouter.recruiting.applicant.implement.Applicant
+import com.yourssu.scouter.recruiting.applicant.implement.ApplicantReader
+import com.yourssu.scouter.recruiting.evaluation.implement.*
+import com.yourssu.scouter.recruiting.rubric.implement.InterviewRubricReader
+import com.yourssu.scouter.recruiting.rubric.implement.InterviewRubricWriter
+import com.yourssu.scouter.recruiting.support.business.EvaluatorDirectory
+import com.yourssu.scouter.recruiting.support.business.EvaluatorInfo
+import com.yourssu.scouter.recruiting.support.business.EvaluatorSummary
+import com.yourssu.scouter.masterdata.part.implement.Part
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.mockito.BDDMockito.given
+import org.mockito.Mockito.mock
+
+class InterviewEvaluationServiceNicknameTest {
+
+    private val interviewEvaluationReader: InterviewEvaluationReader = mock(InterviewEvaluationReader::class.java)
+    private val interviewEvaluationWriter: InterviewEvaluationWriter = mock(InterviewEvaluationWriter::class.java)
+    private val finalEvaluationReader: FinalEvaluationReader = mock(FinalEvaluationReader::class.java)
+    private val finalEvaluationWriter: FinalEvaluationWriter = mock(FinalEvaluationWriter::class.java)
+    private val interviewRubricReader: InterviewRubricReader = mock(InterviewRubricReader::class.java)
+    private val interviewRubricWriter: InterviewRubricWriter = mock(InterviewRubricWriter::class.java)
+    private val applicantReader: ApplicantReader = mock(ApplicantReader::class.java)
+    private val userReader: UserReader = mock(UserReader::class.java)
+    private val evaluatorDirectory: EvaluatorDirectory = mock(EvaluatorDirectory::class.java)
+
+    private lateinit var service: InterviewEvaluationService
+
+    @BeforeEach
+    fun setUp() {
+        service = InterviewEvaluationService(
+            interviewEvaluationReader,
+            interviewEvaluationWriter,
+            finalEvaluationReader,
+            finalEvaluationWriter,
+            interviewRubricReader,
+            interviewRubricWriter,
+            applicantReader,
+            userReader,
+            evaluatorDirectory
+        )
+    }
+
+    @Test
+    @DisplayName("readStatuses 호출 시 EvaluatorStatusDto에 nickname이 정상 포함되어야 한다")
+    fun readStatuses_includesNickname() {
+        val applicantId = 1L
+        val partId = 10L
+        val part = mock(Part::class.java)
+        given(part.id).willReturn(partId)
+
+        val applicant = mock(Applicant::class.java)
+        given(applicant.part).willReturn(part)
+        given(applicantReader.readById(applicantId)).willReturn(applicant)
+
+        val summary = EvaluatorSummary(
+            email = "test@yourssu.com",
+            name = "홍길동",
+            nickname = "gildong(길동)",
+            memberId = 100L
+        )
+        given(evaluatorDirectory.findEvaluatorsByPartId(partId)).willReturn(listOf(summary))
+
+        val userInfo = mock(UserInfo::class.java)
+        given(userInfo.email).willReturn("test@yourssu.com")
+        given(userInfo.name).willReturn("홍길동")
+
+        val user = mock(User::class.java)
+        given(user.id).willReturn(200L)
+        given(user.userInfo).willReturn(userInfo)
+
+        given(userReader.readAllByEmails(listOf("test@yourssu.com"))).willReturn(listOf(user))
+        given(finalEvaluationReader.readAllByApplicantId(applicantId)).willReturn(emptyList())
+
+        val statuses = service.readStatuses(applicantId)
+
+        assertThat(statuses).hasSize(1)
+        assertThat(statuses[0].name).isEqualTo("홍길동")
+        assertThat(statuses[0].nickname).isEqualTo("gildong(길동)")
+    }
+
+    @Test
+    @DisplayName("readOthers 호출 시 OtherInterviewEvaluationDto에 evaluatorNickname이 정상 포함되어야 한다")
+    fun readOthers_includesEvaluatorNickname() {
+        val applicantId = 1L
+        val viewerUserId = 999L
+        val evaluatorUserId = 200L
+
+        val finalEval = mock(FinalEvaluation::class.java)
+        given(finalEval.evaluatorUserId).willReturn(evaluatorUserId)
+        given(finalEval.submit).willReturn(true)
+        given(finalEval.score).willReturn(90)
+        given(finalEval.interviewResult).willReturn(InterviewResult.FINAL_PASS)
+        given(finalEval.overallComment).willReturn("Good")
+
+        given(finalEvaluationReader.readAllByApplicantId(applicantId)).willReturn(listOf(finalEval))
+        given(finalEvaluationReader.readByApplicantIdAndEvaluatorUserId(applicantId, viewerUserId)).willReturn(null)
+
+        val evaluatorInfoObj = mock(UserInfo::class.java)
+        given(evaluatorInfoObj.email).willReturn("evaluator@yourssu.com")
+        given(evaluatorInfoObj.name).willReturn("홍길동")
+
+        val user = mock(User::class.java)
+        given(user.id).willReturn(evaluatorUserId)
+        given(user.userInfo).willReturn(evaluatorInfoObj)
+
+        given(userReader.readById(evaluatorUserId)).willReturn(user)
+        given(evaluatorDirectory.findEvaluatorInfo("evaluator@yourssu.com")).willReturn(
+            EvaluatorInfo(memberId = 100L, nicknameEnglish = "gildong", nicknameKorean = "길동", partName = "Backend")
+        )
+
+        given(interviewEvaluationReader.readAllByApplicantId(applicantId)).willReturn(emptyList())
+
+        val others = service.readOthers(applicantId, viewerUserId)
+
+        assertThat(others).hasSize(1)
+        assertThat(others[0].evaluatorName).isEqualTo("홍길동")
+        assertThat(others[0].evaluatorNickname).isEqualTo("gildong(길동)")
+    }
+}


### PR DESCRIPTION
## Summary
- 면접/서류 평가자 상태 조회 응답(`ReadEvaluatorStatusResponse`)에 `nickname` 필드 추가
- 다른 평가자의 면접/서류 평가 조회 응답(`ReadOtherInterviewEvaluationResponse`, `ReadOtherDocumentEvaluationResponse`)에 `evaluatorNickname` 필드 추가
- `EvaluatorDirectory` 포트에 닉네임 조회를 위한 필드(`EvaluatorSummary.nickname`, `EvaluatorInfo.nicknameKorean`) 추가 및 `MemberEvaluatorDirectory` 구현 반영

Closes #466

## Test plan
- [x] `./gradlew build`로 컴파일/테스트 통과 확인
- [x] 면접/서류 평가자 상태 조회 API 응답에 nickname 필드가 정상적으로 내려오는지 확인
- [x] 다른 평가자의 면접/서류 평가 조회 API 응답에 evaluatorNickname 필드가 정상적으로 내려오는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)