### PR TITLE
[#404]; feat: 구글폼 제출 웹훅 수신 및 처리 기능 추가

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -171,6 +171,7 @@ jobs:
           # 멤버 인포 엑셀 HTML 다운로드 (/members/upload 비밀번호). 비어 있으면 Bearer+특권만 허용.
           MEMBER_EXCEL_DOWNLOAD_PASSWORD: ${{ secrets.MEMBER_EXCEL_DOWNLOAD_PASSWORD }}
           RECRUITING_ADMIN_PASSWORD: ${{ secrets.RECRUITING_ADMIN_PASSWORD }}
+          APPLICANT_WEBHOOK_SECRET: ${{ secrets.APPLICANT_WEBHOOK_SECRET }}
           INPUT_DEPLOY_TAG: ${{ github.event.inputs.tag }}
 
         run: |
@@ -216,6 +217,7 @@ jobs:
           echo "MAIL_SENDER_APP_PASSWORD=$MAIL_SENDER_APP_PASSWORD" >> .env.dev
           echo "MEMBER_EXCEL_DOWNLOAD_PASSWORD=$MEMBER_EXCEL_DOWNLOAD_PASSWORD" >> .env.dev
           echo "RECRUITING_ADMIN_PASSWORD=$RECRUITING_ADMIN_PASSWORD" >> .env.dev
+          echo "APPLICANT_WEBHOOK_SECRET=$APPLICANT_WEBHOOK_SECRET" >> .env.dev
           echo "IMAGE_TAG=$DEPLOY_TAG" >> .env.dev
 
           # create deployment directory structure

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -157,6 +157,7 @@ jobs:
 
           MEMBER_EXCEL_DOWNLOAD_PASSWORD: ${{ secrets.MEMBER_EXCEL_DOWNLOAD_PASSWORD }}
           RECRUITING_ADMIN_PASSWORD: ${{ secrets.RECRUITING_ADMIN_PASSWORD }}
+          APPLICANT_WEBHOOK_SECRET: ${{ secrets.APPLICANT_WEBHOOK_SECRET }}
           INPUT_DEPLOY_TAG: ${{ github.event.inputs.tag }}
 
         run: |
@@ -201,6 +202,7 @@ jobs:
           echo "MAIL_SENDER_APP_PASSWORD=$MAIL_SENDER_APP_PASSWORD" >> .env.prod
           echo "MEMBER_EXCEL_DOWNLOAD_PASSWORD=$MEMBER_EXCEL_DOWNLOAD_PASSWORD" >> .env.prod
           echo "RECRUITING_ADMIN_PASSWORD=$RECRUITING_ADMIN_PASSWORD" >> .env.prod
+          echo "APPLICANT_WEBHOOK_SECRET=$APPLICANT_WEBHOOK_SECRET" >> .env.prod
           echo "IMAGE_TAG=$DEPLOY_TAG" >> .env.prod
 
           ssh -i yourssu.pem ubuntu@$HOST_URL "mkdir -p ~/$PROJECT_NAME-prod-api/logs"

--- a/src/main/kotlin/com/yourssu/scouter/common/configuration/WebConfiguration.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/configuration/WebConfiguration.kt
@@ -3,6 +3,7 @@ package com.yourssu.scouter.common.configuration
 import com.yourssu.scouter.admin.AdminSessionInterceptor
 import com.yourssu.scouter.auth.support.resolver.AuthUserInfoArgumentResolver
 import com.yourssu.scouter.auth.support.interceptor.LoginInterceptor
+import com.yourssu.scouter.recruiting.applicant.application.ApplicantWebhookSecretInterceptor
 import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Configuration
 import org.springframework.http.HttpHeaders
@@ -17,6 +18,7 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
 class WebConfiguration(
     private val loginInterceptor: LoginInterceptor,
     private val adminSessionInterceptor: AdminSessionInterceptor,
+    private val applicantWebhookSecretInterceptor: ApplicantWebhookSecretInterceptor,
     private val authUserInfoArgumentResolver: AuthUserInfoArgumentResolver,
     private val corsProperties: CorsProperties,
 ) : WebMvcConfigurer {
@@ -25,8 +27,12 @@ class WebConfiguration(
             .addPathPatterns("/admin/recruiting/**")
             .excludePathPatterns("/admin/recruiting", "/admin/recruiting/auth")
 
+        registry.addInterceptor(applicantWebhookSecretInterceptor)
+            .addPathPatterns("/applicants/webhook")
+
         registry.addInterceptor(loginInterceptor)
             .addPathPatterns("/**")
+            .excludePathPatterns("/applicants/webhook")
             .excludePathPatterns("/favicon.ico")
             .excludePathPatterns("/error")
             .excludePathPatterns("/oauth2/**")

--- a/src/main/kotlin/com/yourssu/scouter/common/google/GoogleFormsReader.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/google/GoogleFormsReader.kt
@@ -12,6 +12,7 @@ class GoogleFormsReader(
         val questionMap: Map<String, String?> = makeQuestionIdAndTitleMap(questionResponse)
         val descriptiveQuestionIds: Set<String> = makeDescriptiveQuestionIds(questionResponse)
         val groupQuestionMap: Map<String, String> = getGroupItems(questionResponse)
+        val questionOrder: List<String> = makeQuestionIdOrder(questionResponse)
         val formResponses: GoogleFormResponses = googleFormsClient.getFormResponses(authorizationHeader, formId)
 
         return formResponses.responses.map { googleUserResponse ->
@@ -20,7 +21,13 @@ class GoogleFormsReader(
                 createTime = googleUserResponse.createTime,
                 respondentEmail = googleUserResponse.respondentEmail,
                 lastSubmittedTime = googleUserResponse.lastSubmittedTime,
-                responseItems = convertToResponseItems(googleUserResponse, questionMap, groupQuestionMap, descriptiveQuestionIds)
+                responseItems = convertToResponseItems(
+                    googleUserResponse,
+                    questionMap,
+                    groupQuestionMap,
+                    descriptiveQuestionIds,
+                    questionOrder,
+                )
             )
         }
     }
@@ -48,17 +55,31 @@ class GoogleFormsReader(
             } ?: emptyList()
         }.associate { it.first to it.second }
 
+    // 응답은 Map으로 와서 순서가 보장되지 않으므로, 폼에 실제 배치된 문항 순서(items 순서)를 기준으로 정렬 기준을 만든다.
+    private fun makeQuestionIdOrder(questionResponse: GoogleFormQuestions): List<String> =
+        questionResponse.items.flatMap { item ->
+            when {
+                item.questionItem?.question != null -> listOf(item.questionItem.question.questionId)
+                item.questionGroupItem?.questions != null -> item.questionGroupItem.questions.map { it.questionId }
+                else -> emptyList()
+            }
+        }
+
     private fun convertToResponseItems(
         googleUserResponse: GoogleUserResponse,
         questionMap: Map<String, String?>,
         groupQuestionMap: Map<String, String>,
         descriptiveQuestionIds: Set<String>,
+        questionOrder: List<String>,
     ): List<ResponseItem> {
+        val orderIndex: Map<String, Int> = questionOrder.withIndex().associate { (index, questionId) -> questionId to index }
+
         val responseItems: List<ResponseItem> = googleUserResponse.answers.mapNotNull { (questionId, answer) ->
             val questionTitle = questionMap[questionId] ?: groupQuestionMap[questionId] ?: return@mapNotNull null
             val answerText = answer.textAnswers?.answers?.joinToString(", ") { it.value.toString() } ?: ""
-            ResponseItem(questionTitle, answerText, isDescriptive = questionId in descriptiveQuestionIds)
-        }
+            questionId to ResponseItem(questionTitle, answerText, isDescriptive = questionId in descriptiveQuestionIds)
+        }.sortedBy { (questionId, _) -> orderIndex[questionId] ?: Int.MAX_VALUE }
+            .map { (_, responseItem) -> responseItem }
         return responseItems
     }
 }

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/applicant/application/ApplicantWebhookController.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/applicant/application/ApplicantWebhookController.kt
@@ -1,0 +1,44 @@
+package com.yourssu.scouter.recruiting.applicant.application
+
+import com.yourssu.scouter.recruiting.applicant.application.dto.ApplicantSyncResponse
+import com.yourssu.scouter.recruiting.applicant.application.dto.ApplicantWebhookRequest
+import com.yourssu.scouter.recruiting.applicant.business.ApplicantSyncService
+import com.yourssu.scouter.recruiting.applicant.business.dto.ApplicantSyncResult
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.headers.Header
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.validation.Valid
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RestController
+import java.net.URI
+
+@Tag(name = "리크루팅 지원자")
+@Tag(name = "지원자 동기화 API")
+@RestController
+class ApplicantWebhookController(
+    private val applicantSyncService: ApplicantSyncService,
+) {
+
+    private val applicantsLocation: URI = URI.create("/applicants")
+
+    @Operation(
+        summary = "구글폼 제출 웹훅 수신",
+        description = "Google Apps Script가 폼 제출 시점에 직접 호출한다. JWT 대신 " +
+            "${ApplicantWebhookSecretInterceptor.SECRET_HEADER} 헤더의 공유 시크릿으로 인증한다.",
+    )
+    @ApiResponse(
+        description = "CREATED", responseCode = "201", headers = [
+            Header(name = "Location", description = "/applicants")
+        ]
+    )
+    @PostMapping("/applicants/webhook")
+    fun receiveWebhook(
+        @RequestBody @Valid request: ApplicantWebhookRequest,
+    ): ResponseEntity<ApplicantSyncResponse> {
+        val result: ApplicantSyncResult = applicantSyncService.includeFromWebhook(request.toCommand())
+        return result.toCreatedResponse(applicantsLocation, ApplicantSyncResponse::from)
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/applicant/application/ApplicantWebhookProperties.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/applicant/application/ApplicantWebhookProperties.kt
@@ -1,0 +1,8 @@
+package com.yourssu.scouter.recruiting.applicant.application
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+@ConfigurationProperties(prefix = "scouter.applicant-webhook")
+data class ApplicantWebhookProperties(
+    val secret: String = "",
+)

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/applicant/application/ApplicantWebhookSecretInterceptor.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/applicant/application/ApplicantWebhookSecretInterceptor.kt
@@ -1,0 +1,38 @@
+package com.yourssu.scouter.recruiting.applicant.application
+
+import com.yourssu.scouter.recruiting.support.implement.exception.ApplicantWebhookUnauthorizedException
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import java.nio.charset.StandardCharsets
+import java.security.MessageDigest
+import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.stereotype.Component
+import org.springframework.web.servlet.HandlerInterceptor
+
+@Component
+@EnableConfigurationProperties(ApplicantWebhookProperties::class)
+class ApplicantWebhookSecretInterceptor(
+    private val properties: ApplicantWebhookProperties,
+) : HandlerInterceptor {
+
+    override fun preHandle(request: HttpServletRequest, response: HttpServletResponse, handler: Any): Boolean {
+        val configured = properties.secret.trim()
+        if (configured.isEmpty()) {
+            throw ApplicantWebhookUnauthorizedException("웹훅 시크릿이 설정되지 않았습니다. scouter.applicant-webhook.secret을 설정해주세요.")
+        }
+
+        val provided = request.getHeader(SECRET_HEADER)?.trim()
+        if (provided.isNullOrEmpty() || !secureEquals(provided, configured)) {
+            throw ApplicantWebhookUnauthorizedException("웹훅 시크릿이 올바르지 않습니다.")
+        }
+
+        return true
+    }
+
+    private fun secureEquals(a: String, b: String): Boolean =
+        MessageDigest.isEqual(a.toByteArray(StandardCharsets.UTF_8), b.toByteArray(StandardCharsets.UTF_8))
+
+    companion object {
+        const val SECRET_HEADER = "X-Applicant-Webhook-Secret"
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/applicant/application/dto/ApplicantWebhookRequest.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/applicant/application/dto/ApplicantWebhookRequest.kt
@@ -1,0 +1,54 @@
+package com.yourssu.scouter.recruiting.applicant.application.dto
+
+import com.yourssu.scouter.recruiting.applicant.business.dto.ApplicantWebhookCommand
+import com.yourssu.scouter.recruiting.applicant.business.dto.ApplicantWebhookItemCommand
+import jakarta.validation.Valid
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotNull
+import java.time.Instant
+
+data class ApplicantWebhookRequest(
+
+    @field:NotBlank(message = "formId를 입력하지 않았습니다.")
+    val formId: String,
+
+    @field:NotBlank(message = "responseId를 입력하지 않았습니다.")
+    val responseId: String,
+
+    @field:NotNull(message = "제출 시각을 입력하지 않았습니다.")
+    val createTime: Instant,
+
+    val respondentEmail: String?,
+
+    @field:NotNull(message = "문항 목록을 입력하지 않았습니다.")
+    @field:Valid
+    val items: List<ApplicantWebhookItemRequest>,
+) {
+
+    fun toCommand(): ApplicantWebhookCommand = ApplicantWebhookCommand(
+        formId = formId,
+        responseId = responseId,
+        createTime = createTime,
+        respondentEmail = respondentEmail,
+        items = items.map { it.toCommand() },
+    )
+}
+
+data class ApplicantWebhookItemRequest(
+
+    // 폼에 배치된 문항 순서 그대로 담겨 있어야 한다 (items 배열 순서를 그대로 신뢰한다).
+    @field:NotBlank(message = "문항 제목을 입력하지 않았습니다.")
+    val question: String,
+
+    val answer: String,
+
+    // 구글 폼 문항 타입이 장문형(단락)인지 여부. Apps Script의 item.getType() == PARAGRAPH_TEXT
+    val isDescriptive: Boolean = false,
+) {
+
+    fun toCommand(): ApplicantWebhookItemCommand = ApplicantWebhookItemCommand(
+        question = question,
+        answer = answer,
+        isDescriptive = isDescriptive,
+    )
+}

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/applicant/business/ApplicantSyncService.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/applicant/business/ApplicantSyncService.kt
@@ -1,6 +1,7 @@
 package com.yourssu.scouter.recruiting.applicant.business
 
 import com.yourssu.scouter.recruiting.applicant.business.dto.ApplicantSyncResult
+import com.yourssu.scouter.recruiting.applicant.business.dto.ApplicantWebhookCommand
 
 import com.yourssu.scouter.recruiting.applicant.implement.*
 import com.yourssu.scouter.auth.authentication.business.OAuth2Service
@@ -63,6 +64,27 @@ class ApplicantSyncService(
         return ApplicantSyncResult(
             successMessages = successMessages,
             failureMessages = failureMessages,
+        )
+    }
+
+    // 구글 폼 제출 시 Apps Script가 즉시 호출하는 웹훅 엔드포인트용 진입점.
+    // 응답 1건만 받으므로 매핑도 formId로 바로 찾고, 이후 dedup·저장 로직은 pull-sync와 동일하게 재사용한다.
+    fun includeFromWebhook(command: ApplicantWebhookCommand): ApplicantSyncResult {
+        val syncMapping: ApplicantSyncMapping = applicantSyncMappingReader.readByFormId(command.formId)
+
+        val syncResult: ApplicantSyncInfo = formResponseProcessor.mapWebhookResponseToApplicant(
+            responseId = command.responseId,
+            createTime = command.createTime,
+            respondentEmail = command.respondentEmail,
+            items = command.items.map { ResponseItem(it.question, it.answer, it.isDescriptive) },
+            applicantSyncMapping = syncMapping,
+        )
+
+        writeNewApplicants(syncMapping.applicationSemester.id!!, listOf(syncResult))
+
+        return ApplicantSyncResult(
+            successMessages = listOf("Synced applicant for form ${command.formId}, response ${command.responseId}"),
+            failureMessages = emptyList(),
         )
     }
 

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/applicant/business/FormResponseToApplicantProcessor.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/applicant/business/FormResponseToApplicantProcessor.kt
@@ -11,6 +11,7 @@ import com.yourssu.scouter.common.google.GoogleFormsReader
 import com.yourssu.scouter.common.google.ResponseItem
 import com.yourssu.scouter.common.google.UserResponse
 import org.springframework.stereotype.Component
+import java.time.Instant
 
 @Component
 class FormResponseToApplicantProcessor(
@@ -104,6 +105,24 @@ class FormResponseToApplicantProcessor(
             responseId = userResponse.responseId,
             unmappedResponseItems = extractUnmappedResponseItems(userResponse, applicantSyncMapping),
         )
+    }
+
+    // Apps Script가 폼 제출 즉시 보내는 웹훅 payload를 UserResponse로 감싸 pull-sync와 동일한 매핑 로직을 재사용한다.
+    fun mapWebhookResponseToApplicant(
+        responseId: String,
+        createTime: Instant,
+        respondentEmail: String?,
+        items: List<ResponseItem>,
+        applicantSyncMapping: ApplicantSyncMapping,
+    ): ApplicantSyncInfo {
+        val userResponse = UserResponse(
+            responseId = responseId,
+            createTime = createTime,
+            respondentEmail = respondentEmail,
+            lastSubmittedTime = null,
+            responseItems = items,
+        )
+        return mapResponseToApplicant(userResponse, applicantSyncMapping)
     }
 
     private fun extractUnmappedResponseItems(

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/applicant/business/FormResponseToApplicantProcessor.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/applicant/business/FormResponseToApplicantProcessor.kt
@@ -123,8 +123,11 @@ class FormResponseToApplicantProcessor(
             applicantSyncMapping.availableTimeQuestion,
         )
 
+        // 장문형(서술형) 응답만 서류 평가 문항(ApplicantAnswer/DocumentSection) 후보로 저장한다.
         return userResponse.responseItems.filter { item ->
-            item.answer.isNotBlank() && mappedQuestions.none { question -> item.question.startsWith(question) }
+            item.isDescriptive &&
+                item.answer.isNotBlank() &&
+                mappedQuestions.none { question -> item.question.startsWith(question) }
         }
     }
 }

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/applicant/business/dto/ApplicantWebhookCommand.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/applicant/business/dto/ApplicantWebhookCommand.kt
@@ -1,0 +1,17 @@
+package com.yourssu.scouter.recruiting.applicant.business.dto
+
+import java.time.Instant
+
+data class ApplicantWebhookCommand(
+    val formId: String,
+    val responseId: String,
+    val createTime: Instant,
+    val respondentEmail: String?,
+    val items: List<ApplicantWebhookItemCommand>,
+)
+
+data class ApplicantWebhookItemCommand(
+    val question: String,
+    val answer: String,
+    val isDescriptive: Boolean,
+)

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/applicant/implement/ApplicantSyncMappingReader.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/applicant/implement/ApplicantSyncMappingReader.kt
@@ -1,5 +1,6 @@
 package com.yourssu.scouter.recruiting.applicant.implement
 
+import com.yourssu.scouter.recruiting.support.implement.exception.ApplicantSyncMappingNotFoundException
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
 
@@ -11,5 +12,10 @@ class ApplicantSyncMappingReader(
 
     fun readAllByApplicationSemesterId(applicationSemesterId: Long): List<ApplicantSyncMapping> {
         return applicantSyncMappingRepository.findAllByApplicationSemesterId(applicationSemesterId)
+    }
+
+    fun readByFormId(formId: String): ApplicantSyncMapping {
+        return applicantSyncMappingRepository.findByFormId(formId)
+            ?: throw ApplicantSyncMappingNotFoundException("해당 formId에 대한 동기화 매핑이 존재하지 않습니다: $formId")
     }
 }

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/applicant/implement/ApplicantSyncMappingRepository.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/applicant/implement/ApplicantSyncMappingRepository.kt
@@ -4,6 +4,7 @@ interface ApplicantSyncMappingRepository {
 
     fun save(applicantSyncMapping: ApplicantSyncMapping)
     fun findAllByApplicationSemesterId(semesterId: Long): List<ApplicantSyncMapping>
+    fun findByFormId(formId: String): ApplicantSyncMapping?
     fun count(): Long
     fun existsByApplicationSemesterIdAndPartId(applicationSemesterId: Long, partId: Long): Boolean
 }

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/applicant/implement/ApplicantSyncMappingRepositoryImpl.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/applicant/implement/ApplicantSyncMappingRepositoryImpl.kt
@@ -17,6 +17,10 @@ class ApplicantSyncMappingRepositoryImpl(
         return jpaApplicantSyncMappingRepository.findAllByApplicationSemesterId(semesterId).map { it.toDomain() }
     }
 
+    override fun findByFormId(formId: String): ApplicantSyncMapping? {
+        return jpaApplicantSyncMappingRepository.findByFormId(formId)?.toDomain()
+    }
+
     override fun count(): Long {
         return jpaApplicantSyncMappingRepository.count()
     }

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/applicant/storage/JpaApplicantSyncMappingRepository.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/applicant/storage/JpaApplicantSyncMappingRepository.kt
@@ -6,5 +6,7 @@ interface JpaApplicantSyncMappingRepository : JpaRepository<ApplicantSyncMapping
 
     fun findAllByApplicationSemesterId(applicationSemesterId: Long): List<ApplicantSyncMappingEntity>
 
+    fun findByFormId(formId: String): ApplicantSyncMappingEntity?
+
     fun existsByApplicationSemester_IdAndPart_Id(applicationSemesterId: Long, partId: Long): Boolean
 }

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/support/implement/exception/ApplicantSyncMappingNotFoundException.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/support/implement/exception/ApplicantSyncMappingNotFoundException.kt
@@ -1,0 +1,8 @@
+package com.yourssu.scouter.recruiting.support.implement.exception
+
+import com.yourssu.scouter.common.exception.CustomException
+import org.springframework.http.HttpStatus
+
+class ApplicantSyncMappingNotFoundException(
+    message: String,
+) : CustomException(message, "ApplicantSyncMapping-001", HttpStatus.NOT_FOUND)

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/support/implement/exception/ApplicantWebhookUnauthorizedException.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/support/implement/exception/ApplicantWebhookUnauthorizedException.kt
@@ -1,0 +1,8 @@
+package com.yourssu.scouter.recruiting.support.implement.exception
+
+import com.yourssu.scouter.common.exception.CustomException
+import org.springframework.http.HttpStatus
+
+class ApplicantWebhookUnauthorizedException(
+    message: String,
+) : CustomException(message, "ApplicantWebhook-001", HttpStatus.UNAUTHORIZED)

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -11,6 +11,8 @@ scouter:
     init-script: ${SCOUTER_LOCAL_H2_INIT_SCRIPT:}
   recruiting-admin:
     password: scouter
+  applicant-webhook:
+    secret: scouter
 
 spring:
   application:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -31,6 +31,8 @@ scouter:
     download-password: ${MEMBER_EXCEL_DOWNLOAD_PASSWORD:}
   recruiting-admin:
     password: ${RECRUITING_ADMIN_PASSWORD:}
+  applicant-webhook:
+    secret: ${APPLICANT_WEBHOOK_SECRET:}
 
 mail:
   storage:

--- a/src/main/resources/db/migration/V51__add_unique_constraint_to_applicant_sync_log.sql
+++ b/src/main/resources/db/migration/V51__add_unique_constraint_to_applicant_sync_log.sql
@@ -1,0 +1,3 @@
+ALTER TABLE applicant_sync_log
+    ADD CONSTRAINT uk_applicant_sync_log_semester_form_response
+        UNIQUE (application_semester_id, form_id, response_id);

--- a/src/test/kotlin/com/yourssu/scouter/common/google/GoogleFormsReaderTest.kt
+++ b/src/test/kotlin/com/yourssu/scouter/common/google/GoogleFormsReaderTest.kt
@@ -1,0 +1,82 @@
+package com.yourssu.scouter.common.google
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.mockito.kotlin.whenever
+
+@Suppress("NonAsciiCharacters")
+class GoogleFormsReaderTest {
+
+    private val googleFormsClient: GoogleFormsClient = mock(GoogleFormsClient::class.java)
+    private val googleFormsReader = GoogleFormsReader(googleFormsClient)
+
+    @Test
+    fun `응답 항목을 응답 Map 순서가 아니라 실제 폼 문항 순서로 정렬한다`() {
+        // given: 폼 문항 순서는 이름 -> 자기소개(장문형) -> 취미 이지만,
+        // 응답 Map은 반대 순서(취미 -> 자기소개 -> 이름)로 온다.
+        val questions = GoogleFormQuestions(
+            items = listOf(
+                FormItem("item-name", "이름", QuestionItem(Question("q-name", TextQuestion(paragraph = false))), null),
+                FormItem("item-intro", "자기소개", QuestionItem(Question("q-intro", TextQuestion(paragraph = true))), null),
+                FormItem("item-hobby", "취미", QuestionItem(Question("q-hobby", TextQuestion(paragraph = false))), null),
+            )
+        )
+        val responses = GoogleFormResponses(
+            responses = listOf(
+                GoogleUserResponse(
+                    responseId = "response-1",
+                    createTime = "2026-01-01T00:00:00Z",
+                    respondentEmail = "test@example.com",
+                    lastSubmittedTime = "2026-01-01T00:00:00Z",
+                    answers = linkedMapOf(
+                        "q-hobby" to Answer(TextAnswers(listOf(TextAnswer("등산")))),
+                        "q-intro" to Answer(TextAnswers(listOf(TextAnswer("안녕하세요")))),
+                        "q-name" to Answer(TextAnswers(listOf(TextAnswer("홍길동")))),
+                    ),
+                )
+            )
+        )
+        whenever(googleFormsClient.getFormQuestions("Bearer token", "form-1")).thenReturn(questions)
+        whenever(googleFormsClient.getFormResponses("Bearer token", "form-1")).thenReturn(responses)
+
+        // when
+        val userResponses = googleFormsReader.getUserResponses("Bearer token", "form-1")
+
+        // then
+        val responseItems = userResponses.single().responseItems
+        assertThat(responseItems.map { it.question }).containsExactly("이름", "자기소개", "취미")
+    }
+
+    @Test
+    fun `장문형(paragraph) 문항만 isDescriptive가 true다`() {
+        val questions = GoogleFormQuestions(
+            items = listOf(
+                FormItem("item-name", "이름", QuestionItem(Question("q-name", TextQuestion(paragraph = false))), null),
+                FormItem("item-intro", "자기소개", QuestionItem(Question("q-intro", TextQuestion(paragraph = true))), null),
+            )
+        )
+        val responses = GoogleFormResponses(
+            responses = listOf(
+                GoogleUserResponse(
+                    responseId = "response-1",
+                    createTime = "2026-01-01T00:00:00Z",
+                    respondentEmail = null,
+                    lastSubmittedTime = null,
+                    answers = mapOf(
+                        "q-name" to Answer(TextAnswers(listOf(TextAnswer("홍길동")))),
+                        "q-intro" to Answer(TextAnswers(listOf(TextAnswer("안녕하세요")))),
+                    ),
+                )
+            )
+        )
+        whenever(googleFormsClient.getFormQuestions("Bearer token", "form-1")).thenReturn(questions)
+        whenever(googleFormsClient.getFormResponses("Bearer token", "form-1")).thenReturn(responses)
+
+        val responseItems = googleFormsReader.getUserResponses("Bearer token", "form-1").single().responseItems
+
+        assertThat(responseItems.find { it.question == "이름" }?.isDescriptive).isFalse()
+        assertThat(responseItems.find { it.question == "자기소개" }?.isDescriptive).isTrue()
+    }
+}

--- a/src/test/kotlin/com/yourssu/scouter/recruiting/applicant/application/ApplicantWebhookSecretInterceptorTest.kt
+++ b/src/test/kotlin/com/yourssu/scouter/recruiting/applicant/application/ApplicantWebhookSecretInterceptorTest.kt
@@ -1,0 +1,56 @@
+package com.yourssu.scouter.recruiting.applicant.application
+
+import com.yourssu.scouter.recruiting.support.implement.exception.ApplicantWebhookUnauthorizedException
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.mockito.kotlin.whenever
+
+@Suppress("NonAsciiCharacters")
+class ApplicantWebhookSecretInterceptorTest {
+
+    private val request: HttpServletRequest = mock(HttpServletRequest::class.java)
+    private val response: HttpServletResponse = mock(HttpServletResponse::class.java)
+    private val handler = Any()
+
+    @Test
+    fun `설정된 시크릿이 비어있으면 요청을 거부한다`() {
+        val interceptor = ApplicantWebhookSecretInterceptor(ApplicantWebhookProperties(secret = ""))
+        whenever(request.getHeader(ApplicantWebhookSecretInterceptor.SECRET_HEADER)).thenReturn("any-secret")
+
+        assertThatThrownBy { interceptor.preHandle(request, response, handler) }
+            .isInstanceOf(ApplicantWebhookUnauthorizedException::class.java)
+    }
+
+    @Test
+    fun `헤더가 없으면 요청을 거부한다`() {
+        val interceptor = ApplicantWebhookSecretInterceptor(ApplicantWebhookProperties(secret = "correct-secret"))
+        whenever(request.getHeader(ApplicantWebhookSecretInterceptor.SECRET_HEADER)).thenReturn(null)
+
+        assertThatThrownBy { interceptor.preHandle(request, response, handler) }
+            .isInstanceOf(ApplicantWebhookUnauthorizedException::class.java)
+    }
+
+    @Test
+    fun `헤더 값이 설정된 시크릿과 다르면 요청을 거부한다`() {
+        val interceptor = ApplicantWebhookSecretInterceptor(ApplicantWebhookProperties(secret = "correct-secret"))
+        whenever(request.getHeader(ApplicantWebhookSecretInterceptor.SECRET_HEADER)).thenReturn("wrong-secret")
+
+        assertThatThrownBy { interceptor.preHandle(request, response, handler) }
+            .isInstanceOf(ApplicantWebhookUnauthorizedException::class.java)
+    }
+
+    @Test
+    fun `헤더 값이 설정된 시크릿과 일치하면 통과시킨다`() {
+        val interceptor = ApplicantWebhookSecretInterceptor(ApplicantWebhookProperties(secret = "correct-secret"))
+        whenever(request.getHeader(ApplicantWebhookSecretInterceptor.SECRET_HEADER)).thenReturn("correct-secret")
+
+        val result = interceptor.preHandle(request, response, handler)
+
+        assertThat(result).isTrue()
+    }
+}

--- a/src/test/kotlin/com/yourssu/scouter/recruiting/applicant/business/ApplicantSyncServiceTest.kt
+++ b/src/test/kotlin/com/yourssu/scouter/recruiting/applicant/business/ApplicantSyncServiceTest.kt
@@ -1,0 +1,151 @@
+package com.yourssu.scouter.recruiting.applicant.business
+
+import com.yourssu.scouter.auth.authentication.business.OAuth2Service
+import com.yourssu.scouter.masterdata.part.implement.fixture.PartFixtureBuilder
+import com.yourssu.scouter.masterdata.semester.implement.fixture.SemesterFixtureBuilder
+import com.yourssu.scouter.masterdata.semester.implement.SemesterReader
+import com.yourssu.scouter.recruiting.applicant.business.dto.ApplicantWebhookCommand
+import com.yourssu.scouter.recruiting.applicant.business.dto.ApplicantWebhookItemCommand
+import com.yourssu.scouter.recruiting.applicant.implement.Applicant
+import com.yourssu.scouter.recruiting.applicant.implement.ApplicantAnswerWriter
+import com.yourssu.scouter.recruiting.applicant.implement.ApplicantSyncLog
+import com.yourssu.scouter.recruiting.applicant.implement.ApplicantSyncLogReader
+import com.yourssu.scouter.recruiting.applicant.implement.ApplicantSyncLogWriter
+import com.yourssu.scouter.recruiting.applicant.implement.ApplicantSyncMapping
+import com.yourssu.scouter.recruiting.applicant.implement.ApplicantSyncMappingReader
+import com.yourssu.scouter.recruiting.applicant.implement.ApplicantWriter
+import com.yourssu.scouter.recruiting.applicant.implement.fixture.ApplicantFixtureBuilder
+import com.yourssu.scouter.recruiting.rubric.business.DocumentSectionService
+import com.yourssu.scouter.recruiting.support.implement.exception.ApplicantSyncMappingNotFoundException
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.verify
+import org.mockito.kotlin.any
+import org.mockito.kotlin.whenever
+import java.time.Instant
+
+@Suppress("NonAsciiCharacters")
+class ApplicantSyncServiceTest {
+
+    private val oauth2Service: OAuth2Service = mock(OAuth2Service::class.java)
+    private val applicantWriter: ApplicantWriter = mock(ApplicantWriter::class.java)
+    private val applicantAnswerWriter: ApplicantAnswerWriter = mock(ApplicantAnswerWriter::class.java)
+    private val semesterReader: SemesterReader = mock(SemesterReader::class.java)
+    private val applicantSyncLogReader: ApplicantSyncLogReader = mock(ApplicantSyncLogReader::class.java)
+    private val applicantSyncLogWriter: ApplicantSyncLogWriter = mock(ApplicantSyncLogWriter::class.java)
+    private val applicantSyncMappingReader: ApplicantSyncMappingReader = mock(ApplicantSyncMappingReader::class.java)
+    private val formResponseProcessor: FormResponseToApplicantProcessor = mock(FormResponseToApplicantProcessor::class.java)
+    private val documentSectionService: DocumentSectionService = mock(DocumentSectionService::class.java)
+
+    private lateinit var applicantSyncService: ApplicantSyncService
+    private lateinit var mapping: ApplicantSyncMapping
+
+    @BeforeEach
+    fun setUp() {
+        applicantSyncService = ApplicantSyncService(
+            oauth2Service,
+            applicantWriter,
+            applicantAnswerWriter,
+            semesterReader,
+            applicantSyncLogReader,
+            applicantSyncLogWriter,
+            applicantSyncMappingReader,
+            formResponseProcessor,
+            documentSectionService,
+        )
+
+        mapping = ApplicantSyncMapping(
+            applicationSemester = SemesterFixtureBuilder().id(1L).build(),
+            part = PartFixtureBuilder().id(1L).build(),
+            formId = "form-1",
+            nameQuestion = "이름",
+            emailQuestion = null,
+            phoneNumberQuestion = null,
+            ageQuestion = null,
+            departmentQuestion = null,
+            studentIdQuestion = "학번",
+            academicSemesterQuestion = null,
+            availableTimeQuestion = null,
+        )
+    }
+
+    private fun webhookCommand() = ApplicantWebhookCommand(
+        formId = "form-1",
+        responseId = "response-1",
+        createTime = Instant.parse("2026-01-01T00:00:00Z"),
+        respondentEmail = "hong@example.com",
+        items = listOf(ApplicantWebhookItemCommand("이름", "홍길동", false)),
+    )
+
+    @Test
+    fun `formId에 해당하는 매핑이 없으면 예외를 던진다`() {
+        whenever(applicantSyncMappingReader.readByFormId("form-1"))
+            .thenThrow(ApplicantSyncMappingNotFoundException("해당 formId에 대한 동기화 매핑이 존재하지 않습니다: form-1"))
+
+        assertThatThrownBy { applicantSyncService.includeFromWebhook(webhookCommand()) }
+            .isInstanceOf(ApplicantSyncMappingNotFoundException::class.java)
+    }
+
+    @Test
+    fun `동일한 formId, responseId 로그가 이미 있으면 지원자를 저장하지 않는다`() {
+        val applicant = ApplicantFixtureBuilder().name("홍길동").build()
+        val syncInfo = ApplicantSyncInfo(applicant, "form-1", "response-1")
+
+        whenever(applicantSyncMappingReader.readByFormId("form-1")).thenReturn(mapping)
+        whenever(
+            formResponseProcessor.mapWebhookResponseToApplicant(
+                responseId = any(),
+                createTime = any(),
+                respondentEmail = any(),
+                items = any(),
+                applicantSyncMapping = any(),
+            )
+        ).thenReturn(syncInfo)
+        whenever(applicantSyncLogReader.readAllByApplicationSemesterId(1L)).thenReturn(
+            listOf(
+                ApplicantSyncLog(
+                    applicationSemesterId = 1L,
+                    formId = "form-1",
+                    responseId = "response-1",
+                    syncTime = Instant.now(),
+                )
+            )
+        )
+
+        applicantSyncService.includeFromWebhook(webhookCommand())
+
+        verify(applicantWriter).writeAll(emptyList())
+        verify(applicantSyncLogWriter).writeAll(emptyList())
+    }
+
+    @Test
+    fun `새 응답이면 지원자와 동기화 로그를 저장한다`() {
+        val applicant = ApplicantFixtureBuilder().name("홍길동").build()
+        val savedApplicant = ApplicantFixtureBuilder().id(10L).name("홍길동").build()
+        val syncInfo = ApplicantSyncInfo(applicant, "form-1", "response-1")
+
+        whenever(applicantSyncMappingReader.readByFormId("form-1")).thenReturn(mapping)
+        whenever(
+            formResponseProcessor.mapWebhookResponseToApplicant(
+                responseId = any(),
+                createTime = any(),
+                respondentEmail = any(),
+                items = any(),
+                applicantSyncMapping = any(),
+            )
+        ).thenReturn(syncInfo)
+        whenever(applicantSyncLogReader.readAllByApplicationSemesterId(1L)).thenReturn(emptyList())
+        whenever(applicantWriter.writeAll(listOf(applicant))).thenReturn(listOf(savedApplicant))
+
+        val result = applicantSyncService.includeFromWebhook(webhookCommand())
+
+        verify(applicantWriter).writeAll(listOf(applicant))
+        verify(applicantSyncLogWriter).writeAll(any())
+        verify(applicantAnswerWriter).writeAll(emptyList())
+        assertThat(result.failureMessages).isEmpty()
+        assertThat(result.successMessages).hasSize(1)
+    }
+}

--- a/src/test/kotlin/com/yourssu/scouter/recruiting/applicant/business/FormResponseToApplicantProcessorTest.kt
+++ b/src/test/kotlin/com/yourssu/scouter/recruiting/applicant/business/FormResponseToApplicantProcessorTest.kt
@@ -1,0 +1,94 @@
+package com.yourssu.scouter.recruiting.applicant.business
+
+import com.yourssu.scouter.common.google.ResponseItem
+import com.yourssu.scouter.recruiting.applicant.implement.ApplicantSyncMapping
+import com.yourssu.scouter.recruiting.support.business.utils.AvailableTimeParser
+import com.yourssu.scouter.masterdata.part.implement.fixture.PartFixtureBuilder
+import com.yourssu.scouter.masterdata.semester.implement.fixture.SemesterFixtureBuilder
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import java.time.Instant
+
+@Suppress("NonAsciiCharacters")
+class FormResponseToApplicantProcessorTest {
+
+    private val availableTimeParser: AvailableTimeParser = mock(AvailableTimeParser::class.java)
+    private lateinit var processor: FormResponseToApplicantProcessor
+    private lateinit var mapping: ApplicantSyncMapping
+
+    @BeforeEach
+    fun setUp() {
+        processor = FormResponseToApplicantProcessor(mock(), availableTimeParser)
+        whenever(availableTimeParser.parse(any(), any())).thenReturn(emptyList())
+
+        mapping = ApplicantSyncMapping(
+            applicationSemester = SemesterFixtureBuilder().id(1L).build(),
+            part = PartFixtureBuilder().id(1L).build(),
+            formId = "form-1",
+            nameQuestion = "이름",
+            emailQuestion = null,
+            phoneNumberQuestion = "휴대폰 번호",
+            ageQuestion = "나이",
+            departmentQuestion = "학과",
+            studentIdQuestion = "학번",
+            academicSemesterQuestion = "재학중인 학기",
+            availableTimeQuestion = null,
+        )
+    }
+
+    @Test
+    fun `웹훅 payload의 매핑 필드로 Applicant를 구성한다`() {
+        val items = listOf(
+            ResponseItem("이름", "홍길동"),
+            ResponseItem("휴대폰 번호", "010-1234-5678"),
+            ResponseItem("나이", "25"),
+            ResponseItem("학과", "컴퓨터공학부"),
+            ResponseItem("학번", "20210001"),
+            ResponseItem("재학중인 학기", "3-1"),
+        )
+
+        val result = processor.mapWebhookResponseToApplicant(
+            responseId = "response-1",
+            createTime = Instant.parse("2026-01-01T00:00:00Z"),
+            respondentEmail = "hong@example.com",
+            items = items,
+            applicantSyncMapping = mapping,
+        )
+
+        assertThat(result.applicant.name).isEqualTo("홍길동")
+        assertThat(result.applicant.email).isEqualTo("hong@example.com")
+        assertThat(result.applicant.phoneNumber).isEqualTo("010-1234-5678")
+        assertThat(result.formId).isEqualTo("form-1")
+        assertThat(result.responseId).isEqualTo("response-1")
+    }
+
+    @Test
+    fun `매핑 안 된 응답 중 장문형만 unmappedResponseItems 후보로 남긴다`() {
+        val items = listOf(
+            ResponseItem("이름", "홍길동"),
+            ResponseItem("휴대폰 번호", "010-1234-5678"),
+            ResponseItem("나이", "25"),
+            ResponseItem("학과", "컴퓨터공학부"),
+            ResponseItem("학번", "20210001"),
+            ResponseItem("재학중인 학기", "3-1"),
+            ResponseItem("좋아하는 색은?", "빨강", isDescriptive = false),
+            ResponseItem("자기소개를 해주세요", "안녕하세요, 저는...", isDescriptive = true),
+        )
+
+        val result = processor.mapWebhookResponseToApplicant(
+            responseId = "response-1",
+            createTime = Instant.parse("2026-01-01T00:00:00Z"),
+            respondentEmail = "hong@example.com",
+            items = items,
+            applicantSyncMapping = mapping,
+        )
+
+        assertThat(result.unmappedResponseItems).hasSize(1)
+        assertThat(result.unmappedResponseItems.single().question).isEqualTo("자기소개를 해주세요")
+    }
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -3,6 +3,10 @@ app:
     scheduler:
       enabled: false
 
+scouter:
+  applicant-webhook:
+    secret: test-applicant-webhook-secret
+
 spring:
   application:
     name: scouter


### PR DESCRIPTION
## 📄 작업 내용 요약

* 구글 폼 응답 문항을 응답 순서(Map)가 아니라 실제 폼 배치 순서로 정렬하도록 수정
* 매핑 안 된 응답 중 장문형(서술형) 문항만 서류 평가 후보로 저장하도록 필터 추가
* 웹훅 요청을 위한 stateless 시크릿 헤더 인증 컴포넌트 추가 (X-Applicant-Webhook-Secret)
* Google Apps Script가 폼 제출 시점에 직접 호출하는 POST /applicants/webhook 추가
  * formId로 ApplicantSyncMapping을 조회해 매핑/필터/dedup 로직은 기존 pull-sync와 동일하게 재사용
* applicant_sync_log에 (semester, formId, responseId) 유니크 제약 추가 (웹훅 재시도 시 동시 중복 저장 방지)
* 위 변경 사항에 대한 단위 테스트 11건 추가

<details><summary>🧪 로컬 수동 테스트 (curl + H2)</summary>

로컬(`local` 프로필, `scouter.applicant-webhook.secret=scouter`)에서 아래 curl로 웹훅을 직접 호출해 정상 동작을 확인했습니다.

```bash
curl -i -X POST http://localhost:8080/applicants/webhook \
  -H "Content-Type: application/json" \
  -H "X-Applicant-Webhook-Secret: scouter" \
  -d '{
    "formId": "1M3KzymPU851IL_uLL98SUwii8DhNB-xJtzsgTeEO93k",
    "responseId": "test-response-1",
    "createTime": "2026-08-23T00:00:00Z",
    "respondentEmail": "test@example.com",
    "items": [
      {"question": "이름", "answer": "홍길동", "isDescriptive": false},
      {"question": "휴대폰 번호", "answer": "010-1234-5678", "isDescriptive": false},
      {"question": "나이", "answer": "25", "isDescriptive": false},
      {"question": "학과", "answer": "컴퓨터공학부", "isDescriptive": false},
      {"question": "학번", "answer": "20210001", "isDescriptive": false},
      {"question": "재학중인 학기", "answer": "3-1", "isDescriptive": false},
      {"question": "자기소개를 해주세요", "answer": "안녕하세요, 저는 홍길동입니다.", "isDescriptive": true}
    ]
  }'
```

* 응답: `201 Created`, `Location: /applicants`
* H2 콘솔(`/h2-console`)로 확인한 결과:
  * `applicant`: 매핑 필드(이름/전화번호/나이/학과/학번/재학학기)가 정확히 저장됨
  * `applicant_answer`: 매핑 안 된 문항 중 장문형("자기소개를 해주세요")만 저장됨 (단답형/객관식은 제외)
  * `applicant_sync_log`: formId/responseId 기록됨
  * `document_section`: 장문형 문항이 해당 파트의 서류 심사 문항으로 자동 생성됨
* 같은 responseId로 재요청 시 응답은 동일하게 `201`이지만 DB에는 중복 저장되지 않음 (dedup 확인)

</details>

## 📎 Issue 번호

closed yourssu/Yourssu-Scouter-Backend#404