### PR TITLE
fix : assignedQuestion 데이터 삭제 잠금 조치

### DIFF
--- a/src/main/kotlin/com/yourssu/scouter/recruiting/interviewQuestion/business/AssignedQuestionService.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/interviewQuestion/business/AssignedQuestionService.kt
@@ -124,13 +124,15 @@ class AssignedQuestionService(
                         },
                 )
             }
-        val sourceQuestionsById = readSourceQuestionsById(questions)
-        assignedQuestionValidator.validate(questions, sourceQuestionsById, applicantPartId)
+        val questionsWithRestoredParts = restorePartQuestionsRemovedWhileLocked(applicantId, questions, partLocked)
+
+        val sourceQuestionsById = readSourceQuestionsById(questionsWithRestoredParts)
+        assignedQuestionValidator.validate(questionsWithRestoredParts, sourceQuestionsById, applicantPartId)
 
         updateCatalogQuestions(command.questions, sourceQuestionsById, partLocked)
-        deleteRemovedPartQuestions(questions, applicantPartId, applicantSemesterId, partLocked)
+        deleteRemovedPartQuestions(questionsWithRestoredParts, applicantPartId, applicantSemesterId, partLocked)
 
-        val saved = assignedQuestionWriter.replaceAll(applicantId, questions.map { it.withoutCultureSelection() })
+        val saved = assignedQuestionWriter.replaceAll(applicantId, questionsWithRestoredParts.map { it.withoutCultureSelection() })
 
         val savedSourceQuestionsById = readSourceQuestionsById(saved)
         val requirementsById = readRequirementsById(applicant)
@@ -170,6 +172,43 @@ class AssignedQuestionService(
 
         partCultureSelectionWriter.replaceSelection(applicantPartId, applicantSemesterId, newSelection.toList())
         return newSelection
+    }
+
+    /**
+     * 파트가 잠긴 상태(=같은 파트의 다른 지원자가 이미 면접 평가를 받음)에서는 요청 목록에서 기존 PART
+     * 질문을 빼는 방식으로 우회 삭제할 수 없어야 한다. replaceAll은 요청에 없는 인스턴스를 그대로 지워버리므로,
+     * 잠긴 상태에서 요청에서 누락된 기존 PART 인스턴스를 찾아 그대로 복원해 함께 저장되도록 한다.
+     */
+    private fun restorePartQuestionsRemovedWhileLocked(
+        applicantId: Long,
+        questions: List<AssignedQuestion>,
+        partLocked: Boolean,
+    ): List<AssignedQuestion> {
+        if (!partLocked) return questions
+
+        val submittedPartSourceIds = questions
+            .filter { it.category == AssignedQuestionCategory.PART }
+            .mapNotNull { it.sourceQuestionId }
+            .toSet()
+
+        val missingPartQuestions = assignedQuestionReader.readAllByApplicantId(applicantId)
+            .filter { it.category == AssignedQuestionCategory.PART && it.sourceQuestionId !in submittedPartSourceIds }
+        if (missingPartQuestions.isEmpty()) return questions
+
+        val startSortOrder = (questions.maxOfOrNull { it.sortOrder } ?: -1) + 1
+        val restored = missingPartQuestions.mapIndexed { offset, question ->
+            AssignedQuestion(
+                assignedMemberId = question.assignedMemberId,
+                applicantId = applicantId,
+                sourceQuestionId = question.sourceQuestionId,
+                content = question.content,
+                category = question.category,
+                sortOrder = startSortOrder + offset,
+                isSelected = question.isSelected,
+                requirementIds = question.requirementIds,
+            )
+        }
+        return questions + restored
     }
 
     /**

--- a/src/test/kotlin/com/yourssu/scouter/recruiting/interviewQuestion/business/AssignedQuestionServiceTest.kt
+++ b/src/test/kotlin/com/yourssu/scouter/recruiting/interviewQuestion/business/AssignedQuestionServiceTest.kt
@@ -558,6 +558,86 @@ class AssignedQuestionServiceTest {
     }
 
     @Test
+    fun `같은 파트의 다른 지원자가 이미 평가받아 파트가 잠긴 상태에서 요청에서 빠진 기존 PART 질문은 삭제되지 않고 그대로 유지된다`() {
+        val interviewerMemberId = 100L
+        val otherApplicantId = 2L
+        val semesterId = 1L
+        val partQuestionId = 7L
+
+        // 같은 파트의 다른 지원자(otherApplicantId)가 이미 면접 평가를 받아 파트가 잠긴 상태를 만든다.
+        whenever(applicantReader.readByPartId(partId)).thenReturn(
+            listOf(
+                ApplicantFixtureBuilder()
+                    .id(otherApplicantId)
+                    .part(PartFixtureBuilder().id(partId).build())
+                    .applicationSemester(SemesterFixtureBuilder().id(semesterId).build())
+                    .build(),
+            ),
+        )
+        whenever(interviewEvaluationReader.readAllByApplicantIdIn(listOf(otherApplicantId)))
+            .thenReturn(listOf(mock(com.yourssu.scouter.recruiting.evaluation.implement.InterviewEvaluation::class.java)))
+
+        // 이 지원자(applicantId)는 CULTURE 2개와 PART 질문(7L)을 이미 저장해 두었다.
+        val existingSaved = listOf(
+            assignedCultureQuestion(11L, interviewerMemberId, 1L, isSelected = true, sortOrder = 0),
+            assignedCultureQuestion(12L, interviewerMemberId, 2L, isSelected = true, sortOrder = 1),
+            AssignedQuestion(
+                id = 17L,
+                assignedMemberId = interviewerMemberId,
+                applicantId = applicantId,
+                sourceQuestionId = partQuestionId,
+                content = null,
+                category = AssignedQuestionCategory.PART,
+                sortOrder = 2,
+            ),
+        )
+        whenever(assignedQuestionReader.readAllByApplicantId(applicantId)).thenReturn(existingSaved)
+        whenever(partCultureSelectionReader.readSelectedQuestionIds(partId, semesterId)).thenReturn(setOf(1L, 2L))
+        whenever(questionReader.readAllByIdIn(any())).thenReturn(
+            listOf(
+                Question(1L, null, semesterId, QuestionCategory.CULTURE, "컬쳐1", 1, requirementIds = listOf(1L)),
+                Question(2L, null, semesterId, QuestionCategory.CULTURE, "컬쳐2", 2, requirementIds = listOf(1L)),
+                Question(partQuestionId, partId, semesterId, QuestionCategory.PART, "파트 질문", 1, requirementIds = listOf(401L)),
+            ),
+        )
+        whenever(memberReader.readById(interviewerMemberId)).thenReturn(
+            MemberFixtureBuilder().id(interviewerMemberId).build(),
+        )
+        whenever(assignedQuestionWriter.replaceAll(any(), any())).thenReturn(existingSaved)
+
+        // PART 질문(7L)을 요청 목록에서 빼서 우회 삭제를 시도한다.
+        val command = SaveAssignedQuestionsCommand(
+            questions = listOf(
+                SaveAssignedQuestionCommand(
+                    assignedMemberId = interviewerMemberId,
+                    sourceQuestionId = 1L,
+                    content = null,
+                    category = AssignedQuestionCategory.CULTURE,
+                    isSelected = true,
+                ),
+                SaveAssignedQuestionCommand(
+                    assignedMemberId = interviewerMemberId,
+                    sourceQuestionId = 2L,
+                    content = null,
+                    category = AssignedQuestionCategory.CULTURE,
+                    isSelected = true,
+                ),
+            ),
+        )
+
+        assignedQuestionService.upsert(applicantId, command)
+
+        val replaceAllCaptor = argumentCaptor<List<AssignedQuestion>>()
+        verify(assignedQuestionWriter).replaceAll(any(), replaceAllCaptor.capture())
+        val savedPartQuestions = replaceAllCaptor.firstValue.filter { it.category == AssignedQuestionCategory.PART }
+        assertThat(savedPartQuestions).hasSize(1)
+        assertThat(savedPartQuestions.single().sourceQuestionId).isEqualTo(partQuestionId)
+
+        verify(assignedQuestionWriter, org.mockito.Mockito.never()).deleteAllBySourceQuestionIdIn(any())
+        verify(questionWriter, org.mockito.Mockito.never()).deleteAllByIdIn(any())
+    }
+
+    @Test
     fun `제출된 면접 평가가 있으면 질문지 수정 시 예외를 발생시킨다`() {
         val interviewerMemberId = 100L
         whenever(interviewEvaluationReader.existsByApplicantId(applicantId)).thenReturn(true)


### PR DESCRIPTION
## 📄 작업 내용 요약
- 지원자 평가 후 질문지 저장 api로 파트별 공통질문을 삭제한다고 했을때 assignedQuestion 도 같이 삭제되는 문제 수정

## 📎 Issue 번호
closed #470

