### PR TITLE
[#405]; feat: 일반 이메일/비밀번호 로그인 기능 추가

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -57,6 +57,9 @@ dependencies {
 	implementation("jakarta.activation:jakarta.activation-api:2.1.3")
 	implementation("com.sun.activation:jakarta.activation:2.0.1")
 
+	// password encoding
+	implementation("org.springframework.security:spring-security-crypto")
+
 	// jwt
 	implementation ("io.jsonwebtoken:jjwt-api:$jwtVersion")
 	runtimeOnly ("io.jsonwebtoken:jjwt-impl:$jwtVersion")

--- a/src/main/kotlin/com/yourssu/scouter/auth/authentication/application/AuthenticationController.kt
+++ b/src/main/kotlin/com/yourssu/scouter/auth/authentication/application/AuthenticationController.kt
@@ -10,11 +10,15 @@ import com.yourssu.scouter.auth.authentication.application.dto.ValidateTokenResp
 
 import com.yourssu.scouter.auth.authentication.application.dto.OAuth2LoginRequest
 
+import com.yourssu.scouter.auth.authentication.application.dto.SignupRequest
+import com.yourssu.scouter.auth.authentication.application.dto.SignupResponse
 import com.yourssu.scouter.auth.authentication.application.dto.WithdrawalRequest
 
 import com.yourssu.scouter.auth.authentication.application.dto.TokenRefreshRequest
 
 import com.yourssu.scouter.auth.authentication.business.AuthenticationService
+import com.yourssu.scouter.auth.authentication.business.GeneralAuthService
+import com.yourssu.scouter.auth.authentication.business.dto.SignupResult
 import com.yourssu.scouter.auth.authentication.business.dto.TokenDto
 import com.yourssu.scouter.auth.authentication.business.LoginService
 import com.yourssu.scouter.auth.authentication.business.dto.LoginWithMemberResult
@@ -43,9 +47,33 @@ import org.slf4j.LoggerFactory
 class AuthenticationController(
     private val authenticationService: AuthenticationService,
     private val loginService: LoginService,
+    private val generalAuthService: GeneralAuthService,
 ) {
 
     private val logger = LoggerFactory.getLogger(AuthenticationController::class.java)
+
+    @Operation(
+        summary = "일반 회원가입",
+        description = "이메일/비밀번호로 회원가입합니다. 등록된 멤버만 가입할 수 있습니다.",
+        responses = [
+            ApiResponse(responseCode = "200", description = "회원가입 성공"),
+            ApiResponse(responseCode = "401", description = "Member-005 (등록된 멤버가 아닙니다)"),
+            ApiResponse(responseCode = "409", description = "Auth-003 (이미 가입된 이메일입니다)"),
+        ]
+    )
+    @SecurityRequirements // 로그인을 필요로 하지 않는 곳은 전역 인증을 사용하지않도록 초기화
+    @PostMapping("/auth/signup")
+    fun signup(
+        @RequestBody @Valid request: SignupRequest,
+    ): ResponseEntity<SignupResponse> {
+        val signupResult: SignupResult = generalAuthService.signup(
+            email = request.email,
+            password = request.password,
+        )
+        val response: SignupResponse = SignupResponse.from(signupResult)
+
+        return ResponseEntity.ok(response)
+    }
 
     @Tag(name = "OAUTH2")
     @Operation(

--- a/src/main/kotlin/com/yourssu/scouter/auth/authentication/application/AuthenticationController.kt
+++ b/src/main/kotlin/com/yourssu/scouter/auth/authentication/application/AuthenticationController.kt
@@ -59,7 +59,7 @@ class AuthenticationController(
         responses = [
             ApiResponse(responseCode = "200", description = "회원가입 성공"),
             ApiResponse(responseCode = "401", description = "Member-005 (등록된 멤버가 아닙니다)"),
-            ApiResponse(responseCode = "409", description = "Auth-003 (이미 가입된 이메일입니다)"),
+            ApiResponse(responseCode = "409", description = "Auth-005 (이미 가입된 이메일입니다)"),
         ]
     )
     @SecurityRequirements
@@ -79,7 +79,7 @@ class AuthenticationController(
         description = "이메일/비밀번호로 로그인합니다. 등록된 멤버만 로그인할 수 있습니다.",
         responses = [
             ApiResponse(responseCode = "200", description = "로그인 성공 — 토큰 반환"),
-            ApiResponse(responseCode = "401", description = "Auth-004 (이메일 또는 비밀번호가 올바르지 않습니다) / Member-005 (등록된 멤버가 아닙니다)"),
+            ApiResponse(responseCode = "401", description = "Auth-006 (이메일 또는 비밀번호가 올바르지 않습니다) / Member-005 (등록된 멤버가 아닙니다)"),
         ]
     )
     @SecurityRequirements

--- a/src/main/kotlin/com/yourssu/scouter/auth/authentication/application/AuthenticationController.kt
+++ b/src/main/kotlin/com/yourssu/scouter/auth/authentication/application/AuthenticationController.kt
@@ -8,6 +8,7 @@ import com.yourssu.scouter.auth.authentication.application.dto.LogoutRequest
 
 import com.yourssu.scouter.auth.authentication.application.dto.ValidateTokenResponse
 
+import com.yourssu.scouter.auth.authentication.application.dto.LoginRequest
 import com.yourssu.scouter.auth.authentication.application.dto.OAuth2LoginRequest
 
 import com.yourssu.scouter.auth.authentication.application.dto.SignupRequest
@@ -61,7 +62,7 @@ class AuthenticationController(
             ApiResponse(responseCode = "409", description = "Auth-003 (이미 가입된 이메일입니다)"),
         ]
     )
-    @SecurityRequirements // 로그인을 필요로 하지 않는 곳은 전역 인증을 사용하지않도록 초기화
+    @SecurityRequirements
     @PostMapping("/auth/signup")
     fun signup(
         @RequestBody @Valid request: SignupRequest,
@@ -70,9 +71,27 @@ class AuthenticationController(
             email = request.email,
             password = request.password,
         )
-        val response: SignupResponse = SignupResponse.from(signupResult)
+        return ResponseEntity.ok(SignupResponse.from(signupResult))
+    }
 
-        return ResponseEntity.ok(response)
+    @Operation(
+        summary = "일반 로그인",
+        description = "이메일/비밀번호로 로그인합니다. 등록된 멤버만 로그인할 수 있습니다.",
+        responses = [
+            ApiResponse(responseCode = "200", description = "로그인 성공 — 토큰 반환"),
+            ApiResponse(responseCode = "401", description = "Auth-004 (이메일 또는 비밀번호가 올바르지 않습니다) / Member-005 (등록된 멤버가 아닙니다)"),
+        ]
+    )
+    @SecurityRequirements
+    @PostMapping("/auth/login")
+    fun login(
+        @RequestBody @Valid request: LoginRequest,
+    ): ResponseEntity<LoginResponse> {
+        val loginWithMemberResult: LoginWithMemberResult = generalAuthService.login(
+            email = request.email,
+            password = request.password,
+        )
+        return ResponseEntity.ok(LoginResponse.from(loginWithMemberResult))
     }
 
     @Tag(name = "OAUTH2")

--- a/src/main/kotlin/com/yourssu/scouter/auth/authentication/application/AuthenticationController.kt
+++ b/src/main/kotlin/com/yourssu/scouter/auth/authentication/application/AuthenticationController.kt
@@ -101,6 +101,10 @@ class AuthenticationController(
         responses = [
             ApiResponse(responseCode = "200", description = "로그인 성공 — 토큰 반환"),
             ApiResponse(responseCode = "401", description = "Member-005 (등록된 멤버가 아닙니다)"),
+            ApiResponse(
+                responseCode = "409",
+                description = "Auth-005 (이미 일반 회원가입 또는 다른 소셜 계정이 사용 중인 이메일입니다)",
+            ),
         ]
     )
     @SecurityRequirements // 로그인을 필요로 하지 않는 곳은 전역 인증을 사용하지않도록 초기화

--- a/src/main/kotlin/com/yourssu/scouter/auth/authentication/application/dto/LoginRequest.kt
+++ b/src/main/kotlin/com/yourssu/scouter/auth/authentication/application/dto/LoginRequest.kt
@@ -1,0 +1,14 @@
+package com.yourssu.scouter.auth.authentication.application.dto
+
+import jakarta.validation.constraints.Email
+import jakarta.validation.constraints.NotBlank
+
+data class LoginRequest(
+
+    @field:NotBlank(message = "이메일이 입력되지 않았습니다.")
+    @field:Email(message = "이메일 형식이 올바르지 않습니다.")
+    val email: String,
+
+    @field:NotBlank(message = "비밀번호가 입력되지 않았습니다.")
+    val password: String,
+)

--- a/src/main/kotlin/com/yourssu/scouter/auth/authentication/application/dto/LoginRequest.kt
+++ b/src/main/kotlin/com/yourssu/scouter/auth/authentication/application/dto/LoginRequest.kt
@@ -11,4 +11,8 @@ data class LoginRequest(
 
     @field:NotBlank(message = "비밀번호가 입력되지 않았습니다.")
     val password: String,
-)
+) {
+
+    // data class의 기본 toString()은 비밀번호를 평문으로 노출하므로 마스킹한다.
+    override fun toString(): String = "LoginRequest(email=$email, password=****)"
+}

--- a/src/main/kotlin/com/yourssu/scouter/auth/authentication/application/dto/LoginResponse.kt
+++ b/src/main/kotlin/com/yourssu/scouter/auth/authentication/application/dto/LoginResponse.kt
@@ -1,6 +1,7 @@
 package com.yourssu.scouter.auth.authentication.application.dto
 
 import com.yourssu.scouter.auth.authentication.business.dto.LoginWithMemberResult
+import com.yourssu.scouter.auth.support.constants.AuthConstants
 import io.swagger.v3.oas.annotations.media.Schema
 
 @Schema(description = "로그인 응답")
@@ -14,7 +15,7 @@ data class LoginResponse(
 ) {
     companion object {
         fun from(result: LoginWithMemberResult): LoginResponse = LoginResponse(
-            tokenType = "Bearer",
+            tokenType = AuthConstants.BEARER_TOKEN_TYPE,
             accessToken = result.accessToken,
             refreshToken = result.refreshToken,
         )

--- a/src/main/kotlin/com/yourssu/scouter/auth/authentication/application/dto/SignupRequest.kt
+++ b/src/main/kotlin/com/yourssu/scouter/auth/authentication/application/dto/SignupRequest.kt
@@ -11,7 +11,8 @@ data class SignupRequest(
     val email: String,
 
     @field:NotBlank(message = "비밀번호가 입력되지 않았습니다.")
-    @field:Size(min = 8, message = "비밀번호는 8자 이상이어야 합니다.")
+    // BCrypt는 72바이트를 넘는 입력을 잘라내므로 상한을 둔다.
+    @field:Size(min = 8, max = 64, message = "비밀번호는 8자 이상 64자 이하여야 합니다.")
     val password: String,
 ) {
 

--- a/src/main/kotlin/com/yourssu/scouter/auth/authentication/application/dto/SignupRequest.kt
+++ b/src/main/kotlin/com/yourssu/scouter/auth/authentication/application/dto/SignupRequest.kt
@@ -13,4 +13,8 @@ data class SignupRequest(
     @field:NotBlank(message = "비밀번호가 입력되지 않았습니다.")
     @field:Size(min = 8, message = "비밀번호는 8자 이상이어야 합니다.")
     val password: String,
-)
+) {
+
+    // data class의 기본 toString()은 비밀번호를 평문으로 노출하므로 마스킹한다.
+    override fun toString(): String = "SignupRequest(email=$email, password=****)"
+}

--- a/src/main/kotlin/com/yourssu/scouter/auth/authentication/application/dto/SignupRequest.kt
+++ b/src/main/kotlin/com/yourssu/scouter/auth/authentication/application/dto/SignupRequest.kt
@@ -1,0 +1,16 @@
+package com.yourssu.scouter.auth.authentication.application.dto
+
+import jakarta.validation.constraints.Email
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Size
+
+data class SignupRequest(
+
+    @field:NotBlank(message = "이메일이 입력되지 않았습니다.")
+    @field:Email(message = "이메일 형식이 올바르지 않습니다.")
+    val email: String,
+
+    @field:NotBlank(message = "비밀번호가 입력되지 않았습니다.")
+    @field:Size(min = 8, message = "비밀번호는 8자 이상이어야 합니다.")
+    val password: String,
+)

--- a/src/main/kotlin/com/yourssu/scouter/auth/authentication/application/dto/SignupResponse.kt
+++ b/src/main/kotlin/com/yourssu/scouter/auth/authentication/application/dto/SignupResponse.kt
@@ -1,0 +1,22 @@
+package com.yourssu.scouter.auth.authentication.application.dto
+
+import com.yourssu.scouter.auth.authentication.business.dto.SignupResult
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "회원가입 응답")
+data class SignupResponse(
+    @field:Schema(description = "유저 ID")
+    val id: Long,
+    @field:Schema(description = "이메일")
+    val email: String,
+    @field:Schema(description = "이름")
+    val name: String,
+) {
+    companion object {
+        fun from(result: SignupResult): SignupResponse = SignupResponse(
+            id = result.id,
+            email = result.email,
+            name = result.name,
+        )
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/auth/authentication/application/dto/TokenRefreshResponse.kt
+++ b/src/main/kotlin/com/yourssu/scouter/auth/authentication/application/dto/TokenRefreshResponse.kt
@@ -1,6 +1,7 @@
 package com.yourssu.scouter.auth.authentication.application.dto
 
 import com.yourssu.scouter.auth.authentication.business.dto.TokenDto
+import com.yourssu.scouter.auth.support.constants.AuthConstants
 
 data class TokenRefreshResponse(
     val tokenType: String,
@@ -10,7 +11,7 @@ data class TokenRefreshResponse(
 
     companion object {
         fun from(tokenDto: TokenDto) = TokenRefreshResponse(
-            tokenType = "Bearer",
+            tokenType = AuthConstants.BEARER_TOKEN_TYPE,
             accessToken = tokenDto.accessToken,
             refreshToken = tokenDto.refreshToken,
         )

--- a/src/main/kotlin/com/yourssu/scouter/auth/authentication/business/GeneralAuthService.kt
+++ b/src/main/kotlin/com/yourssu/scouter/auth/authentication/business/GeneralAuthService.kt
@@ -1,0 +1,34 @@
+package com.yourssu.scouter.auth.authentication.business
+
+import com.yourssu.scouter.auth.authentication.business.dto.SignupResult
+import com.yourssu.scouter.auth.authentication.implement.GeneralAuthValidator
+import com.yourssu.scouter.auth.user.implement.User
+import com.yourssu.scouter.auth.user.implement.UserWriter
+import com.yourssu.scouter.member.core.implement.Member
+import org.springframework.security.crypto.password.PasswordEncoder
+import org.springframework.stereotype.Service
+
+@Service
+class GeneralAuthService(
+    private val userWriter: UserWriter,
+    private val generalAuthValidator: GeneralAuthValidator,
+    private val passwordEncoder: PasswordEncoder,
+) {
+
+    fun signup(email: String, password: String): SignupResult {
+        val member: Member = generalAuthValidator.validateSignupEligible(email)
+
+        val encodedPassword: String = passwordEncoder.encode(password)
+        val user: User = userWriter.writeGeneral(
+            name = member.name,
+            email = email,
+            encodedPassword = encodedPassword,
+        )
+
+        return SignupResult(
+            id = user.id!!,
+            email = user.getEmailAddress(),
+            name = member.name,
+        )
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/auth/authentication/business/GeneralAuthService.kt
+++ b/src/main/kotlin/com/yourssu/scouter/auth/authentication/business/GeneralAuthService.kt
@@ -1,17 +1,26 @@
 package com.yourssu.scouter.auth.authentication.business
 
+import com.yourssu.scouter.auth.authentication.business.dto.LoginWithMemberResult
 import com.yourssu.scouter.auth.authentication.business.dto.SignupResult
 import com.yourssu.scouter.auth.authentication.implement.GeneralAuthValidator
+import com.yourssu.scouter.auth.authentication.implement.PrivateClaims
+import com.yourssu.scouter.auth.authentication.implement.Token
+import com.yourssu.scouter.auth.authentication.implement.TokenProcessor
 import com.yourssu.scouter.auth.user.implement.User
+import com.yourssu.scouter.auth.user.implement.UserMemberLinker
 import com.yourssu.scouter.auth.user.implement.UserWriter
+import com.yourssu.scouter.member.core.business.dto.MemberDto
 import com.yourssu.scouter.member.core.implement.Member
 import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.stereotype.Service
+import java.time.Instant
 
 @Service
 class GeneralAuthService(
     private val userWriter: UserWriter,
+    private val userMemberLinker: UserMemberLinker,
     private val generalAuthValidator: GeneralAuthValidator,
+    private val tokenProcessor: TokenProcessor,
     private val passwordEncoder: PasswordEncoder,
 ) {
 
@@ -29,6 +38,26 @@ class GeneralAuthService(
             id = user.id!!,
             email = user.getEmailAddress(),
             name = member.name,
+        )
+    }
+
+    fun login(email: String, password: String): LoginWithMemberResult {
+        val user: User = generalAuthValidator.validateLoginCredentials(email, password)
+
+        val tokenIssueTime = Instant.now()
+        val privateClaims = PrivateClaims(user.id!!)
+        val token: Token = tokenProcessor.generateToken(
+            issueTime = tokenIssueTime,
+            privateClaims = privateClaims.toMap(),
+        )
+
+        val member: Member = userMemberLinker.link(user.id, email)
+
+        return LoginWithMemberResult(
+            accessToken = token.accessToken,
+            refreshToken = token.refreshToken,
+            profileImageUrl = user.userInfo.profileImageUrl,
+            member = MemberDto.from(member),
         )
     }
 }

--- a/src/main/kotlin/com/yourssu/scouter/auth/authentication/business/GeneralAuthService.kt
+++ b/src/main/kotlin/com/yourssu/scouter/auth/authentication/business/GeneralAuthService.kt
@@ -6,13 +6,16 @@ import com.yourssu.scouter.auth.authentication.implement.GeneralAuthValidator
 import com.yourssu.scouter.auth.authentication.implement.PrivateClaims
 import com.yourssu.scouter.auth.authentication.implement.Token
 import com.yourssu.scouter.auth.authentication.implement.TokenProcessor
+import com.yourssu.scouter.auth.support.exception.DuplicateEmailException
 import com.yourssu.scouter.auth.user.implement.User
 import com.yourssu.scouter.auth.user.implement.UserMemberLinker
 import com.yourssu.scouter.auth.user.implement.UserWriter
 import com.yourssu.scouter.member.core.business.dto.MemberDto
 import com.yourssu.scouter.member.core.implement.Member
+import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 import java.time.Instant
 
 @Service
@@ -24,15 +27,22 @@ class GeneralAuthService(
     private val passwordEncoder: PasswordEncoder,
 ) {
 
+    @Transactional
     fun signup(email: String, password: String): SignupResult {
         val member: Member = generalAuthValidator.validateSignupEligible(email)
 
         val encodedPassword: String = passwordEncoder.encode(password)
-        val user: User = userWriter.writeGeneral(
-            name = member.name,
-            email = email,
-            encodedPassword = encodedPassword,
-        )
+        // 중복 확인과 저장 사이에는 락이 없어 동시 요청이 유니크 제약에 걸릴 수 있다.
+        // 그대로 두면 400 Database-Constraint-Violation이 나가므로 409로 맞춰준다.
+        val user: User = try {
+            userWriter.writeGeneral(
+                name = member.name,
+                email = email,
+                encodedPassword = encodedPassword,
+            )
+        } catch (e: DataIntegrityViolationException) {
+            throw DuplicateEmailException("이미 가입된 이메일입니다.")
+        }
 
         return SignupResult(
             id = user.id!!,

--- a/src/main/kotlin/com/yourssu/scouter/auth/authentication/business/LoginService.kt
+++ b/src/main/kotlin/com/yourssu/scouter/auth/authentication/business/LoginService.kt
@@ -4,16 +4,15 @@ import com.yourssu.scouter.auth.authentication.business.dto.LoginWithMemberResul
 
 import com.yourssu.scouter.auth.authentication.business.dto.LoginResult
 import com.yourssu.scouter.auth.authentication.implement.OAuth2Type
+import com.yourssu.scouter.auth.user.implement.UserMemberLinker
 import com.yourssu.scouter.member.core.business.dto.MemberDto
 import com.yourssu.scouter.member.core.implement.Member
-import com.yourssu.scouter.member.core.implement.MemberWriter
-import com.yourssu.scouter.member.support.exception.MemberNotRegisteredException
 import org.springframework.stereotype.Service
 
 @Service
 class LoginService(
     private val oauth2Service: OAuth2Service,
-    private val memberWriter: MemberWriter,
+    private val userMemberLinker: UserMemberLinker,
 ) {
 
     fun login(
@@ -29,8 +28,7 @@ class LoginService(
             redirectUriOverride = redirectUriOverride,
         )
 
-        val member = memberWriter.updateUserIdByEmail(loginResult.id, loginResult.email)
-            ?: throw MemberNotRegisteredException("등록된 멤버가 아닙니다.")
+        val member: Member = userMemberLinker.link(loginResult.id, loginResult.email)
 
         return LoginWithMemberResult(
             accessToken = loginResult.accessToken,

--- a/src/main/kotlin/com/yourssu/scouter/auth/authentication/business/OAuth2Service.kt
+++ b/src/main/kotlin/com/yourssu/scouter/auth/authentication/business/OAuth2Service.kt
@@ -8,6 +8,7 @@ import com.yourssu.scouter.auth.authentication.implement.OAuth2Handler
 import com.yourssu.scouter.auth.authentication.implement.OAuth2HandlerComposite
 import com.yourssu.scouter.auth.authentication.implement.OAuth2TokenInfo
 import com.yourssu.scouter.auth.authentication.implement.OAuth2Type
+import com.yourssu.scouter.auth.authentication.implement.OAuth2SignupValidator
 import com.yourssu.scouter.auth.authentication.implement.OAuth2User
 import com.yourssu.scouter.auth.authentication.implement.PrivateClaims
 import com.yourssu.scouter.auth.authentication.implement.Token
@@ -25,6 +26,7 @@ class OAuth2Service(
     private val oauth2HandlerComposite: OAuth2HandlerComposite,
     private val userReader: UserReader,
     private val userWriter: UserWriter,
+    private val oauth2SignupValidator: OAuth2SignupValidator,
     private val tokenProcessor: TokenProcessor,
 ) {
 
@@ -82,6 +84,8 @@ class OAuth2Service(
             userWriter.write(findUser)
             return findUser
         }
+
+        oauth2SignupValidator.validateEmailNotTaken(oauth2User.userInfo.email)
 
         return userWriter.write(oauth2User)
     }

--- a/src/main/kotlin/com/yourssu/scouter/auth/authentication/business/dto/SignupResult.kt
+++ b/src/main/kotlin/com/yourssu/scouter/auth/authentication/business/dto/SignupResult.kt
@@ -1,0 +1,7 @@
+package com.yourssu.scouter.auth.authentication.business.dto
+
+data class SignupResult(
+    val id: Long,
+    val email: String,
+    val name: String,
+)

--- a/src/main/kotlin/com/yourssu/scouter/auth/authentication/implement/GeneralAuthValidator.kt
+++ b/src/main/kotlin/com/yourssu/scouter/auth/authentication/implement/GeneralAuthValidator.kt
@@ -1,16 +1,20 @@
 package com.yourssu.scouter.auth.authentication.implement
 
 import com.yourssu.scouter.auth.support.exception.DuplicateEmailException
+import com.yourssu.scouter.auth.support.exception.InvalidCredentialsException
+import com.yourssu.scouter.auth.user.implement.User
 import com.yourssu.scouter.auth.user.implement.UserReader
 import com.yourssu.scouter.member.core.implement.Member
 import com.yourssu.scouter.member.core.implement.MemberReader
 import com.yourssu.scouter.member.support.exception.MemberNotRegisteredException
+import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.stereotype.Component
 
 @Component
 class GeneralAuthValidator(
     private val userReader: UserReader,
     private val memberReader: MemberReader,
+    private val passwordEncoder: PasswordEncoder,
 ) {
 
     fun validateSignupEligible(email: String): Member {
@@ -22,5 +26,16 @@ class GeneralAuthValidator(
         }
 
         return member
+    }
+
+    fun validateLoginCredentials(email: String, password: String): User {
+        val user: User = userReader.findByEmail(email)
+            ?: throw InvalidCredentialsException("이메일 또는 비밀번호가 올바르지 않습니다.")
+
+        if (!passwordEncoder.matches(password, user.userInfo.password)) {
+            throw InvalidCredentialsException("이메일 또는 비밀번호가 올바르지 않습니다.")
+        }
+
+        return user
     }
 }

--- a/src/main/kotlin/com/yourssu/scouter/auth/authentication/implement/GeneralAuthValidator.kt
+++ b/src/main/kotlin/com/yourssu/scouter/auth/authentication/implement/GeneralAuthValidator.kt
@@ -1,0 +1,26 @@
+package com.yourssu.scouter.auth.authentication.implement
+
+import com.yourssu.scouter.auth.support.exception.DuplicateEmailException
+import com.yourssu.scouter.auth.user.implement.UserReader
+import com.yourssu.scouter.member.core.implement.Member
+import com.yourssu.scouter.member.core.implement.MemberReader
+import com.yourssu.scouter.member.support.exception.MemberNotRegisteredException
+import org.springframework.stereotype.Component
+
+@Component
+class GeneralAuthValidator(
+    private val userReader: UserReader,
+    private val memberReader: MemberReader,
+) {
+
+    fun validateSignupEligible(email: String): Member {
+        val member: Member = memberReader.readByEmailOrNull(email)
+            ?: throw MemberNotRegisteredException("등록된 멤버가 아닙니다.")
+
+        if (userReader.findByEmail(email) != null) {
+            throw DuplicateEmailException("이미 가입된 이메일입니다.")
+        }
+
+        return member
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/auth/authentication/implement/GeneralAuthValidator.kt
+++ b/src/main/kotlin/com/yourssu/scouter/auth/authentication/implement/GeneralAuthValidator.kt
@@ -2,6 +2,7 @@ package com.yourssu.scouter.auth.authentication.implement
 
 import com.yourssu.scouter.auth.support.exception.DuplicateEmailException
 import com.yourssu.scouter.auth.support.exception.InvalidCredentialsException
+import com.yourssu.scouter.auth.user.implement.AuthType
 import com.yourssu.scouter.auth.user.implement.User
 import com.yourssu.scouter.auth.user.implement.UserReader
 import com.yourssu.scouter.member.core.implement.Member
@@ -31,6 +32,12 @@ class GeneralAuthValidator(
     fun validateLoginCredentials(email: String, password: String): User {
         val user: User = userReader.findByEmail(email)
             ?: throw InvalidCredentialsException("이메일 또는 비밀번호가 올바르지 않습니다.")
+
+        // OAuth 유저는 password가 null이라 matches()가 false를 반환하긴 하지만,
+        // 인코더 구현에 기대지 않고 인증 방식을 명시적으로 확인한다.
+        if (user.userInfo.authType != AuthType.GENERAL) {
+            throw InvalidCredentialsException("이메일 또는 비밀번호가 올바르지 않습니다.")
+        }
 
         if (!passwordEncoder.matches(password, user.userInfo.password)) {
             throw InvalidCredentialsException("이메일 또는 비밀번호가 올바르지 않습니다.")

--- a/src/main/kotlin/com/yourssu/scouter/auth/authentication/implement/OAuth2SignupValidator.kt
+++ b/src/main/kotlin/com/yourssu/scouter/auth/authentication/implement/OAuth2SignupValidator.kt
@@ -1,0 +1,27 @@
+package com.yourssu.scouter.auth.authentication.implement
+
+import com.yourssu.scouter.auth.support.exception.DuplicateEmailException
+import com.yourssu.scouter.auth.user.implement.AuthType
+import com.yourssu.scouter.auth.user.implement.User
+import com.yourssu.scouter.auth.user.implement.UserReader
+import org.springframework.stereotype.Component
+
+/**
+ * OAuth 로그인은 oauth_id로 기존 유저를 찾으므로, 같은 이메일이라도 oauth_id가 다르면
+ * 새 유저를 만들려 한다. users.email에 유니크 제약이 생긴 뒤로는 그 INSERT가 DB 제약 위반으로
+ * 실패해 400 Database-Constraint-Violation이 나가므로, 그 전에 도메인 예외로 걸러낸다.
+ */
+@Component
+class OAuth2SignupValidator(
+    private val userReader: UserReader,
+) {
+
+    fun validateEmailNotTaken(email: String) {
+        val existingUser: User = userReader.findByEmail(email) ?: return
+
+        if (existingUser.userInfo.authType == AuthType.GENERAL) {
+            throw DuplicateEmailException("이미 이메일/비밀번호로 가입된 이메일입니다. 일반 로그인을 이용해 주세요.")
+        }
+        throw DuplicateEmailException("이미 다른 소셜 계정으로 가입된 이메일입니다.")
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/auth/support/configuration/PasswordEncoderConfiguration.kt
+++ b/src/main/kotlin/com/yourssu/scouter/auth/support/configuration/PasswordEncoderConfiguration.kt
@@ -1,0 +1,15 @@
+package com.yourssu.scouter.auth.support.configuration
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder
+import org.springframework.security.crypto.password.PasswordEncoder
+
+@Configuration
+class PasswordEncoderConfiguration {
+
+    @Bean
+    fun passwordEncoder(): PasswordEncoder {
+        return BCryptPasswordEncoder()
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/auth/support/constants/AuthConstants.kt
+++ b/src/main/kotlin/com/yourssu/scouter/auth/support/constants/AuthConstants.kt
@@ -1,0 +1,5 @@
+package com.yourssu.scouter.auth.support.constants
+
+object AuthConstants {
+    const val BEARER_TOKEN_TYPE: String = "Bearer"
+}

--- a/src/main/kotlin/com/yourssu/scouter/auth/support/exception/DuplicateEmailException.kt
+++ b/src/main/kotlin/com/yourssu/scouter/auth/support/exception/DuplicateEmailException.kt
@@ -5,4 +5,4 @@ import org.springframework.http.HttpStatus
 
 class DuplicateEmailException(
     message: String,
-) : CustomException(message, "Auth-003", HttpStatus.CONFLICT)
+) : CustomException(message, "Auth-005", HttpStatus.CONFLICT)

--- a/src/main/kotlin/com/yourssu/scouter/auth/support/exception/DuplicateEmailException.kt
+++ b/src/main/kotlin/com/yourssu/scouter/auth/support/exception/DuplicateEmailException.kt
@@ -1,0 +1,8 @@
+package com.yourssu.scouter.auth.support.exception
+
+import com.yourssu.scouter.common.exception.CustomException
+import org.springframework.http.HttpStatus
+
+class DuplicateEmailException(
+    message: String,
+) : CustomException(message, "Auth-003", HttpStatus.CONFLICT)

--- a/src/main/kotlin/com/yourssu/scouter/auth/support/exception/InvalidCredentialsException.kt
+++ b/src/main/kotlin/com/yourssu/scouter/auth/support/exception/InvalidCredentialsException.kt
@@ -1,0 +1,8 @@
+package com.yourssu.scouter.auth.support.exception
+
+import com.yourssu.scouter.common.exception.CustomException
+import org.springframework.http.HttpStatus
+
+class InvalidCredentialsException(
+    message: String,
+) : CustomException(message, "Auth-004", HttpStatus.UNAUTHORIZED)

--- a/src/main/kotlin/com/yourssu/scouter/auth/support/exception/InvalidCredentialsException.kt
+++ b/src/main/kotlin/com/yourssu/scouter/auth/support/exception/InvalidCredentialsException.kt
@@ -5,4 +5,4 @@ import org.springframework.http.HttpStatus
 
 class InvalidCredentialsException(
     message: String,
-) : CustomException(message, "Auth-004", HttpStatus.UNAUTHORIZED)
+) : CustomException(message, "Auth-006", HttpStatus.UNAUTHORIZED)

--- a/src/main/kotlin/com/yourssu/scouter/auth/user/implement/AuthType.kt
+++ b/src/main/kotlin/com/yourssu/scouter/auth/user/implement/AuthType.kt
@@ -1,0 +1,7 @@
+package com.yourssu.scouter.auth.user.implement
+
+enum class AuthType {
+    OAUTH2,
+    GENERAL,
+    ;
+}

--- a/src/main/kotlin/com/yourssu/scouter/auth/user/implement/User.kt
+++ b/src/main/kotlin/com/yourssu/scouter/auth/user/implement/User.kt
@@ -7,25 +7,29 @@ import java.time.Instant
 class User(
     val id: Long? = null,
     val userInfo: UserInfo,
-    var tokenInfo: TokenInfo,
+    var tokenInfo: TokenInfo? = null,
 ) {
     fun getBearerAccessToken(): String {
-        return tokenInfo.getBearerAccessToken()
+        return requireTokenInfo().getBearerAccessToken()
     }
 
     fun getBearerRefreshToken(): String {
-        return tokenInfo.getBearerRefreshToken()
+        return requireTokenInfo().getBearerRefreshToken()
     }
 
     fun isAccessTokenRemainMoreThan(minutes: Long): Boolean {
-        return tokenInfo.isAccessTokenRemainMoreThan(minutes)
+        return requireTokenInfo().isAccessTokenRemainMoreThan(minutes)
+    }
+
+    private fun requireTokenInfo(): TokenInfo {
+        return tokenInfo ?: throw IllegalStateException("OAuth2 토큰 정보가 없는 사용자입니다.")
     }
 
     fun updateToken(oauth2TokenInfo: OAuth2TokenInfo) {
         tokenInfo = TokenInfo(
             tokenPrefix = oauth2TokenInfo.tokenPrefix,
             accessToken = oauth2TokenInfo.accessToken,
-            refreshToken = oauth2TokenInfo.refreshToken ?: tokenInfo.refreshToken,
+            refreshToken = oauth2TokenInfo.refreshToken ?: tokenInfo?.refreshToken.orEmpty(),
             accessTokenExpirationDateTime = Instant.now().plusSeconds(oauth2TokenInfo.expiresIn),
         )
     }
@@ -52,8 +56,10 @@ class UserInfo(
     val name: String,
     val email: String,
     val profileImageUrl: String,
-    val oauthId: String,
-    val oauth2Type: OAuth2Type,
+    val authType: AuthType,
+    val oauthId: String? = null,
+    val oauth2Type: OAuth2Type? = null,
+    val password: String? = null,
 )
 
 class TokenInfo(

--- a/src/main/kotlin/com/yourssu/scouter/auth/user/implement/User.kt
+++ b/src/main/kotlin/com/yourssu/scouter/auth/user/implement/User.kt
@@ -29,7 +29,7 @@ class User(
         tokenInfo = TokenInfo(
             tokenPrefix = oauth2TokenInfo.tokenPrefix,
             accessToken = oauth2TokenInfo.accessToken,
-            refreshToken = oauth2TokenInfo.refreshToken ?: tokenInfo?.refreshToken.orEmpty(),
+            refreshToken = oauth2TokenInfo.refreshToken ?: requireTokenInfo().refreshToken,
             accessTokenExpirationDateTime = Instant.now().plusSeconds(oauth2TokenInfo.expiresIn),
         )
     }

--- a/src/main/kotlin/com/yourssu/scouter/auth/user/implement/UserMemberLinker.kt
+++ b/src/main/kotlin/com/yourssu/scouter/auth/user/implement/UserMemberLinker.kt
@@ -1,0 +1,17 @@
+package com.yourssu.scouter.auth.user.implement
+
+import com.yourssu.scouter.member.core.implement.Member
+import com.yourssu.scouter.member.core.implement.MemberWriter
+import com.yourssu.scouter.member.support.exception.MemberNotRegisteredException
+import org.springframework.stereotype.Component
+
+@Component
+class UserMemberLinker(
+    private val memberWriter: MemberWriter,
+) {
+
+    fun link(userId: Long, email: String): Member {
+        return memberWriter.updateUserIdByEmail(userId, email)
+            ?: throw MemberNotRegisteredException("등록된 멤버가 아닙니다.")
+    }
+}

--- a/src/main/kotlin/com/yourssu/scouter/auth/user/implement/UserWriter.kt
+++ b/src/main/kotlin/com/yourssu/scouter/auth/user/implement/UserWriter.kt
@@ -15,6 +15,7 @@ class UserWriter(
             name = oauth2User.userInfo.name,
             email = oauth2User.userInfo.email,
             profileImageUrl = oauth2User.userInfo.profileImageUrl,
+            authType = AuthType.OAUTH2,
             oauthId = oauth2User.userInfo.oauthId,
             oauth2Type = oauth2User.userInfo.oauth2Type,
         )

--- a/src/main/kotlin/com/yourssu/scouter/auth/user/implement/UserWriter.kt
+++ b/src/main/kotlin/com/yourssu/scouter/auth/user/implement/UserWriter.kt
@@ -39,6 +39,18 @@ class UserWriter(
         return userRepository.save(user)
     }
 
+    fun writeGeneral(name: String, email: String, encodedPassword: String): User {
+        val userInfo = UserInfo(
+            name = name,
+            email = email,
+            profileImageUrl = "",
+            authType = AuthType.GENERAL,
+            password = encodedPassword,
+        )
+
+        return userRepository.save(User(userInfo = userInfo))
+    }
+
     fun withdraw(userId: Long) {
         userRepository.deleteById(userId)
     }

--- a/src/main/kotlin/com/yourssu/scouter/auth/user/storage/UserEntity.kt
+++ b/src/main/kotlin/com/yourssu/scouter/auth/user/storage/UserEntity.kt
@@ -82,6 +82,8 @@ class UserEntity(
             oauth2Type = oauth2Type,
             password = password,
         ),
+        // 일반 로그인 유저는 OAuth 토큰 정보가 없다.
+        // 엔티티 프로퍼티는 all-open 대상이라 스마트캐스트가 되지 않으므로 지역 변수로 받는다.
         tokenInfo = run {
             val prefix = tokenPrefix
             val access = accessToken

--- a/src/main/kotlin/com/yourssu/scouter/auth/user/storage/UserEntity.kt
+++ b/src/main/kotlin/com/yourssu/scouter/auth/user/storage/UserEntity.kt
@@ -1,6 +1,7 @@
 package com.yourssu.scouter.auth.user.storage
 
 import com.yourssu.scouter.auth.authentication.implement.OAuth2Type
+import com.yourssu.scouter.auth.user.implement.AuthType
 import com.yourssu.scouter.auth.user.implement.TokenInfo
 import com.yourssu.scouter.auth.user.implement.User
 import com.yourssu.scouter.auth.user.implement.UserInfo
@@ -25,30 +26,32 @@ class UserEntity(
     @Column(nullable = false)
     val name: String,
 
-    @Column(nullable = false)
+    @Column(nullable = false, unique = true)
     val email: String,
 
     @Column(nullable = false)
     val profileImageUrl: String,
 
-    @Column(nullable = false, unique = true)
-    val oauthId: String,
-
     @Column(nullable = false)
     @Enumerated(EnumType.STRING)
-    val oauth2Type: OAuth2Type,
+    val authType: AuthType,
 
-    @Column(nullable = false)
-    val tokenPrefix: String,
+    @Column(unique = true)
+    val oauthId: String? = null,
 
-    @Column(nullable = false, length = 511)
-    val accessToken: String,
+    @Enumerated(EnumType.STRING)
+    val oauth2Type: OAuth2Type? = null,
 
-    @Column(nullable = false)
-    val refreshToken: String,
+    val password: String? = null,
 
-    @Column(nullable = false)
-    val accessTokenExpirationDateTime: Instant,
+    val tokenPrefix: String? = null,
+
+    @Column(length = 511)
+    val accessToken: String? = null,
+
+    val refreshToken: String? = null,
+
+    val accessTokenExpirationDateTime: Instant? = null,
 ) {
 
     companion object {
@@ -57,12 +60,14 @@ class UserEntity(
             name = user.userInfo.name,
             email = user.userInfo.email,
             profileImageUrl = user.userInfo.profileImageUrl,
+            authType = user.userInfo.authType,
             oauthId = user.userInfo.oauthId,
             oauth2Type = user.userInfo.oauth2Type,
-            tokenPrefix = user.tokenInfo.tokenPrefix,
-            accessToken = user.tokenInfo.accessToken,
-            refreshToken = user.tokenInfo.refreshToken,
-            accessTokenExpirationDateTime = user.tokenInfo.accessTokenExpirationDateTime,
+            password = user.userInfo.password,
+            tokenPrefix = user.tokenInfo?.tokenPrefix,
+            accessToken = user.tokenInfo?.accessToken,
+            refreshToken = user.tokenInfo?.refreshToken,
+            accessTokenExpirationDateTime = user.tokenInfo?.accessTokenExpirationDateTime,
         )
     }
 
@@ -72,15 +77,27 @@ class UserEntity(
             name = name,
             email = email,
             profileImageUrl = profileImageUrl,
+            authType = authType,
             oauthId = oauthId,
             oauth2Type = oauth2Type,
+            password = password,
         ),
-        tokenInfo = TokenInfo(
-            tokenPrefix = tokenPrefix,
-            accessToken = accessToken,
-            refreshToken = refreshToken,
-            accessTokenExpirationDateTime = accessTokenExpirationDateTime,
-        ),
+        tokenInfo = run {
+            val prefix = tokenPrefix
+            val access = accessToken
+            val refresh = refreshToken
+            val expiration = accessTokenExpirationDateTime
+            if (prefix != null && access != null && refresh != null && expiration != null) {
+                TokenInfo(
+                    tokenPrefix = prefix,
+                    accessToken = access,
+                    refreshToken = refresh,
+                    accessTokenExpirationDateTime = expiration,
+                )
+            } else {
+                null
+            }
+        },
     )
 
     override fun equals(other: Any?): Boolean {

--- a/src/main/kotlin/com/yourssu/scouter/common/configuration/WebConfiguration.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/configuration/WebConfiguration.kt
@@ -36,6 +36,8 @@ class WebConfiguration(
             .excludePathPatterns("/favicon.ico")
             .excludePathPatterns("/error")
             .excludePathPatterns("/oauth2/**")
+            .excludePathPatterns("/auth/signup")
+            .excludePathPatterns("/auth/login")
             .excludePathPatterns("/validate-token")
             .excludePathPatterns("/refresh-token")
             .excludePathPatterns("/members/upload")

--- a/src/main/kotlin/com/yourssu/scouter/common/exception/CommonExceptionHandler.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/exception/CommonExceptionHandler.kt
@@ -50,7 +50,13 @@ class CommonExceptionHandler: ResponseEntityExceptionHandler() {
         status: HttpStatusCode,
         request: WebRequest
     ): ResponseEntity<Any>? {
-        logger.warn(String.format(LOG_MESSAGE_FORMAT, ex.javaClass.simpleName, ex.message), ex)
+        // ex.message와 스택트레이스에는 거절된 입력값이 그대로 담긴다(비밀번호 등이 평문으로 남는다).
+        // 로그에는 어떤 필드가 왜 거절됐는지만 남긴다.
+        val logMessage = ex.fieldErrors
+            .stream()
+            .map { fieldError: FieldError -> "${fieldError.field}: ${fieldError.defaultMessage}" }
+            .collect(Collectors.joining(", "))
+        logger.warn(String.format(LOG_MESSAGE_FORMAT, ex.javaClass.simpleName, logMessage))
 
         val message = ex.fieldErrors
             .stream()

--- a/src/main/resources/db/migration/V53__add_general_auth_fields_to_users.sql
+++ b/src/main/resources/db/migration/V53__add_general_auth_fields_to_users.sql
@@ -1,6 +1,10 @@
 -- 일반 이메일/비밀번호 로그인(#405)을 추가하기 위해 users 테이블에 인증 방식 구분 컬럼과
 -- 비밀번호 컬럼을 추가한다. 기존 OAuth 유저는 auth_type='OAUTH2'로 채워 이전 데이터를 보존하고,
 -- oauth_id/oauth2_type/token 관련 컬럼은 GENERAL 유저에게는 값이 없을 수 있으므로 nullable로 완화한다.
+--
+-- email 유니크 제약은 기존 데이터에 따라 실패할 수 있어 V54로 분리했다. 한 파일에 두면
+-- 제약 추가에서 실패했을 때 (MySQL DDL은 롤백되지 않으므로) 컬럼만 추가된 채로 V53이
+-- failed 상태로 남아 flywayRepair가 필요해진다.
 ALTER TABLE users
     ADD COLUMN auth_type VARCHAR(20) NOT NULL DEFAULT 'OAUTH2' AFTER profile_image_url,
     ADD COLUMN password VARCHAR(255) NULL AFTER oauth2_type,
@@ -11,5 +15,7 @@ ALTER TABLE users
     MODIFY COLUMN refresh_token VARCHAR(255) NULL,
     MODIFY COLUMN access_token_expiration_date_time DATETIME(6) NULL;
 
+-- auth_type의 DEFAULT는 기존 row 백필용이다. 신규 row는 항상 애플리케이션이 값을 채우므로
+-- 백필이 끝난 뒤에는 DEFAULT를 제거해 auth_type 누락이 조용히 OAUTH2로 저장되지 않게 한다.
 ALTER TABLE users
-    ADD CONSTRAINT uk_users_email UNIQUE (email);
+    ALTER COLUMN auth_type DROP DEFAULT;

--- a/src/main/resources/db/migration/V53__add_general_auth_fields_to_users.sql
+++ b/src/main/resources/db/migration/V53__add_general_auth_fields_to_users.sql
@@ -1,0 +1,15 @@
+-- 일반 이메일/비밀번호 로그인(#405)을 추가하기 위해 users 테이블에 인증 방식 구분 컬럼과
+-- 비밀번호 컬럼을 추가한다. 기존 OAuth 유저는 auth_type='OAUTH2'로 채워 이전 데이터를 보존하고,
+-- oauth_id/oauth2_type/token 관련 컬럼은 GENERAL 유저에게는 값이 없을 수 있으므로 nullable로 완화한다.
+ALTER TABLE users
+    ADD COLUMN auth_type VARCHAR(20) NOT NULL DEFAULT 'OAUTH2' AFTER profile_image_url,
+    ADD COLUMN password VARCHAR(255) NULL AFTER oauth2_type,
+    MODIFY COLUMN oauth_id VARCHAR(255) NULL,
+    MODIFY COLUMN oauth2_type VARCHAR(20) NULL,
+    MODIFY COLUMN token_prefix VARCHAR(255) NULL,
+    MODIFY COLUMN access_token VARCHAR(511) NULL,
+    MODIFY COLUMN refresh_token VARCHAR(255) NULL,
+    MODIFY COLUMN access_token_expiration_date_time DATETIME(6) NULL;
+
+ALTER TABLE users
+    ADD CONSTRAINT uk_users_email UNIQUE (email);

--- a/src/main/resources/db/migration/V54__add_unique_constraint_to_users_email.sql
+++ b/src/main/resources/db/migration/V54__add_unique_constraint_to_users_email.sql
@@ -1,0 +1,15 @@
+-- 일반 로그인(#405)은 "이메일당 인증 수단 하나"를 전제로 하므로 users.email에 유니크 제약을 건다.
+--
+-- 지금까지 users의 유니크 키는 oauth_id였고 email은 아니었다. 한 사람이 서로 다른 OAuth 계정으로
+-- 로그인한 이력이 있으면 같은 email을 가진 row가 여러 개 존재할 수 있고, 그 상태에서는 아래 제약
+-- 추가가 'Duplicate entry ... for key uk_users_email'로 실패한다. 배포 전에 중복 여부를 확인한다.
+--
+--   SELECT email, COUNT(*) AS cnt, GROUP_CONCAT(id) AS user_ids
+--   FROM users GROUP BY email HAVING cnt > 1;
+--
+-- applicant_sync_log(V51)와 달리 중복 row를 자동으로 삭제하지 않는다. users.id는 member,
+-- user_role, assigned_question, document_evaluation, 메일 예약 등 여러 테이블이 참조하고 있어,
+-- 어떤 row를 남기고 참조를 어디로 옮길지는 데이터를 보고 판단해야 한다. 중복이 있다면 참조를
+-- 남길 user로 옮긴 뒤 나머지를 지우고 배포한다.
+ALTER TABLE users
+    ADD CONSTRAINT uk_users_email UNIQUE (email);

--- a/src/test/kotlin/com/yourssu/scouter/auth/authentication/application/AuthenticationControllerGeneralAuthTest.kt
+++ b/src/test/kotlin/com/yourssu/scouter/auth/authentication/application/AuthenticationControllerGeneralAuthTest.kt
@@ -1,0 +1,99 @@
+package com.yourssu.scouter.auth.authentication.application
+
+import com.yourssu.scouter.auth.authentication.application.dto.LoginRequest
+import com.yourssu.scouter.auth.authentication.application.dto.SignupRequest
+import com.yourssu.scouter.auth.authentication.business.AuthenticationService
+import com.yourssu.scouter.auth.authentication.business.GeneralAuthService
+import com.yourssu.scouter.auth.authentication.business.LoginService
+import com.yourssu.scouter.auth.authentication.business.dto.LoginWithMemberResult
+import com.yourssu.scouter.auth.authentication.business.dto.SignupResult
+import com.yourssu.scouter.auth.support.exception.DuplicateEmailException
+import com.yourssu.scouter.auth.support.exception.InvalidCredentialsException
+import com.yourssu.scouter.member.core.business.dto.MemberDto
+import com.yourssu.scouter.member.core.fixture.MemberFixtureBuilder
+import com.yourssu.scouter.member.support.exception.MemberNotRegisteredException
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+@Suppress("NonAsciiCharacters")
+class AuthenticationControllerGeneralAuthTest {
+
+    private val authenticationService: AuthenticationService = mock()
+    private val loginService: LoginService = mock()
+    private val generalAuthService: GeneralAuthService = mock()
+
+    private val controller = AuthenticationController(
+        authenticationService = authenticationService,
+        loginService = loginService,
+        generalAuthService = generalAuthService,
+    )
+
+    @Test
+    fun `signup은 이메일과 비밀번호로 가입해 200과 회원 정보를 반환한다`() {
+        val request = SignupRequest(email = "hong@soongsil.ac.kr", password = "password1234")
+        whenever(generalAuthService.signup(email = request.email, password = request.password))
+            .thenReturn(SignupResult(id = 1L, email = request.email, name = "홍길동"))
+
+        val response = controller.signup(request)
+
+        assertThat(response.statusCode.value()).isEqualTo(200)
+        assertThat(response.body?.id).isEqualTo(1L)
+        assertThat(response.body?.email).isEqualTo(request.email)
+        assertThat(response.body?.name).isEqualTo("홍길동")
+    }
+
+    @Test
+    fun `signup은 등록되지 않은 멤버면 예외를 전파한다`() {
+        val request = SignupRequest(email = "unknown@soongsil.ac.kr", password = "password1234")
+        whenever(generalAuthService.signup(email = request.email, password = request.password))
+            .thenThrow(MemberNotRegisteredException("등록된 멤버가 아닙니다."))
+
+        assertThatThrownBy { controller.signup(request) }
+            .isInstanceOf(MemberNotRegisteredException::class.java)
+    }
+
+    @Test
+    fun `signup은 이미 가입된 이메일이면 예외를 전파한다`() {
+        val request = SignupRequest(email = "hong@soongsil.ac.kr", password = "password1234")
+        whenever(generalAuthService.signup(email = request.email, password = request.password))
+            .thenThrow(DuplicateEmailException("이미 가입된 이메일입니다."))
+
+        assertThatThrownBy { controller.signup(request) }
+            .isInstanceOf(DuplicateEmailException::class.java)
+    }
+
+    @Test
+    fun `login은 이메일과 비밀번호로 로그인해 200과 토큰을 반환한다`() {
+        val request = LoginRequest(email = "hong@soongsil.ac.kr", password = "password1234")
+        val member: MemberDto = MemberDto.from(MemberFixtureBuilder().email(request.email).build())
+        whenever(generalAuthService.login(email = request.email, password = request.password))
+            .thenReturn(
+                LoginWithMemberResult(
+                    accessToken = "access-token",
+                    refreshToken = "refresh-token",
+                    profileImageUrl = "",
+                    member = member,
+                ),
+            )
+
+        val response = controller.login(request)
+
+        assertThat(response.statusCode.value()).isEqualTo(200)
+        assertThat(response.body?.accessToken).isEqualTo("access-token")
+        assertThat(response.body?.refreshToken).isEqualTo("refresh-token")
+        assertThat(response.body?.tokenType).isEqualTo("Bearer")
+    }
+
+    @Test
+    fun `login은 이메일 또는 비밀번호가 틀리면 예외를 전파한다`() {
+        val request = LoginRequest(email = "hong@soongsil.ac.kr", password = "wrong-password")
+        whenever(generalAuthService.login(email = request.email, password = request.password))
+            .thenThrow(InvalidCredentialsException("이메일 또는 비밀번호가 올바르지 않습니다."))
+
+        assertThatThrownBy { controller.login(request) }
+            .isInstanceOf(InvalidCredentialsException::class.java)
+    }
+}

--- a/src/test/kotlin/com/yourssu/scouter/auth/authentication/business/GeneralAuthServiceTest.kt
+++ b/src/test/kotlin/com/yourssu/scouter/auth/authentication/business/GeneralAuthServiceTest.kt
@@ -1,9 +1,13 @@
 package com.yourssu.scouter.auth.authentication.business
 
 import com.yourssu.scouter.auth.authentication.implement.GeneralAuthValidator
+import com.yourssu.scouter.auth.authentication.implement.Token
+import com.yourssu.scouter.auth.authentication.implement.TokenProcessor
+import com.yourssu.scouter.auth.support.exception.InvalidCredentialsException
 import com.yourssu.scouter.auth.user.implement.AuthType
 import com.yourssu.scouter.auth.user.implement.User
 import com.yourssu.scouter.auth.user.implement.UserInfo
+import com.yourssu.scouter.auth.user.implement.UserMemberLinker
 import com.yourssu.scouter.auth.user.implement.UserWriter
 import com.yourssu.scouter.member.core.fixture.MemberFixtureBuilder
 import com.yourssu.scouter.member.core.implement.Member
@@ -21,12 +25,16 @@ import org.springframework.security.crypto.password.PasswordEncoder
 class GeneralAuthServiceTest {
 
     private val userWriter = mock<UserWriter>()
+    private val userMemberLinker = mock<UserMemberLinker>()
     private val generalAuthValidator = mock<GeneralAuthValidator>()
+    private val tokenProcessor = mock<TokenProcessor>()
     private val passwordEncoder = mock<PasswordEncoder>()
 
     private val generalAuthService = GeneralAuthService(
         userWriter = userWriter,
+        userMemberLinker = userMemberLinker,
         generalAuthValidator = generalAuthValidator,
+        tokenProcessor = tokenProcessor,
         passwordEncoder = passwordEncoder,
     )
 
@@ -68,5 +76,40 @@ class GeneralAuthServiceTest {
             .isInstanceOf(MemberNotRegisteredException::class.java)
 
         verify(userWriter, org.mockito.kotlin.never()).writeGeneral(any(), any(), any())
+    }
+
+    @Test
+    fun `이메일과 비밀번호로 로그인하면 토큰과 멤버 정보를 반환한다`() {
+        val email = "hong@soongsil.ac.kr"
+        val user = User(
+            id = 1L,
+            userInfo = UserInfo(
+                name = "홍길동",
+                email = email,
+                profileImageUrl = "",
+                authType = AuthType.GENERAL,
+                password = "encoded-password",
+            ),
+        )
+        val member: Member = MemberFixtureBuilder().email(email).build()
+        whenever(generalAuthValidator.validateLoginCredentials(email, "password1234")).thenReturn(user)
+        whenever(tokenProcessor.generateToken(any(), any())).thenReturn(Token("access", "refresh"))
+        whenever(userMemberLinker.link(1L, email)).thenReturn(member)
+
+        val result = generalAuthService.login(email = email, password = "password1234")
+
+        assertThat(result.accessToken).isEqualTo("access")
+        assertThat(result.refreshToken).isEqualTo("refresh")
+        assertThat(result.member.email).isEqualTo(email)
+    }
+
+    @Test
+    fun `로그인 자격 검증에 실패하면 예외를 전파한다`() {
+        val email = "hong@soongsil.ac.kr"
+        whenever(generalAuthValidator.validateLoginCredentials(email, "wrong-password"))
+            .thenThrow(InvalidCredentialsException("이메일 또는 비밀번호가 올바르지 않습니다."))
+
+        assertThatThrownBy { generalAuthService.login(email = email, password = "wrong-password") }
+            .isInstanceOf(InvalidCredentialsException::class.java)
     }
 }

--- a/src/test/kotlin/com/yourssu/scouter/auth/authentication/business/GeneralAuthServiceTest.kt
+++ b/src/test/kotlin/com/yourssu/scouter/auth/authentication/business/GeneralAuthServiceTest.kt
@@ -13,7 +13,9 @@ import com.yourssu.scouter.member.core.fixture.MemberFixtureBuilder
 import com.yourssu.scouter.member.core.implement.Member
 import com.yourssu.scouter.member.support.exception.MemberNotRegisteredException
 import org.assertj.core.api.Assertions.assertThat
+import com.yourssu.scouter.auth.support.exception.DuplicateEmailException
 import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.springframework.dao.DataIntegrityViolationException
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
@@ -76,6 +78,19 @@ class GeneralAuthServiceTest {
             .isInstanceOf(MemberNotRegisteredException::class.java)
 
         verify(userWriter, org.mockito.kotlin.never()).writeGeneral(any(), any(), any())
+    }
+
+    @Test
+    fun `저장 중 유니크 제약에 걸리면 중복 이메일 예외로 변환한다`() {
+        val email = "hong@soongsil.ac.kr"
+        val member: Member = MemberFixtureBuilder().email(email).name("홍길동").build()
+        whenever(generalAuthValidator.validateSignupEligible(email)).thenReturn(member)
+        whenever(passwordEncoder.encode("password1234")).thenReturn("encoded-password")
+        whenever(userWriter.writeGeneral(name = "홍길동", email = email, encodedPassword = "encoded-password"))
+            .thenThrow(DataIntegrityViolationException("duplicate"))
+
+        assertThatThrownBy { generalAuthService.signup(email = email, password = "password1234") }
+            .isInstanceOf(DuplicateEmailException::class.java)
     }
 
     @Test

--- a/src/test/kotlin/com/yourssu/scouter/auth/authentication/business/GeneralAuthServiceTest.kt
+++ b/src/test/kotlin/com/yourssu/scouter/auth/authentication/business/GeneralAuthServiceTest.kt
@@ -1,0 +1,72 @@
+package com.yourssu.scouter.auth.authentication.business
+
+import com.yourssu.scouter.auth.authentication.implement.GeneralAuthValidator
+import com.yourssu.scouter.auth.user.implement.AuthType
+import com.yourssu.scouter.auth.user.implement.User
+import com.yourssu.scouter.auth.user.implement.UserInfo
+import com.yourssu.scouter.auth.user.implement.UserWriter
+import com.yourssu.scouter.member.core.fixture.MemberFixtureBuilder
+import com.yourssu.scouter.member.core.implement.Member
+import com.yourssu.scouter.member.support.exception.MemberNotRegisteredException
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.springframework.security.crypto.password.PasswordEncoder
+
+@Suppress("NonAsciiCharacters")
+class GeneralAuthServiceTest {
+
+    private val userWriter = mock<UserWriter>()
+    private val generalAuthValidator = mock<GeneralAuthValidator>()
+    private val passwordEncoder = mock<PasswordEncoder>()
+
+    private val generalAuthService = GeneralAuthService(
+        userWriter = userWriter,
+        generalAuthValidator = generalAuthValidator,
+        passwordEncoder = passwordEncoder,
+    )
+
+    @Test
+    fun `등록된 멤버는 이메일과 비밀번호로 회원가입할 수 있다`() {
+        val email = "hong@soongsil.ac.kr"
+        val member: Member = MemberFixtureBuilder().email(email).name("홍길동").build()
+        whenever(generalAuthValidator.validateSignupEligible(email)).thenReturn(member)
+        whenever(passwordEncoder.encode("password1234")).thenReturn("encoded-password")
+        whenever(userWriter.writeGeneral(name = "홍길동", email = email, encodedPassword = "encoded-password"))
+            .thenReturn(
+                User(
+                    id = 1L,
+                    userInfo = UserInfo(
+                        name = "홍길동",
+                        email = email,
+                        profileImageUrl = "",
+                        authType = AuthType.GENERAL,
+                        password = "encoded-password",
+                    ),
+                ),
+            )
+
+        val result = generalAuthService.signup(email = email, password = "password1234")
+
+        assertThat(result.id).isEqualTo(1L)
+        assertThat(result.email).isEqualTo(email)
+        assertThat(result.name).isEqualTo("홍길동")
+        verify(userWriter).writeGeneral(name = "홍길동", email = email, encodedPassword = "encoded-password")
+    }
+
+    @Test
+    fun `가입 자격 검증에 실패하면 유저를 생성하지 않고 예외를 전파한다`() {
+        val email = "unknown@soongsil.ac.kr"
+        whenever(generalAuthValidator.validateSignupEligible(email))
+            .thenThrow(MemberNotRegisteredException("등록된 멤버가 아닙니다."))
+
+        assertThatThrownBy { generalAuthService.signup(email = email, password = "password1234") }
+            .isInstanceOf(MemberNotRegisteredException::class.java)
+
+        verify(userWriter, org.mockito.kotlin.never()).writeGeneral(any(), any(), any())
+    }
+}

--- a/src/test/kotlin/com/yourssu/scouter/auth/authentication/business/LoginServiceTest.kt
+++ b/src/test/kotlin/com/yourssu/scouter/auth/authentication/business/LoginServiceTest.kt
@@ -3,7 +3,7 @@ package com.yourssu.scouter.auth.authentication.business
 import com.yourssu.scouter.auth.authentication.business.dto.LoginResult
 import com.yourssu.scouter.auth.authentication.implement.OAuth2Type
 import com.yourssu.scouter.member.core.fixture.MemberFixtureBuilder
-import com.yourssu.scouter.member.core.implement.MemberWriter
+import com.yourssu.scouter.auth.user.implement.UserMemberLinker
 import com.yourssu.scouter.member.support.exception.MemberNotRegisteredException
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
@@ -19,13 +19,13 @@ class LoginServiceTest {
 
     private lateinit var loginService: LoginService
     private lateinit var oauth2Service: OAuth2Service
-    private lateinit var memberWriter: MemberWriter
+    private lateinit var userMemberLinker: UserMemberLinker
 
     @BeforeEach
     fun setUp() {
         oauth2Service = mock(OAuth2Service::class.java)
-        memberWriter = mock(MemberWriter::class.java)
-        loginService = LoginService(oauth2Service, memberWriter)
+        userMemberLinker = mock(UserMemberLinker::class.java)
+        loginService = LoginService(oauth2Service, userMemberLinker)
     }
 
     private fun createLoginResult(email: String = "hong@soongsil.ac.kr") = LoginResult(
@@ -54,7 +54,7 @@ class LoginServiceTest {
                     redirectUriOverride = null,
                 )
             ).thenReturn(loginResult)
-            whenever(memberWriter.updateUserIdByEmail(loginResult.id, "hong@soongsil.ac.kr")).thenReturn(member)
+            whenever(userMemberLinker.link(loginResult.id, "hong@soongsil.ac.kr")).thenReturn(member)
 
             // when
             val result = loginService.login(
@@ -86,7 +86,8 @@ class LoginServiceTest {
                     redirectUriOverride = null,
                 )
             ).thenReturn(loginResult)
-            whenever(memberWriter.updateUserIdByEmail(loginResult.id, "unknown@gmail.com")).thenReturn(null)
+            whenever(userMemberLinker.link(loginResult.id, "unknown@gmail.com"))
+                .thenThrow(MemberNotRegisteredException("등록된 멤버가 아닙니다."))
 
             // when & then
             assertThatThrownBy {
@@ -114,7 +115,7 @@ class LoginServiceTest {
                     redirectUriOverride = null,
                 )
             ).thenReturn(loginResult)
-            whenever(memberWriter.updateUserIdByEmail(loginResult.id, "hong@soongsil.ac.kr")).thenReturn(member)
+            whenever(userMemberLinker.link(loginResult.id, "hong@soongsil.ac.kr")).thenReturn(member)
 
             // when
             val result = loginService.login(
@@ -150,7 +151,7 @@ class LoginServiceTest {
                     redirectUriOverride = null,
                 )
             ).thenReturn(loginResult)
-            whenever(memberWriter.updateUserIdByEmail(loginResult.id, "hong@soongsil.ac.kr")).thenReturn(member)
+            whenever(userMemberLinker.link(loginResult.id, "hong@soongsil.ac.kr")).thenReturn(member)
 
             // when
             val result = loginService.login(

--- a/src/test/kotlin/com/yourssu/scouter/auth/authentication/business/OAuth2ServiceTest.kt
+++ b/src/test/kotlin/com/yourssu/scouter/auth/authentication/business/OAuth2ServiceTest.kt
@@ -4,6 +4,7 @@ import com.yourssu.scouter.auth.authentication.implement.OAuth2Handler
 import com.yourssu.scouter.auth.authentication.implement.OAuth2HandlerComposite
 import com.yourssu.scouter.auth.authentication.implement.OAuth2TokenInfo
 import com.yourssu.scouter.auth.authentication.implement.OAuth2Type
+import com.yourssu.scouter.auth.user.implement.AuthType
 import com.yourssu.scouter.auth.user.implement.TokenInfo
 import com.yourssu.scouter.auth.user.implement.User
 import com.yourssu.scouter.auth.user.implement.UserInfo
@@ -38,6 +39,7 @@ class OAuth2ServiceTest {
                 name = "test",
                 email = "test@example.com",
                 profileImageUrl = "",
+                authType = AuthType.OAUTH2,
                 oauthId = "oauth-id",
                 oauth2Type = OAuth2Type.GOOGLE,
             ),

--- a/src/test/kotlin/com/yourssu/scouter/auth/authentication/business/OAuth2ServiceTest.kt
+++ b/src/test/kotlin/com/yourssu/scouter/auth/authentication/business/OAuth2ServiceTest.kt
@@ -2,6 +2,7 @@ package com.yourssu.scouter.auth.authentication.business
 
 import com.yourssu.scouter.auth.authentication.implement.OAuth2Handler
 import com.yourssu.scouter.auth.authentication.implement.OAuth2HandlerComposite
+import com.yourssu.scouter.auth.authentication.implement.OAuth2SignupValidator
 import com.yourssu.scouter.auth.authentication.implement.OAuth2TokenInfo
 import com.yourssu.scouter.auth.authentication.implement.OAuth2Type
 import com.yourssu.scouter.auth.user.implement.AuthType
@@ -30,6 +31,7 @@ class OAuth2ServiceTest {
     private val oauth2HandlerComposite = mock<OAuth2HandlerComposite>()
     private val userReader = mock<UserReader>()
     private val userWriter = mock<UserWriter>()
+    private val oauth2SignupValidator = mock<OAuth2SignupValidator>()
     private val tokenProcessor = mock<TokenProcessor>()
 
     private fun createUserWithExpiredToken(id: Long = 1L): User {
@@ -58,6 +60,7 @@ class OAuth2ServiceTest {
             oauth2HandlerComposite,
             userReader,
             userWriter,
+            oauth2SignupValidator,
             tokenProcessor,
         )
     }

--- a/src/test/kotlin/com/yourssu/scouter/auth/authentication/implement/GeneralAuthValidatorTest.kt
+++ b/src/test/kotlin/com/yourssu/scouter/auth/authentication/implement/GeneralAuthValidatorTest.kt
@@ -1,6 +1,7 @@
 package com.yourssu.scouter.auth.authentication.implement
 
 import com.yourssu.scouter.auth.support.exception.DuplicateEmailException
+import com.yourssu.scouter.auth.support.exception.InvalidCredentialsException
 import com.yourssu.scouter.auth.user.implement.AuthType
 import com.yourssu.scouter.auth.user.implement.User
 import com.yourssu.scouter.auth.user.implement.UserInfo
@@ -14,16 +15,30 @@ import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
+import org.springframework.security.crypto.password.PasswordEncoder
 
 @Suppress("NonAsciiCharacters")
 class GeneralAuthValidatorTest {
 
     private val userReader = mock<UserReader>()
     private val memberReader = mock<MemberReader>()
+    private val passwordEncoder = mock<PasswordEncoder>()
 
     private val generalAuthValidator = GeneralAuthValidator(
         userReader = userReader,
         memberReader = memberReader,
+        passwordEncoder = passwordEncoder,
+    )
+
+    private fun generalUser(email: String, encodedPassword: String) = User(
+        id = 1L,
+        userInfo = UserInfo(
+            name = "홍길동",
+            email = email,
+            profileImageUrl = "",
+            authType = AuthType.GENERAL,
+            password = encodedPassword,
+        ),
     )
 
     @Test
@@ -52,20 +67,60 @@ class GeneralAuthValidatorTest {
         val email = "hong@soongsil.ac.kr"
         val member: Member = MemberFixtureBuilder().email(email).build()
         whenever(memberReader.readByEmailOrNull(email)).thenReturn(member)
-        whenever(userReader.findByEmail(email)).thenReturn(
-            User(
-                id = 1L,
-                userInfo = UserInfo(
-                    name = "홍길동",
-                    email = email,
-                    profileImageUrl = "",
-                    authType = AuthType.GENERAL,
-                    password = "already-encoded",
-                ),
-            ),
-        )
+        whenever(userReader.findByEmail(email)).thenReturn(generalUser(email, "already-encoded"))
 
         assertThatThrownBy { generalAuthValidator.validateSignupEligible(email) }
             .isInstanceOf(DuplicateEmailException::class.java)
+    }
+
+    @Test
+    fun `이메일과 비밀번호가 일치하면 유저를 반환한다`() {
+        val email = "hong@soongsil.ac.kr"
+        val user = generalUser(email, "encoded-password")
+        whenever(userReader.findByEmail(email)).thenReturn(user)
+        whenever(passwordEncoder.matches("password1234", "encoded-password")).thenReturn(true)
+
+        val result = generalAuthValidator.validateLoginCredentials(email, "password1234")
+
+        assertThat(result).isEqualTo(user)
+    }
+
+    @Test
+    fun `가입되지 않은 이메일로 로그인하면 예외를 던진다`() {
+        val email = "unknown@soongsil.ac.kr"
+        whenever(userReader.findByEmail(email)).thenReturn(null)
+
+        assertThatThrownBy { generalAuthValidator.validateLoginCredentials(email, "password1234") }
+            .isInstanceOf(InvalidCredentialsException::class.java)
+    }
+
+    @Test
+    fun `비밀번호가 일치하지 않으면 예외를 던진다`() {
+        val email = "hong@soongsil.ac.kr"
+        val user = generalUser(email, "encoded-password")
+        whenever(userReader.findByEmail(email)).thenReturn(user)
+        whenever(passwordEncoder.matches("wrong-password", "encoded-password")).thenReturn(false)
+
+        assertThatThrownBy { generalAuthValidator.validateLoginCredentials(email, "wrong-password") }
+            .isInstanceOf(InvalidCredentialsException::class.java)
+    }
+
+    @Test
+    fun `OAuth 유저는 일반 로그인할 수 없다`() {
+        val email = "oauth@soongsil.ac.kr"
+        val oauthUser = User(
+            id = 2L,
+            userInfo = UserInfo(
+                name = "구글유저",
+                email = email,
+                profileImageUrl = "",
+                authType = AuthType.OAUTH2,
+                oauthId = "oauth-id",
+            ),
+        )
+        whenever(userReader.findByEmail(email)).thenReturn(oauthUser)
+
+        assertThatThrownBy { generalAuthValidator.validateLoginCredentials(email, "password1234") }
+            .isInstanceOf(InvalidCredentialsException::class.java)
     }
 }

--- a/src/test/kotlin/com/yourssu/scouter/auth/authentication/implement/GeneralAuthValidatorTest.kt
+++ b/src/test/kotlin/com/yourssu/scouter/auth/authentication/implement/GeneralAuthValidatorTest.kt
@@ -1,0 +1,71 @@
+package com.yourssu.scouter.auth.authentication.implement
+
+import com.yourssu.scouter.auth.support.exception.DuplicateEmailException
+import com.yourssu.scouter.auth.user.implement.AuthType
+import com.yourssu.scouter.auth.user.implement.User
+import com.yourssu.scouter.auth.user.implement.UserInfo
+import com.yourssu.scouter.auth.user.implement.UserReader
+import com.yourssu.scouter.member.core.fixture.MemberFixtureBuilder
+import com.yourssu.scouter.member.core.implement.Member
+import com.yourssu.scouter.member.core.implement.MemberReader
+import com.yourssu.scouter.member.support.exception.MemberNotRegisteredException
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+@Suppress("NonAsciiCharacters")
+class GeneralAuthValidatorTest {
+
+    private val userReader = mock<UserReader>()
+    private val memberReader = mock<MemberReader>()
+
+    private val generalAuthValidator = GeneralAuthValidator(
+        userReader = userReader,
+        memberReader = memberReader,
+    )
+
+    @Test
+    fun `등록된 멤버이면서 이메일이 중복되지 않으면 멤버를 반환한다`() {
+        val email = "hong@soongsil.ac.kr"
+        val member: Member = MemberFixtureBuilder().email(email).build()
+        whenever(memberReader.readByEmailOrNull(email)).thenReturn(member)
+        whenever(userReader.findByEmail(email)).thenReturn(null)
+
+        val result = generalAuthValidator.validateSignupEligible(email)
+
+        assertThat(result).isEqualTo(member)
+    }
+
+    @Test
+    fun `등록된 멤버가 아니면 예외를 던진다`() {
+        val email = "unknown@soongsil.ac.kr"
+        whenever(memberReader.readByEmailOrNull(email)).thenReturn(null)
+
+        assertThatThrownBy { generalAuthValidator.validateSignupEligible(email) }
+            .isInstanceOf(MemberNotRegisteredException::class.java)
+    }
+
+    @Test
+    fun `이미 가입된 이메일이면 예외를 던진다`() {
+        val email = "hong@soongsil.ac.kr"
+        val member: Member = MemberFixtureBuilder().email(email).build()
+        whenever(memberReader.readByEmailOrNull(email)).thenReturn(member)
+        whenever(userReader.findByEmail(email)).thenReturn(
+            User(
+                id = 1L,
+                userInfo = UserInfo(
+                    name = "홍길동",
+                    email = email,
+                    profileImageUrl = "",
+                    authType = AuthType.GENERAL,
+                    password = "already-encoded",
+                ),
+            ),
+        )
+
+        assertThatThrownBy { generalAuthValidator.validateSignupEligible(email) }
+            .isInstanceOf(DuplicateEmailException::class.java)
+    }
+}

--- a/src/test/kotlin/com/yourssu/scouter/auth/authentication/implement/OAuth2SignupValidatorTest.kt
+++ b/src/test/kotlin/com/yourssu/scouter/auth/authentication/implement/OAuth2SignupValidatorTest.kt
@@ -1,0 +1,61 @@
+package com.yourssu.scouter.auth.authentication.implement
+
+import com.yourssu.scouter.auth.support.exception.DuplicateEmailException
+import com.yourssu.scouter.auth.user.implement.AuthType
+import com.yourssu.scouter.auth.user.implement.User
+import com.yourssu.scouter.auth.user.implement.UserInfo
+import com.yourssu.scouter.auth.user.implement.UserReader
+import org.assertj.core.api.Assertions.assertThatCode
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+@Suppress("NonAsciiCharacters")
+class OAuth2SignupValidatorTest {
+
+    private val userReader = mock<UserReader>()
+
+    private val oauth2SignupValidator = OAuth2SignupValidator(userReader = userReader)
+
+    private fun user(email: String, authType: AuthType) = User(
+        id = 1L,
+        userInfo = UserInfo(
+            name = "홍길동",
+            email = email,
+            profileImageUrl = "",
+            authType = authType,
+            password = if (authType == AuthType.GENERAL) "encoded-password" else null,
+            oauthId = if (authType == AuthType.OAUTH2) "oauth-id" else null,
+        ),
+    )
+
+    @Test
+    fun `같은 이메일의 유저가 없으면 통과한다`() {
+        val email = "hong@soongsil.ac.kr"
+        whenever(userReader.findByEmail(email)).thenReturn(null)
+
+        assertThatCode { oauth2SignupValidator.validateEmailNotTaken(email) }
+            .doesNotThrowAnyException()
+    }
+
+    @Test
+    fun `이미 일반 회원가입으로 쓰이고 있는 이메일이면 예외를 던진다`() {
+        val email = "hong@soongsil.ac.kr"
+        whenever(userReader.findByEmail(email)).thenReturn(user(email, AuthType.GENERAL))
+
+        assertThatThrownBy { oauth2SignupValidator.validateEmailNotTaken(email) }
+            .isInstanceOf(DuplicateEmailException::class.java)
+            .hasMessageContaining("일반 로그인")
+    }
+
+    @Test
+    fun `이미 다른 소셜 계정이 쓰고 있는 이메일이면 예외를 던진다`() {
+        val email = "hong@soongsil.ac.kr"
+        whenever(userReader.findByEmail(email)).thenReturn(user(email, AuthType.OAUTH2))
+
+        assertThatThrownBy { oauth2SignupValidator.validateEmailNotTaken(email) }
+            .isInstanceOf(DuplicateEmailException::class.java)
+            .hasMessageContaining("소셜 계정")
+    }
+}

--- a/src/test/kotlin/com/yourssu/scouter/auth/user/implement/UserMemberLinkerTest.kt
+++ b/src/test/kotlin/com/yourssu/scouter/auth/user/implement/UserMemberLinkerTest.kt
@@ -1,0 +1,38 @@
+package com.yourssu.scouter.auth.user.implement
+
+import com.yourssu.scouter.member.core.fixture.MemberFixtureBuilder
+import com.yourssu.scouter.member.core.implement.Member
+import com.yourssu.scouter.member.core.implement.MemberWriter
+import com.yourssu.scouter.member.support.exception.MemberNotRegisteredException
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+@Suppress("NonAsciiCharacters")
+class UserMemberLinkerTest {
+
+    private val memberWriter = mock<MemberWriter>()
+    private val userMemberLinker = UserMemberLinker(memberWriter)
+
+    @Test
+    fun `등록된 멤버가 있으면 User와 연결한다`() {
+        val email = "hong@soongsil.ac.kr"
+        val member: Member = MemberFixtureBuilder().email(email).build()
+        whenever(memberWriter.updateUserIdByEmail(1L, email)).thenReturn(member)
+
+        val result = userMemberLinker.link(1L, email)
+
+        assertThat(result).isEqualTo(member)
+    }
+
+    @Test
+    fun `등록된 멤버가 없으면 예외를 던진다`() {
+        val email = "unknown@soongsil.ac.kr"
+        whenever(memberWriter.updateUserIdByEmail(1L, email)).thenReturn(null)
+
+        assertThatThrownBy { userMemberLinker.link(1L, email) }
+            .isInstanceOf(MemberNotRegisteredException::class.java)
+    }
+}

--- a/src/test/kotlin/com/yourssu/scouter/mail/core/business/MailReservationIntegrationTest.kt
+++ b/src/test/kotlin/com/yourssu/scouter/mail/core/business/MailReservationIntegrationTest.kt
@@ -4,6 +4,7 @@ import com.yourssu.scouter.auth.authentication.implement.OAuth2Type
 import com.yourssu.scouter.mail.core.implement.MailReservation
 import com.yourssu.scouter.mail.core.implement.MailReservationRepository
 import com.yourssu.scouter.mail.core.implement.MailReservationStatus
+import com.yourssu.scouter.auth.user.implement.AuthType
 import com.yourssu.scouter.auth.user.implement.TokenInfo
 import com.yourssu.scouter.auth.user.implement.User
 import com.yourssu.scouter.auth.user.implement.UserInfo
@@ -49,6 +50,7 @@ class MailReservationIntegrationTest {
                         name = "reservation-it",
                         email = email,
                         profileImageUrl = "http://example.com/profile.png",
+                        authType = AuthType.OAUTH2,
                         oauthId = "reservation-it-${UUID.randomUUID()}",
                         oauth2Type = OAuth2Type.GOOGLE,
                     ),

--- a/src/test/kotlin/com/yourssu/scouter/mail/core/business/MailServiceTest.kt
+++ b/src/test/kotlin/com/yourssu/scouter/mail/core/business/MailServiceTest.kt
@@ -11,6 +11,7 @@ import com.yourssu.scouter.mail.core.implement.MailReservationRepository
 import com.yourssu.scouter.mail.core.implement.MailReservationStatus
 import com.yourssu.scouter.mail.core.implement.MailReservationWriter
 import com.yourssu.scouter.mail.template.implement.MailTemplateRepository
+import com.yourssu.scouter.auth.user.implement.AuthType
 import com.yourssu.scouter.auth.user.implement.TokenInfo
 import com.yourssu.scouter.auth.user.implement.User
 import com.yourssu.scouter.auth.user.implement.UserInfo
@@ -78,6 +79,7 @@ class MailServiceTest {
                     name = "tester",
                     email = email,
                     profileImageUrl = "http://example.com/profile.png",
+                    authType = AuthType.OAUTH2,
                     oauthId = "oauth-$id",
                     oauth2Type = OAuth2Type.GOOGLE,
                 ),

--- a/src/test/kotlin/com/yourssu/scouter/member/core/business/MeServiceTest.kt
+++ b/src/test/kotlin/com/yourssu/scouter/member/core/business/MeServiceTest.kt
@@ -1,6 +1,7 @@
 package com.yourssu.scouter.member.core.business
 
 import com.yourssu.scouter.auth.authentication.implement.OAuth2Type
+import com.yourssu.scouter.auth.user.implement.AuthType
 import com.yourssu.scouter.auth.user.implement.TokenInfo
 import com.yourssu.scouter.auth.user.implement.User
 import com.yourssu.scouter.auth.user.implement.UserInfo
@@ -37,6 +38,7 @@ class MeServiceTest {
             name = "홍길동",
             email = email,
             profileImageUrl = profileImageUrl,
+            authType = AuthType.OAUTH2,
             oauthId = "oauth-id-123",
             oauth2Type = OAuth2Type.GOOGLE,
         ),

--- a/src/test/kotlin/com/yourssu/scouter/member/core/business/MemberPrivacyServiceTest.kt
+++ b/src/test/kotlin/com/yourssu/scouter/member/core/business/MemberPrivacyServiceTest.kt
@@ -1,5 +1,6 @@
 package com.yourssu.scouter.member.core.business
 
+import com.yourssu.scouter.auth.user.implement.AuthType
 import com.yourssu.scouter.auth.user.implement.User
 import com.yourssu.scouter.auth.user.implement.UserInfo
 import com.yourssu.scouter.auth.user.implement.UserReader
@@ -100,6 +101,7 @@ class MemberPrivacyServiceTest {
             name = "name",
             email = email,
             profileImageUrl = "http://example.com/profile.png",
+            authType = AuthType.OAUTH2,
             oauthId = "oauth-id",
             oauth2Type = OAuth2Type.GOOGLE,
         )

--- a/src/test/kotlin/com/yourssu/scouter/recruiting/evaluation/storage/DocumentEvaluationRepositoryImplTest.kt
+++ b/src/test/kotlin/com/yourssu/scouter/recruiting/evaluation/storage/DocumentEvaluationRepositoryImplTest.kt
@@ -11,6 +11,7 @@ import com.yourssu.scouter.masterdata.semester.implement.Term
 import com.yourssu.scouter.masterdata.division.storage.DivisionEntity
 import com.yourssu.scouter.masterdata.part.storage.PartEntity
 import com.yourssu.scouter.masterdata.semester.storage.SemesterEntity
+import com.yourssu.scouter.auth.user.implement.AuthType
 import com.yourssu.scouter.auth.user.storage.JpaUserRepository
 import com.yourssu.scouter.auth.user.storage.UserEntity
 import com.yourssu.scouter.recruiting.rubric.storage.DocumentSectionEntity
@@ -74,6 +75,7 @@ class DocumentEvaluationRepositoryImplTest {
                 name = "오리",
                 email = "ori@example.com",
                 profileImageUrl = "",
+                authType = AuthType.OAUTH2,
                 oauthId = "oauth-ori",
                 oauth2Type = OAuth2Type.GOOGLE,
                 tokenPrefix = "Bearer",

--- a/src/test/kotlin/com/yourssu/scouter/recruiting/interviewQuestion/storage/AssignedQuestionRepositoryImplTest.kt
+++ b/src/test/kotlin/com/yourssu/scouter/recruiting/interviewQuestion/storage/AssignedQuestionRepositoryImplTest.kt
@@ -1,6 +1,7 @@
 package com.yourssu.scouter.recruiting.interviewQuestion.storage
 
 import com.yourssu.scouter.auth.authentication.implement.OAuth2Type
+import com.yourssu.scouter.auth.user.implement.AuthType
 import com.yourssu.scouter.auth.user.storage.UserEntity
 import com.yourssu.scouter.masterdata.division.storage.DivisionEntity
 import com.yourssu.scouter.masterdata.part.storage.PartEntity
@@ -61,6 +62,7 @@ class AssignedQuestionRepositoryImplTest {
                 name = "면접관",
                 email = "interviewer@example.com",
                 profileImageUrl = "",
+                authType = AuthType.OAUTH2,
                 oauthId = "oauth-interviewer",
                 oauth2Type = OAuth2Type.GOOGLE,
                 tokenPrefix = "Bearer",


### PR DESCRIPTION
## 📄 작업 내용 요약
- users 테이블에 인증 방식 구분(`AuthType`: OAUTH2/GENERAL)과 password 컬럼을 추가
- oauthId/oauth2Type/토큰 관련 컬럼을 nullable로 완화하는 마이그레이션(V53) 추가
- `users.email`에 unique 제약 추가
- 이메일/비밀번호 회원가입 기능 추가 (`POST /auth/signup`)
  - 등록된 Member만 가입 가능, 가입 자격 검증은 `GeneralAuthValidator`로 분리
- 이메일/비밀번호 로그인 기능 추가 (`POST /auth/login`)
  - JWT 발급 + `UserMemberLinker`로 Member 연결
- `LoginInterceptor`가 `/auth/signup`, `/auth/login`을 인증 없이 통과시키도록 `WebConfiguration` 수정
- "Bearer" 토큰 타입 문자열 상수화 (`AuthConstants`)
- 기존 OAuth 로그인(`LoginService`)도 신규 `UserMemberLinker`를 재사용하도록 리팩터링해 Member 연결 로직 통일
- `/auth/signup`, `/auth/login` 컨트롤러 레벨 테스트 및 각 컴포넌트 단위 테스트 추가

## 📌 참고사항
- 기존 OAuth 로그인은 그대로 사용할 수 있습니다.
- 일반 로그인/회원가입은 OAuth를 대체하는 것을 전제로 설계했습니다.
  - users.email에 unique 제약을 적용하여 이메일당 하나의 인증 수단만 허용합니다.
  - 따라서 OAuth 가입 계정과 동일한 이메일로 일반 회원가입은 불가능하며, 두 인증 방식을 병행하기 위한 별도 로직은 구현하지 않았습니다.

## 📎 Issue 번호
closed #405