### PR TITLE
[#473]; feat: 서류 평가 문항 조회 API에 isLocked 필드 추가

### DIFF
--- a/src/main/kotlin/com/yourssu/scouter/recruiting/rubric/application/DocumentRubricController.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/rubric/application/DocumentRubricController.kt
@@ -25,10 +25,10 @@ class DocumentRubricController(
     @GetMapping("/parts/{partId}/documents/rubrics")
     fun readByPartId(
         @PathVariable partId: Long,
-    ): ResponseEntity<List<ReadRubricResponse>> {
-        val sections = documentSectionService.readByPartId(partId)
+    ): ResponseEntity<ReadRubricResponse> {
+        val rubrics = documentSectionService.readByPartId(partId)
 
-        return ResponseEntity.ok(sections.map(ReadRubricResponse::from))
+        return ResponseEntity.ok(ReadRubricResponse.from(rubrics))
     }
 
     @Operation(summary = "서류 평가 문항 수정", description = "배점과 평가 지표만 수정합니다. 배점 합계는 100이어야 합니다.")

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/rubric/application/dto/ReadRubricResponse.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/rubric/application/dto/ReadRubricResponse.kt
@@ -1,19 +1,32 @@
 package com.yourssu.scouter.recruiting.rubric.application.dto
 
+import com.yourssu.scouter.recruiting.rubric.business.dto.DocumentRubricsResult
 import com.yourssu.scouter.recruiting.rubric.business.dto.DocumentSectionDto
 
 data class ReadRubricResponse(
-    val sectionId: Long,
-    val question: String,
-    val maxScore: Int,
-    val criterionDetail: String,
+    val isLocked: Boolean,
+    val rubrics: List<RubricResponse>,
 ) {
+    data class RubricResponse(
+        val sectionId: Long,
+        val question: String,
+        val maxScore: Int,
+        val criterionDetail: String,
+    ) {
+        companion object {
+            fun from(dto: DocumentSectionDto): RubricResponse = RubricResponse(
+                sectionId = dto.sectionId,
+                question = dto.question,
+                maxScore = dto.maxScore,
+                criterionDetail = dto.criterionDetail,
+            )
+        }
+    }
+
     companion object {
-        fun from(dto: DocumentSectionDto): ReadRubricResponse = ReadRubricResponse(
-            sectionId = dto.sectionId,
-            question = dto.question,
-            maxScore = dto.maxScore,
-            criterionDetail = dto.criterionDetail,
+        fun from(result: DocumentRubricsResult): ReadRubricResponse = ReadRubricResponse(
+            isLocked = result.isLocked,
+            rubrics = result.sections.map(RubricResponse::from),
         )
     }
 }

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/rubric/business/DocumentSectionService.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/rubric/business/DocumentSectionService.kt
@@ -2,6 +2,8 @@ package com.yourssu.scouter.recruiting.rubric.business
 
 import com.yourssu.scouter.recruiting.rubric.business.dto.UpdateRubricItemCommand
 
+import com.yourssu.scouter.recruiting.rubric.business.dto.DocumentRubricsResult
+
 import com.yourssu.scouter.recruiting.rubric.business.dto.DocumentSectionDto
 
 import com.yourssu.scouter.masterdata.part.implement.PartReader
@@ -22,10 +24,18 @@ class DocumentSectionService(
     private val partReader: PartReader,
 ) {
 
-    fun readByPartId(partId: Long): List<DocumentSectionDto> {
+    fun readByPartId(partId: Long): DocumentRubricsResult {
         partReader.readById(partId)
 
-        return documentSectionReader.readAllByPartId(partId).map(DocumentSectionDto::from)
+        val sections = documentSectionReader.readAllByPartId(partId)
+        if (sections.isEmpty()) {
+            return DocumentRubricsResult(isLocked = false, sections = emptyList())
+        }
+
+        // updateRubrics와 동일한 정책. 파트의 문항 중 하나라도 참조하는 서류 평가가 있으면 전체를 수정할 수 없다.
+        val isLocked = documentEvaluationReader.existsBySectionIdIn(sections.mapNotNull { it.id })
+
+        return DocumentRubricsResult(isLocked = isLocked, sections = sections.map(DocumentSectionDto::from))
     }
 
     @Transactional

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/rubric/business/dto/DocumentRubricsResult.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/rubric/business/dto/DocumentRubricsResult.kt
@@ -1,0 +1,6 @@
+package com.yourssu.scouter.recruiting.rubric.business.dto
+
+data class DocumentRubricsResult(
+    val isLocked: Boolean,
+    val sections: List<DocumentSectionDto>,
+)

--- a/src/test/kotlin/com/yourssu/scouter/recruiting/rubric/business/DocumentSectionServiceTest.kt
+++ b/src/test/kotlin/com/yourssu/scouter/recruiting/rubric/business/DocumentSectionServiceTest.kt
@@ -1,0 +1,87 @@
+package com.yourssu.scouter.recruiting.rubric.business
+
+import com.yourssu.scouter.masterdata.part.implement.PartReader
+import com.yourssu.scouter.masterdata.part.implement.fixture.PartFixtureBuilder
+import com.yourssu.scouter.recruiting.evaluation.implement.DocumentEvaluationReader
+import com.yourssu.scouter.recruiting.rubric.implement.DocumentSection
+import com.yourssu.scouter.recruiting.rubric.implement.DocumentSectionReader
+import com.yourssu.scouter.recruiting.rubric.implement.DocumentSectionWriter
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.never
+import org.mockito.kotlin.any
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+@Suppress("NonAsciiCharacters")
+class DocumentSectionServiceTest {
+
+    private lateinit var documentSectionReader: DocumentSectionReader
+    private lateinit var documentSectionWriter: DocumentSectionWriter
+    private lateinit var documentEvaluationReader: DocumentEvaluationReader
+    private lateinit var partReader: PartReader
+    private lateinit var documentSectionService: DocumentSectionService
+
+    private val partId = 10L
+
+    @BeforeEach
+    fun setUp() {
+        documentSectionReader = mock(DocumentSectionReader::class.java)
+        documentSectionWriter = mock(DocumentSectionWriter::class.java)
+        documentEvaluationReader = mock(DocumentEvaluationReader::class.java)
+        partReader = mock(PartReader::class.java)
+
+        documentSectionService = DocumentSectionService(
+            documentSectionReader,
+            documentSectionWriter,
+            documentEvaluationReader,
+            partReader,
+        )
+
+        whenever(partReader.readById(partId)).thenReturn(PartFixtureBuilder().id(partId).build())
+    }
+
+    @Test
+    fun `참조하는 서류 평가가 없으면 isLocked는 false다`() {
+        whenever(documentSectionReader.readAllByPartId(partId)).thenReturn(listOf(section(1L), section(2L)))
+        whenever(documentEvaluationReader.existsBySectionIdIn(listOf(1L, 2L))).thenReturn(false)
+
+        val result = documentSectionService.readByPartId(partId)
+
+        assertThat(result.isLocked).isFalse
+        assertThat(result.sections).extracting<Long> { it.sectionId }.containsExactly(1L, 2L)
+    }
+
+    @Test
+    fun `문항 중 하나라도 참조하는 서류 평가가 있으면 isLocked는 true다`() {
+        whenever(documentSectionReader.readAllByPartId(partId)).thenReturn(listOf(section(1L), section(2L)))
+        whenever(documentEvaluationReader.existsBySectionIdIn(listOf(1L, 2L))).thenReturn(true)
+
+        val result = documentSectionService.readByPartId(partId)
+
+        assertThat(result.isLocked).isTrue
+        assertThat(result.sections).hasSize(2)
+    }
+
+    @Test
+    fun `문항이 없으면 평가 조회 없이 잠기지 않은 빈 목록을 반환한다`() {
+        whenever(documentSectionReader.readAllByPartId(partId)).thenReturn(emptyList())
+
+        val result = documentSectionService.readByPartId(partId)
+
+        assertThat(result.isLocked).isFalse
+        assertThat(result.sections).isEmpty()
+        verify(documentEvaluationReader, never()).existsBySectionIdIn(any())
+        verify(documentSectionWriter, never()).writeAll(any())
+    }
+
+    private fun section(id: Long): DocumentSection = DocumentSection(
+        id = id,
+        partId = partId,
+        question = "질문 $id",
+        maxScore = 50,
+        criterionDetail = "지표 $id",
+    )
+}


### PR DESCRIPTION
## 📄 작업 내용 요약

서류 평가 문항 조회 API(`GET /parts/{partId}/documents/rubrics`) 응답에 `isLocked` 필드를 추가했습니다.

- 잠금 판단 기준은 수정 API(`PUT`)의 `RubricLockedException` 조건과 **동일**합니다.
  파트의 문항 중 **하나라도** 참조하는 `DocumentEvaluationItem`이 존재하면 `isLocked = true`
- 문항 단위가 아닌 파트 단위 값이므로 응답을 envelope 객체로 변경
- 조회 결과 전달용 `DocumentRubricsResult`(`isLocked` + 문항 목록) 추가
- 기존 `existsBySectionIdIn`을 그대로 재사용해 저장소 레이어 변경 없음
- 문항이 하나도 없는 파트(구글폼 동기화 전 상태)는 평가 조회 없이 `isLocked = false` + 빈 목록 반환
  - `syncSectionsFromQuestions`가 문항을 지연 생성하므로 실제로 도달 가능한 상태이고, 그대로 두면 `IN ()` 쿼리가 나갑니다.
- `DocumentSectionServiceTest` 신규 추가 (잠김 / 안 잠김 / 문항 없음)

## 📌 참고사항

- **응답 스키마가 배열에서 객체로 바뀌는 breaking change입니다.** 프론트엔드 동시 배포가 필요합니다.

```jsonc
// before
[ { "sectionId": 1, "question": "...", "maxScore": 60, "criterionDetail": "..." } ]

// after
{
  "isLocked": false,
  "rubrics": [ { "sectionId": 1, "question": "...", "maxScore": 60, "criterionDetail": "..." } ]
}
```

- `isLocked = true`이면 해당 파트의 문항은 배점·평가 지표를 수정할 수 없습니다. (평가 데이터를 먼저 삭제해야 합니다)

## 📎 Issue 번호
closed #473

🤖 Generated with [Claude Code](https://claude.com/claude-code)
