### PR TITLE
[#480]; refactor: 서류 템플릿 면접 가능시간 동기화 로직 현재 구조에 맞게 수정

### DIFF
--- a/src/main/kotlin/com/yourssu/scouter/common/google/GoogleFormsClient.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/google/GoogleFormsClient.kt
@@ -29,20 +29,6 @@ data class FormItem(
     val itemId: String,
     val title: String?,
     val questionItem: QuestionItem?,
-    val questionGroupItem: QuestionGroupItem?
-)
-
-data class QuestionGroupItem(
-    val questions: List<Questions>?,
-)
-
-data class Questions(
-    val questionId: String,
-    val rowQuestion: RowQuestion
-)
-
-data class RowQuestion(
-    val title: String
 )
 
 data class QuestionItem(

--- a/src/main/kotlin/com/yourssu/scouter/common/google/GoogleFormsReader.kt
+++ b/src/main/kotlin/com/yourssu/scouter/common/google/GoogleFormsReader.kt
@@ -11,7 +11,6 @@ class GoogleFormsReader(
         val questionResponse = googleFormsClient.getFormQuestions(authorizationHeader, formId)
         val questionMap: Map<String, String?> = makeQuestionIdAndTitleMap(questionResponse)
         val descriptiveQuestionIds: Set<String> = makeDescriptiveQuestionIds(questionResponse)
-        val groupQuestionMap: Map<String, String> = getGroupItems(questionResponse)
         val questionOrder: List<String> = makeQuestionIdOrder(questionResponse)
         val formResponses: GoogleFormResponses = googleFormsClient.getFormResponses(authorizationHeader, formId)
 
@@ -24,7 +23,6 @@ class GoogleFormsReader(
                 responseItems = convertToResponseItems(
                     googleUserResponse,
                     questionMap,
-                    groupQuestionMap,
                     descriptiveQuestionIds,
                     questionOrder,
                 )
@@ -47,35 +45,20 @@ class GoogleFormsReader(
             .map { question -> question.questionId }
             .toSet()
 
-    private fun getGroupItems(questionResponse: GoogleFormQuestions) =
-        questionResponse.items.flatMap { item ->
-            if (item.questionGroupItem == null) return@flatMap emptyList()
-            item.questionGroupItem.questions?.map { (questionId, rowQuestion) ->
-                questionId to item.title + ":" + rowQuestion.title
-            } ?: emptyList()
-        }.associate { it.first to it.second }
-
     // 응답은 Map으로 와서 순서가 보장되지 않으므로, 폼에 실제 배치된 문항 순서(items 순서)를 기준으로 정렬 기준을 만든다.
     private fun makeQuestionIdOrder(questionResponse: GoogleFormQuestions): List<String> =
-        questionResponse.items.flatMap { item ->
-            when {
-                item.questionItem?.question != null -> listOf(item.questionItem.question.questionId)
-                item.questionGroupItem?.questions != null -> item.questionGroupItem.questions.map { it.questionId }
-                else -> emptyList()
-            }
-        }
+        questionResponse.items.mapNotNull { item -> item.questionItem?.question?.questionId }
 
     private fun convertToResponseItems(
         googleUserResponse: GoogleUserResponse,
         questionMap: Map<String, String?>,
-        groupQuestionMap: Map<String, String>,
         descriptiveQuestionIds: Set<String>,
         questionOrder: List<String>,
     ): List<ResponseItem> {
         val orderIndex: Map<String, Int> = questionOrder.withIndex().associate { (index, questionId) -> questionId to index }
 
         val responseItems: List<ResponseItem> = googleUserResponse.answers.mapNotNull { (questionId, answer) ->
-            val questionTitle = questionMap[questionId] ?: groupQuestionMap[questionId] ?: return@mapNotNull null
+            val questionTitle = questionMap[questionId] ?: return@mapNotNull null
             val answerText = answer.textAnswers?.answers?.joinToString(", ") { it.value.toString() } ?: ""
             questionId to ResponseItem(questionTitle, answerText, isDescriptive = questionId in descriptiveQuestionIds)
         }.sortedBy { (questionId, _) -> orderIndex[questionId] ?: Int.MAX_VALUE }

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/applicant/business/FormResponseToApplicantProcessor.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/applicant/business/FormResponseToApplicantProcessor.kt
@@ -130,7 +130,7 @@ class FormResponseToApplicantProcessor(
         applicantSyncMapping: ApplicantSyncMapping,
     ): List<ResponseItem> {
         // getAnswer/getAll과 동일하게 startsWith 기준으로 매핑 여부를 판단한다.
-        // availableTimeQuestion은 그룹 질문이라 "제목:행제목" 형태의 항목까지 함께 제외된다.
+        // availableTimeQuestion은 날짜별로 독립된 문항이 여러 개 존재하지만 모두 같은 접두어로 시작하므로 함께 제외된다.
         val mappedQuestions: List<String> = listOfNotNull(
             applicantSyncMapping.nameQuestion,
             applicantSyncMapping.emailQuestion,

--- a/src/main/kotlin/com/yourssu/scouter/recruiting/support/business/utils/AvailableTimeParser.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/support/business/utils/AvailableTimeParser.kt
@@ -25,7 +25,7 @@ class AvailableTimeParser(
     ): List<Instant> =
         selectCandidateItems(responseItems, availableTimeQuestion)
             .flatMap { responseItem ->
-                parseByQuestionDayAndAnswerTime(responseItem)
+                parseByQuestionDayAndAnswerTime(responseItem, availableTimeQuestion)
                     .ifEmpty { parseDateTimeFromAnswer(responseItem.answer) }
             }
             .distinct()
@@ -47,21 +47,26 @@ class AvailableTimeParser(
         val heuristicallyMatchedItems =
             responseItems
                 .filterNot { directMatchedItems.contains(it) }
-                .filter { isLikelyAvailableTimeItem(it) }
+                .filter { isLikelyAvailableTimeItem(it, availableTimeQuestion) }
 
         return directMatchedItems + heuristicallyMatchedItems
     }
 
-    private fun isLikelyAvailableTimeItem(responseItem: ResponseItem): Boolean =
-        parseByQuestionDayAndAnswerTime(responseItem).isNotEmpty() ||
+    private fun isLikelyAvailableTimeItem(responseItem: ResponseItem, availableTimeQuestion: String?): Boolean =
+        parseByQuestionDayAndAnswerTime(responseItem, availableTimeQuestion).isNotEmpty() ||
             parseDateTimeFromAnswer(responseItem.answer).isNotEmpty()
 
-    private fun parseByQuestionDayAndAnswerTime(responseItem: ResponseItem): List<Instant> {
+    // 날짜별 단일 체크박스 문항의 제목은 "{공통 접두어}\n{날짜}" 형태이므로,
+    // 접두어를 제거하면 날짜만 남는다. 접두어가 없거나 일치하지 않으면 문항 제목 전체를 날짜로 취급한다.
+    private fun parseByQuestionDayAndAnswerTime(
+        responseItem: ResponseItem,
+        availableTimeQuestion: String?,
+    ): List<Instant> {
         if (responseItem.answer == "불가") {
             return emptyList()
         }
 
-        val days = responseItem.question.substringAfterLast(":").trim()
+        val days = responseItem.question.removePrefix(availableTimeQuestion ?: "").trim()
         val times: List<String> = getAvailableTimes(responseItem.answer) ?: return emptyList()
         val nowInSeoul = nowInSeoul()
         val year = nowInSeoul.year

--- a/src/main/resources/applicant-available-time-map.yml
+++ b/src/main/resources/applicant-available-time-map.yml
@@ -1,6 +1,7 @@
 applicant-available-time-map:
   time:
     - "(\\d+)시\\s*~\\s*(\\d+)시"
+    - "(\\d+):(\\d+)\\s*~\\s*(\\d+):(\\d+)"
 
   days:
     - "yyyy M월 d일 E요일 HH:mm"

--- a/src/test/kotlin/com/yourssu/scouter/common/google/GoogleFormsReaderTest.kt
+++ b/src/test/kotlin/com/yourssu/scouter/common/google/GoogleFormsReaderTest.kt
@@ -18,9 +18,9 @@ class GoogleFormsReaderTest {
         // 응답 Map은 반대 순서(취미 -> 자기소개 -> 이름)로 온다.
         val questions = GoogleFormQuestions(
             items = listOf(
-                FormItem("item-name", "이름", QuestionItem(Question("q-name", TextQuestion(paragraph = false))), null),
-                FormItem("item-intro", "자기소개", QuestionItem(Question("q-intro", TextQuestion(paragraph = true))), null),
-                FormItem("item-hobby", "취미", QuestionItem(Question("q-hobby", TextQuestion(paragraph = false))), null),
+                FormItem("item-name", "이름", QuestionItem(Question("q-name", TextQuestion(paragraph = false)))),
+                FormItem("item-intro", "자기소개", QuestionItem(Question("q-intro", TextQuestion(paragraph = true)))),
+                FormItem("item-hobby", "취미", QuestionItem(Question("q-hobby", TextQuestion(paragraph = false)))),
             )
         )
         val responses = GoogleFormResponses(
@@ -53,8 +53,8 @@ class GoogleFormsReaderTest {
     fun `장문형(paragraph) 문항만 isDescriptive가 true다`() {
         val questions = GoogleFormQuestions(
             items = listOf(
-                FormItem("item-name", "이름", QuestionItem(Question("q-name", TextQuestion(paragraph = false))), null),
-                FormItem("item-intro", "자기소개", QuestionItem(Question("q-intro", TextQuestion(paragraph = true))), null),
+                FormItem("item-name", "이름", QuestionItem(Question("q-name", TextQuestion(paragraph = false)))),
+                FormItem("item-intro", "자기소개", QuestionItem(Question("q-intro", TextQuestion(paragraph = true)))),
             )
         )
         val responses = GoogleFormResponses(

--- a/src/test/kotlin/com/yourssu/scouter/recruiting/support/business/utils/AvailableTimeParserTest.kt
+++ b/src/test/kotlin/com/yourssu/scouter/recruiting/support/business/utils/AvailableTimeParserTest.kt
@@ -30,7 +30,7 @@ class AvailableTimeParserTest {
     @DisplayName("지원자의 면접 가능시간을 나타내는 ResponseItem 배열을 Instant 배열로 변환한다.")
     fun parseTimeOnlyHourSuccessTest() {
         // given
-        val item1 = ResponseItem(":09.24", "12시~15시")
+        val item1 = ResponseItem("09.24", "12시~15시")
         val responseItems: List<ResponseItem> = listOf(item1)
 
         val expectedOutput =
@@ -49,7 +49,7 @@ class AvailableTimeParserTest {
     @DisplayName("availableTimeMap에 지원하는 날짜 형식이 없는 경우 빈 배열을 반환한다.")
     fun parseInvalidDayFormatTest() {
         // given
-        val item1 = ResponseItem(":9/24", "12시~15시")
+        val item1 = ResponseItem("9/24", "12시~15시")
         val responseItems: List<ResponseItem> = listOf(item1)
         // when
         val localDateTimes = parser.parse(responseItems)
@@ -61,7 +61,7 @@ class AvailableTimeParserTest {
     @DisplayName("availableTimeMap에 지원하는 시간 형식이 없는 경우 빈 배열을 반환한다.")
     fun parseInvalidTimeFormatTest() {
         // given
-        val item1 = ResponseItem(":9.24", "12:00~15:00")
+        val item1 = ResponseItem("9.24", "12:00~15:00")
         val responseItems: List<ResponseItem> = listOf(item1)
         // when
         val localDateTimes = parser.parse(responseItems)
@@ -84,7 +84,7 @@ class AvailableTimeParserTest {
     @DisplayName("시간이 역순으로 들어올 경우, 빈 배열을 반환한다.")
     fun parseReversedTimeTest() {
         // given
-        val item1 = ResponseItem(":9.24", answer = "14시~12시")
+        val item1 = ResponseItem("9.24", answer = "14시~12시")
         val responseItems = listOf(item1)
         // when
         val localDateTimes = parser.parse(responseItems)
@@ -96,7 +96,7 @@ class AvailableTimeParserTest {
     @DisplayName("응답이 '불가'인 경우 빈 배열을 반환한다.")
     fun parseUnavailableAnswerTest() {
         // given
-        val item1 = ResponseItem(":9.24", answer = "불가")
+        val item1 = ResponseItem("9.24", answer = "불가")
         val responseItems = listOf(item1)
         // when
         val localDateTimes = parser.parse(responseItems)
@@ -108,7 +108,7 @@ class AvailableTimeParserTest {
     @DisplayName("응답이 '상관없음'인 경우 09:00부터 23:00까지 모든 시간을 반환한다.")
     fun parseAllAvailableAnswerTest() {
         // given
-        val item1 = ResponseItem(":09.24", answer = "상관없음")
+        val item1 = ResponseItem("09.24", answer = "상관없음")
         val responseItems = listOf(item1)
         // when
         val localDateTimes = parser.parse(responseItems)
@@ -128,7 +128,7 @@ class AvailableTimeParserTest {
     @DisplayName("쉼표로 구분된 여러 시간을 파싱한다.")
     fun parseMultipleTimesTest() {
         // given
-        val item1 = ResponseItem(":09.24", answer = "12시~14시, 16시~18시")
+        val item1 = ResponseItem("09.24", answer = "12시~14시, 16시~18시")
         val responseItems = listOf(item1)
         val expectedOutput =
             listOf(
@@ -147,8 +147,8 @@ class AvailableTimeParserTest {
     @DisplayName("여러 ResponseItem이 있을 때 모든 시간을 합쳐서 반환한다.")
     fun parseMultipleResponseItemsTest() {
         // given
-        val item1 = ResponseItem(":09.24", answer = "12시~14시")
-        val item2 = ResponseItem(":09.25", answer = "16시~18시")
+        val item1 = ResponseItem("09.24", answer = "12시~14시")
+        val item2 = ResponseItem("09.25", answer = "16시~18시")
         val responseItems = listOf(item1, item2)
         val expectedOutput =
             listOf(
@@ -167,8 +167,8 @@ class AvailableTimeParserTest {
     @DisplayName("각기 다른 날짜 형식을 사용해도 파싱한다.")
     fun parseAlternateDateFormatTest() {
         // given
-        val item1 = ResponseItem(":09.24", answer = "12시~15시")
-        val item2 = ResponseItem(":9월 25일", answer = "12시~13시")
+        val item1 = ResponseItem("09.24", answer = "12시~15시")
+        val item2 = ResponseItem("9월 25일", answer = "12시~13시")
         val responseItems = listOf(item1, item2)
         val expectedOutput =
             listOf(
@@ -194,7 +194,7 @@ class AvailableTimeParserTest {
             )
         val parserWithMinutes = AvailableTimeParser(availableTimeMapWithMinutes)
 
-        val item1 = ResponseItem(":9월 24일", answer = "12:30~14:30")
+        val item1 = ResponseItem("9월 24일", answer = "12:30~14:30")
         val responseItems = listOf(item1)
         val expectedOutput =
             listOf(
@@ -210,11 +210,11 @@ class AvailableTimeParserTest {
     }
 
     @Test
-    @DisplayName("질문이 날짜별로 여러 개일 때도 매핑 질문 외 날짜 항목까지 파싱한다.")
+    @DisplayName("질문이 날짜별로 여러 개일 때 availableTimeQuestion과 무관한 항목은 제외하고 파싱한다.")
     fun parseMultipleDateQuestionsTest() {
         // given
-        val item1 = ResponseItem("9월 24일", answer = "12시, 13시")
-        val item2 = ResponseItem("9월 25일", answer = "14시")
+        val item1 = ResponseItem("가능하신 시간대를 모두 선택해주세요.\n9월 24일", answer = "12시, 13시")
+        val item2 = ResponseItem("가능하신 시간대를 모두 선택해주세요.\n9월 25일", answer = "14시")
         val item3 = ResponseItem("학과", answer = "컴퓨터공학부")
         val responseItems = listOf(item1, item2, item3)
         val expectedOutput =
@@ -225,14 +225,14 @@ class AvailableTimeParserTest {
             )
 
         // when
-        val localDateTimes = parser.parse(responseItems, availableTimeQuestion = "9월 24일")
+        val localDateTimes = parser.parse(responseItems, availableTimeQuestion = "가능하신 시간대를 모두 선택해주세요.")
 
         // then
         assertEquals(expectedOutput, localDateTimes)
     }
 
     @Test
-    @DisplayName("질문 하나의 체크박스 항목이 월 일 시간 형식일 때 파싱한다.")
+    @DisplayName("질문 하나에 날짜와 시간이 모두 담긴 답변 형식일 때도 파싱한다.")
     fun parseSingleQuestionDateTimeOptionsTest() {
         // given
         val item1 = ResponseItem("가능하신 시간대를 모두 선택해주세요.", answer = "9월 24일 12시, 9월 25일 13시")
@@ -251,10 +251,60 @@ class AvailableTimeParserTest {
     }
 
     @Test
+    @DisplayName("날짜별 단일 체크박스 문항이 여러 개일 때 공통 접두어로 모두 매칭해 파싱한다.")
+    fun parseSingleQuestionPerDateTest() {
+        // given: 날짜마다 독립된 체크박스 문항 - 제목은 "공통 접두어\n날짜" 형태
+        val item1 = ResponseItem("가능하신 시간대를 모두 선택해주세요.\n9월 24일", answer = "12시~13시")
+        val item2 = ResponseItem("가능하신 시간대를 모두 선택해주세요.\n9월 25일", answer = "13시~14시")
+        val responseItems = listOf(item1, item2)
+        val expectedOutput =
+            listOf(
+                LocalDateTime.of(currentYear, 9, 24, 12, 0, 0).atZone(ZoneId.of("Asia/Seoul")).toInstant(),
+                LocalDateTime.of(currentYear, 9, 25, 13, 0, 0).atZone(ZoneId.of("Asia/Seoul")).toInstant(),
+            )
+
+        // when
+        val localDateTimes = parser.parse(responseItems, availableTimeQuestion = "가능하신 시간대를 모두 선택해주세요.")
+
+        // then
+        assertEquals(expectedOutput, localDateTimes)
+    }
+
+    @Test
+    @DisplayName("HH:mm~HH:mm 형식의 체크박스 선택지를 파싱한다.")
+    fun parseHourMinuteRangeCheckboxOptionsTest() {
+        // given
+        val timeRangeMap =
+            ApplicantAvailableTimeMap(
+                time = listOf("(\\d+):(\\d+)\\s*~\\s*(\\d+):(\\d+)"),
+                days = listOf("yyyy M월 d일 E요일 HH:mm"),
+            )
+        val timeRangeParser = AvailableTimeParser(timeRangeMap) { fixedNow }
+
+        // given: 2026년 9월 16일은 수요일
+        val item1 = ResponseItem("가능하신 시간대를 모두 선택해주세요.\n9월 16일 수요일", answer = "17:00~18:00, 18:00~19:00")
+        val responseItems = listOf(item1)
+        val expectedOutput =
+            listOf(
+                LocalDateTime.of(2026, 9, 16, 17, 0, 0).atZone(ZoneId.of("Asia/Seoul")).toInstant(),
+                LocalDateTime.of(2026, 9, 16, 17, 30, 0).atZone(ZoneId.of("Asia/Seoul")).toInstant(),
+                LocalDateTime.of(2026, 9, 16, 18, 0, 0).atZone(ZoneId.of("Asia/Seoul")).toInstant(),
+                LocalDateTime.of(2026, 9, 16, 18, 30, 0).atZone(ZoneId.of("Asia/Seoul")).toInstant(),
+            )
+
+        // when
+        val localDateTimes =
+            timeRangeParser.parse(responseItems, availableTimeQuestion = "가능하신 시간대를 모두 선택해주세요.")
+
+        // then
+        assertEquals(expectedOutput, localDateTimes)
+    }
+
+    @Test
     @DisplayName("요일이 현재 연도와 맞으면 요일을 포함한 형식으로 파싱한다.")
     fun parseDayOfWeekMatchTest() {
         // given: 2026년 9월 11일은 금요일
-        val item1 = ResponseItem("가능하신 시간대를 모두 선택해주세요.:9월 11일 금요일", answer = "14시~16시")
+        val item1 = ResponseItem("가능하신 시간대를 모두 선택해주세요.\n9월 11일 금요일", answer = "14시~16시")
         val responseItems = listOf(item1)
         val expectedOutput =
             listOf(
@@ -274,7 +324,7 @@ class AvailableTimeParserTest {
     @DisplayName("요일이 현재 연도와 맞지 않으면 요일을 무시하고 현재 연도로 파싱한다.")
     fun parseDayOfWeekMismatchIgnoresDayOfWeekTest() {
         // given: 2026년 9월 12일은 토요일이라 '금요일'과 불일치
-        val item1 = ResponseItem("가능하신 시간대를 모두 선택해주세요.:9월 12일 금요일", answer = "14시~16시")
+        val item1 = ResponseItem("가능하신 시간대를 모두 선택해주세요.\n9월 12일 금요일", answer = "14시~16시")
         val responseItems = listOf(item1)
         val expectedOutput =
             listOf(
@@ -301,7 +351,7 @@ class AvailableTimeParserTest {
             )
         val dayOfWeekOnlyParser = AvailableTimeParser(dayOfWeekOnlyMap) { fixedNow }
 
-        val item1 = ResponseItem("가능하신 시간대를 모두 선택해주세요.:1월 5일 화요일", answer = "14시~16시")
+        val item1 = ResponseItem("가능하신 시간대를 모두 선택해주세요.\n1월 5일 화요일", answer = "14시~16시")
         val responseItems = listOf(item1)
         val expectedOutput =
             listOf(
@@ -321,7 +371,7 @@ class AvailableTimeParserTest {
     @DisplayName("days에 월 정보가 없으면 현재 월을 사용해 파싱한다.")
     fun parseDayWithoutMonthUsesCurrentMonthTest() {
         // given
-        val item1 = ResponseItem(":16일 월요일", answer = "12시~14시")
+        val item1 = ResponseItem("16일 월요일", answer = "12시~14시")
         val responseItems = listOf(item1)
         val expectedOutput =
             listOf(


### PR DESCRIPTION
## Summary
- 지원자 면접 가능 시간 동기화 로직이 전제하던 구글폼 Grid(체크박스 그리드) 문항 관련 코드를 전부 제거
- 대신 날짜마다 독립된 단일 체크박스 문항(제목: `"공통 접두어\n날짜"`, 예: `"가능하신 시간대를 모두 선택해주세요.\n9월 16일 수요일"`, 선택지: `"HH:mm~HH:mm"`/`"불가"`/`"상관없음"`)을 파싱하도록 `AvailableTimeParser`의 날짜 추출 방식을 콜론 분리(`substringAfterLast(":")`) 대신 접두어 제거(`removePrefix`)로 변경
- `applicant-available-time-map.yml`에 `HH:mm~HH:mm` 시간대 포맷 정규식 추가 (기존 "12시~15시" 포맷은 과거 데이터 재동기화 대비 유지)

## Test plan
- [x] `./gradlew test` 전체 통과 확인
- [x] `./gradlew build` 통과 확인
- [x] `AvailableTimeParserTest`, `GoogleFormsReaderTest`, `FormResponseToApplicantProcessorTest` 개별 통과 확인

Closes #480

https://claude.ai/code/session_01THEHCcHm6beBBXxkWTdvUK