### PR TITLE
[#483]; fix: 면접 가능시간 '상관없음' 응답을 30분 단위로 파싱

### DIFF
--- a/src/main/kotlin/com/yourssu/scouter/recruiting/support/business/utils/AvailableTimeParser.kt
+++ b/src/main/kotlin/com/yourssu/scouter/recruiting/support/business/utils/AvailableTimeParser.kt
@@ -233,7 +233,15 @@ class AvailableTimeParser(
         return null
     }
 
-    private fun allAvailable(): List<String> = parseTimeOnlyHour("09", "24")
+    // 다른 시간 응답들과 동일하게 09:00~23:30을 30분 단위로 채운다.
+    private fun allAvailable(): List<String> {
+        val result = mutableListOf<String>()
+        for (hour in 9 until 24) {
+            result.add("%02d:00".format(hour))
+            result.add("%02d:30".format(hour))
+        }
+        return result
+    }
 
     private fun parseTimeOnlyHour(
         before: String,

--- a/src/test/kotlin/com/yourssu/scouter/recruiting/support/business/utils/AvailableTimeParserTest.kt
+++ b/src/test/kotlin/com/yourssu/scouter/recruiting/support/business/utils/AvailableTimeParserTest.kt
@@ -105,7 +105,7 @@ class AvailableTimeParserTest {
     }
 
     @Test
-    @DisplayName("응답이 '상관없음'인 경우 09:00부터 23:00까지 모든 시간을 반환한다.")
+    @DisplayName("응답이 '상관없음'인 경우 09:00부터 23:30까지 30분 단위로 모든 시간을 반환한다.")
     fun parseAllAvailableAnswerTest() {
         // given
         val item1 = ResponseItem("09.24", answer = "상관없음")
@@ -113,13 +113,17 @@ class AvailableTimeParserTest {
         // when
         val localDateTimes = parser.parse(responseItems)
         // then
-        assertEquals(15, localDateTimes.size)
+        assertEquals(30, localDateTimes.size)
         assertEquals(
             LocalDateTime.of(currentYear, 9, 24, 9, 0).atZone(ZoneId.of("Asia/Seoul")).toInstant(),
             localDateTimes.first(),
         )
         assertEquals(
-            LocalDateTime.of(currentYear, 9, 24, 23, 0).atZone(ZoneId.of("Asia/Seoul")).toInstant(),
+            LocalDateTime.of(currentYear, 9, 24, 9, 30).atZone(ZoneId.of("Asia/Seoul")).toInstant(),
+            localDateTimes[1],
+        )
+        assertEquals(
+            LocalDateTime.of(currentYear, 9, 24, 23, 30).atZone(ZoneId.of("Asia/Seoul")).toInstant(),
             localDateTimes.last(),
         )
     }


### PR DESCRIPTION
## Summary
- 면접 가능 시간 문항에서 "상관없음"으로 응답했을 때 `AvailableTimeParser.allAvailable()`이 09:00~23:00을 1시간 단위로만 생성하던 문제를 수정
- 다른 시간 범위 응답(예: "12:30~14:30")과 동일하게 09:00~23:30을 30분 단위(30개 슬롯)로 생성하도록 변경

## Test plan
- [x] `AvailableTimeParserTest` 통과 확인 (30개 슬롯, 09:00/09:30/23:30 검증 포함)
- [x] `./gradlew test` 전체 통과 확인

Closes #483

https://claude.ai/code/session_01THEHCcHm6beBBXxkWTdvUK